### PR TITLE
add: support UseNumber/UseInt64 for ast

### DIFF
--- a/ast/parser.go
+++ b/ast/parser.go
@@ -246,11 +246,12 @@ func (self *Parser) decodeString(iv int64, ep int) (Node, native.ParsingError) {
 }
 
 /** Parser Interface **/
-
+// Pos returns current position at parsed json
 func (self *Parser) Pos() int {
     return self.p
 }
 
+// Parse loads the inner json with lazy-load mode
 func (self *Parser) Parse() (Node, native.ParsingError) {
     switch val := self.decodeValue(); val.Vt {
         case native.V_EOF     : return Node{}, native.ERR_EOF
@@ -285,8 +286,10 @@ func (self *Parser) skip() (int, native.ParsingError) {
     return start, 0
 }
 
-/** Parser Factory **/
-
+// Loads fully parses given json and returns:
+//  the finally parsed position,
+//  the interface{} representing results,
+//  or ParsingError if any mistake happends
 func Loads(src string) (int, interface{}, native.ParsingError) {
     ps := &Parser{s: src}
     np, err := ps.Parse()
@@ -294,11 +297,39 @@ func Loads(src string) (int, interface{}, native.ParsingError) {
     /* check for errors */
     if err != 0 {
         return 0, nil, err
-    } else {
-        return ps.Pos(), np.Interface(), 0
-    }
+    } 
+    return ps.Pos(), np.Interface(), 0
 }
 
+// LoadUseNumber is almost same with Loads,
+// except returned numbers are json.Number
+func LoadUseNuumber(src string) (int, interface{}, native.ParsingError) {
+    ps := &Parser{s: src}
+    np, err := ps.Parse()
+
+    /* check for errors */
+    if err != 0 {
+        return 0, nil, err
+    } 
+    return ps.Pos(), np.InterfaceUseNumber(), 0
+}
+
+// LoadUseNumber is almost same with Loads,
+// except returned numbers are int64
+func LoadUseInt64(src string) (int, interface{}, native.ParsingError) {
+    ps := &Parser{s: src}
+    np, err := ps.Parse()
+
+    /* check for errors */
+    if err != 0 {
+        return 0, nil, err
+    } 
+    return ps.Pos(), np.InterfaceUseInt64(), 0
+}
+
+
+
+// NewParser.
 func NewParser(src string) *Parser {
     return &Parser{s: src}
 }

--- a/ast/search.go
+++ b/ast/search.go
@@ -22,11 +22,14 @@ import (
     `github.com/bytedance/sonic/internal/native`
 )
 
+// Searcher is used for path searches.
+// It looks for specific key and skip unnecessary parsing
 type Searcher struct {
     parser Parser
     // cache map[string]*Node
 }
 
+// NewSearch creates a Searcher with lazy-load parser by default
 func NewSearcher(str string) *Searcher {
     return &Searcher{
         parser: Parser{
@@ -35,6 +38,7 @@ func NewSearcher(str string) *Searcher {
         },
     }
 }
+
 
 func (self *Parser) printNear(start int) string {
     start -= 10
@@ -48,6 +52,12 @@ func (self *Parser) printNear(start int) string {
     return self.s[start:end]
 }
 
+// GetByPath searches the given path json,
+// and returns its representing ast.Node
+//
+// Each path arg must be integer or string:
+//     - Integer means searching current node as array,
+//     - String means searching current node as object
 func (self *Searcher) GetByPath(path ...interface{}) (Node, error) {
     self.parser.p = 0
 

--- a/internal/native/fastfloat_test.go
+++ b/internal/native/fastfloat_test.go
@@ -53,7 +53,7 @@ func BenchmarkFastFloat_Encode(b *testing.B) {
         test func(*testing.B)
     }{{
         name: "StdLib",
-        test: func(b *testing.B) { var buf [64]byte; for i := 0; i < b.N; i++ { strconv.AppendFloat(buf[:], val, 'g', -1, 64) }},
+        test: func(b *testing.B) { var buf [64]byte; for i := 0; i < b.N; i++ { strconv.AppendFloat(buf[:0], val, 'g', -1, 64) }},
     }, {
         name: "FastFloat",
         test: func(b *testing.B) { var buf [64]byte; for i := 0; i < b.N; i++ { __f64toa(&buf[0], val) }},

--- a/internal/native/fastint_test.go
+++ b/internal/native/fastint_test.go
@@ -100,10 +100,10 @@ func BenchmarkFastInt_IntToString(b *testing.B) {
         test func(*testing.B)
     }{{
         name: "StdLib-Positive",
-        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendInt(buf[:], int64(i), 10) }},
+        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendInt(buf[:0], int64(i), 10) }},
     }, {
         name: "StdLib-Negative",
-        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendInt(buf[:], -int64(i), 10) }},
+        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendInt(buf[:0], -int64(i), 10) }},
     }, {
         name: "FastInt-Positive",
         test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { __i64toa(&buf[0], int64(i)) }},
@@ -122,7 +122,7 @@ func BenchmarkFastInt_UintToString(b *testing.B) {
         test func(*testing.B)
     }{{
         name: "StdLib",
-        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendUint(buf[:], uint64(i), 10) }},
+        test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { strconv.AppendUint(buf[:0], uint64(i), 10) }},
     }, {
         name: "FastInt",
         test: func(b *testing.B) { var buf [32]byte; for i := 0; i < b.N; i++ { __u64toa(&buf[0], uint64(i)) }},

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -146,3 +146,13 @@ func SkipOne(s *string, p *int, m *StateMachine) int {
 func Unquote(s unsafe.Pointer, nb int, dp unsafe.Pointer, ep *int, flags uint64) int {
     return __unquote(s, nb, dp, ep, flags)
 }
+
+func I64toa(i int64) []byte {
+    var buf [32]byte
+    return buf[:__i64toa(&buf[0], i)]
+}
+
+func F64toa(i float64) []byte {
+    var buf [64]byte
+    return buf[:__f64toa(&buf[0], i)]
+}


### PR DESCRIPTION
0. cast numbers of interface{} to float64 by default, aligned to std
1. export `native.__i64toa()\native.__f64toa()`
2. add `node.InterfaceUseNumber()\InterfaceUseInt64()` and related API
