### PR TITLE
feat: support json.Number for ast

### DIFF
--- a/ast/iterator_test.go
+++ b/ast/iterator_test.go
@@ -53,6 +53,9 @@ func TestIterator(t *testing.T) {
 		if i < int64(loop) && v.Int64() != i {
 			t.Fatalf("exp:%v, got:%v", i, v)
 		}
+		if i != int64(ai.Pos())-1 || i >= int64(ai.Len()) {
+			t.Fatal(i)
+		}
 		i++
 	}
 
@@ -69,6 +72,9 @@ func TestIterator(t *testing.T) {
 		}
 		if i < int64(loop) &&( v.Value.Int64() != i ||v.Key != fmt.Sprintf("k%d", i)) {
 			t.Fatalf("exp:%v, got:%v", i, v.Value.Interface())
+		}
+		if i != int64(mi.Pos())-1 || i >= int64(mi.Len()) {
+			t.Fatal(i)
 		}
 		i++
 	}

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -257,19 +257,19 @@ func (self *Parser) Parse() (Node, native.ParsingError) {
         case native.V_NULL    : return nullNode, 0
         case native.V_TRUE    : return trueNode, 0
         case native.V_FALSE   : return falseNode, 0
-    case native.V_ARRAY:
-        if self.noLazy {
-            return self.decodeArray(make([]Node, 0, _DEFAULT_NODE_CAP))
-        }
-        return newRawArray(self, make([]Node, 0, _DEFAULT_NODE_CAP)), 0
-    case native.V_OBJECT:
-        if self.noLazy {
-            return self.decodeObject(make([]Pair, 0, _DEFAULT_NODE_CAP))
-        }
-        return newRawObject(self, make([]Pair, 0, _DEFAULT_NODE_CAP)), 0
         case native.V_STRING  : return self.decodeString(val.Iv, val.Ep)
-        case native.V_DOUBLE  : return newFloat64(val.Dv), 0
-        case native.V_INTEGER : return newInt64(val.Iv), 0
+        case native.V_ARRAY:
+            if self.noLazy {
+                return self.decodeArray(make([]Node, 0, _DEFAULT_NODE_CAP))
+            }
+            return newRawArray(self, make([]Node, 0, _DEFAULT_NODE_CAP)), 0
+        case native.V_OBJECT:
+            if self.noLazy {
+                return self.decodeObject(make([]Pair, 0, _DEFAULT_NODE_CAP))
+            }
+            return newRawObject(self, make([]Pair, 0, _DEFAULT_NODE_CAP)), 0
+        case native.V_DOUBLE  : return newNumber(self.s[val.Ep:self.p]), 0
+        case native.V_INTEGER : return newNumber(self.s[val.Ep:self.p]), 0
         default               : return Node{}, native.ParsingError(-val.Vt)
     }
 }
@@ -287,6 +287,7 @@ func (self *Parser) skip() (int, native.ParsingError) {
 
 /** Parser Factory **/
 
+// Loads parse all json into interface{}
 func Loads(src string) (int, interface{}, native.ParsingError) {
     ps := &Parser{s: src}
     np, err := ps.Parse()
@@ -296,6 +297,19 @@ func Loads(src string) (int, interface{}, native.ParsingError) {
         return 0, nil, err
     } else {
         return ps.Pos(), np.Interface(), 0
+    }
+}
+
+// Loads parse all json into interface{}, with numeric nodes casted to json.Number
+func LoadsUseNumber(src string) (int, interface{}, native.ParsingError) {
+    ps := &Parser{s: src}
+    np, err := ps.Parse()
+
+    /* check for errors */
+    if err != 0 {
+        return 0, nil, err
+    } else {
+        return ps.Pos(), np.InterfaceUseNumber(), 0
     }
 }
 

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -18,8 +18,6 @@ package ast
 
 import (
     `encoding/json`
-    `fmt`
-    `reflect`
     `testing`
 
     jsoniter `github.com/json-iterator/go`
@@ -30,8 +28,41 @@ import (
 func runDecoderTest(t *testing.T, src string, expect interface{}) {
     vv, err := NewParser(src).Parse()
     if err != 0 { panic(err) }
-    fmt.Printf("%s -> %s :: %v\n", src, reflect.TypeOf(vv), vv)
     assert.Equal(t, expect, vv.Interface())
+}
+
+func runDecoderTestUseNumber(t *testing.T, src string, expect interface{}) {
+    vv, err := NewParser(src).Parse()
+    if err != 0 { panic(err) }
+    vvv := vv.InterfaceUseNumber()
+    switch vvv.(type) {
+    case json.Number:
+        assert.Equal(t, expect, n2f64(vvv.(json.Number)))
+    case []interface{}:
+        x := vvv.([]interface{})
+        for i, e := range x {
+            if ev,ok := e.(json.Number);ok {
+                x[i] = n2f64(ev)
+            }
+        }
+        assert.Equal(t, expect, x)
+    case map[string]interface{}:
+        x := vvv.(map[string]interface{})
+        for k,v := range x {
+            if ev, ok := v.(json.Number); ok {
+                x[k] = n2f64(ev)
+            }
+        }
+        assert.Equal(t, expect, x)
+    }
+}
+
+func n2f64(i json.Number) float64{ 
+    x, err := i.Float64()
+    if err != nil {
+        panic(err)
+    }
+    return x
 }
 
 func TestParser_Basic(t *testing.T) {
@@ -40,10 +71,10 @@ func TestParser_Basic(t *testing.T) {
     runDecoderTest(t, `false`, false)
     runDecoderTest(t, `"hello, world \\ \/ \b \f \n \r \t \u666f 测试中文"`, "hello, world \\ / \b \f \n \r \t \u666f 测试中文")
     runDecoderTest(t, `"\ud83d\ude00"`, "😀")
-    runDecoderTest(t, `0`, int64(0))
-    runDecoderTest(t, `-0`, int64(0))
-    runDecoderTest(t, `123456`, int64(123456))
-    runDecoderTest(t, `-12345`, int64(-12345))
+    runDecoderTest(t, `0`, float64(0))
+    runDecoderTest(t, `-0`, float64(0))
+    runDecoderTest(t, `123456`, float64(123456))
+    runDecoderTest(t, `-12345`, float64(-12345))
     runDecoderTest(t, `0.2`, 0.2)
     runDecoderTest(t, `1.2`, 1.2)
     runDecoderTest(t, `-0.2`, -0.2)
@@ -78,6 +109,62 @@ func TestParser_Basic(t *testing.T) {
     runDecoderTest(t, `{}`, map[string]interface{}{})
     runDecoderTest(t, `["asd", "123", true, false, null, 2.4, 1.2e15]`, []interface{}{"asd", "123", true, false, nil, 2.4, 1.2e15})
     runDecoderTest(t, `{"asdf": "qwer", "zxcv": true}`, map[string]interface{}{"asdf": "qwer", "zxcv": true})
+    runDecoderTest(t, `{"a": "123", "b": true, "c": false, "d": null, "e": 2.4, "f": 1.2e15, "g": 1}`, map[string]interface{}{"a":"123", "b":true, "c":false, "d":nil, "e":float64(2.4), "f":float64(1.2e15), "g":float64(1)})
+
+    runDecoderTestUseNumber(t, `null`, nil)
+    runDecoderTestUseNumber(t, `true`, true)
+    runDecoderTestUseNumber(t, `false`, false)
+    runDecoderTestUseNumber(t, `"hello, world \\ \/ \b \f \n \r \t \u666f 测试中文"`, "hello, world \\ / \b \f \n \r \t \u666f 测试中文")
+    runDecoderTestUseNumber(t, `"\ud83d\ude00"`, "😀")
+    runDecoderTestUseNumber(t, `0`, float64(0))
+    runDecoderTestUseNumber(t, `-0`, float64(0))
+    runDecoderTestUseNumber(t, `123456`, float64(123456))
+    runDecoderTestUseNumber(t, `-12345`, float64(-12345))
+    runDecoderTestUseNumber(t, `0.2`, float64(0.2))
+    runDecoderTestUseNumber(t, `1.2`, float64(1.2))
+    runDecoderTestUseNumber(t, `-0.2`, float64(-0.2))
+    runDecoderTestUseNumber(t, `-1.2`, float64(-1.2))
+    runDecoderTestUseNumber(t, `0e12`, float64(0e12))
+    runDecoderTestUseNumber(t, `0e+12`, float64(0e+12))
+    runDecoderTestUseNumber(t, `0e-12`, float64(0e-12))
+    runDecoderTestUseNumber(t, `-0e12`, float64(-0e12))
+    runDecoderTestUseNumber(t, `-0e+12`, float64(-0e+12))
+    runDecoderTestUseNumber(t, `-0e-12`, float64(-0e-12))
+    runDecoderTestUseNumber(t, `2e12`, float64(2e12))
+    runDecoderTestUseNumber(t, `2E12`, float64(2e12))
+    runDecoderTestUseNumber(t, `2e+12`, float64(2e+12))
+    runDecoderTestUseNumber(t, `2e-12`, float64(2e-12))
+    runDecoderTestUseNumber(t, `-2e12`, float64(-2e12))
+    runDecoderTestUseNumber(t, `-2e+12`, float64(-2e+12))
+    runDecoderTestUseNumber(t, `-2e-12`, float64(-2e-12))
+    runDecoderTestUseNumber(t, `0.2e12`, float64(0.2e12))
+    runDecoderTestUseNumber(t, `0.2e+12`, float64(0.2e+12))
+    runDecoderTestUseNumber(t, `0.2e-12`, float64(0.2e-12))
+    runDecoderTestUseNumber(t, `-0.2e12`, float64(-0.2e12))
+    runDecoderTestUseNumber(t, `-0.2e+12`, float64(-0.2e+12))
+    runDecoderTestUseNumber(t, `-0.2e-12`, float64(-0.2e-12))
+    runDecoderTestUseNumber(t, `1.2e12`, float64(1.2e12))
+    runDecoderTestUseNumber(t, `1.2e+12`, float64(1.2e+12))
+    runDecoderTestUseNumber(t, `1.2e-12`, float64(1.2e-12))
+    runDecoderTestUseNumber(t, `-1.2e12`, float64(-1.2e12))
+    runDecoderTestUseNumber(t, `-1.2e+12`, float64(-1.2e+12))
+    runDecoderTestUseNumber(t, `-1.2e-12`, float64(-1.2e-12))
+    runDecoderTestUseNumber(t, `-1.2E-12`, float64(-1.2e-12))
+    runDecoderTestUseNumber(t, `["asd", "123", true, false, null, 2.4, 1.2e15, 1]`, []interface{}{"asd", "123", true, false, nil, float64(2.4), float64(1.2e15), float64(1)})
+    runDecoderTestUseNumber(t, `{"a": "123", "b": true, "c": false, "d": null, "e": 2.4, "f": 1.2e15, "g": 1}`, map[string]interface{}{"a":"123", "b":true, "c":false, "d":nil, "e":float64(2.4), "f":float64(1.2e15), "g":float64(1)})
+}
+
+func TestLoads(t *testing.T) {
+    _,i,e := Loads(`{"a": "123", "b": true, "c": false, "d": null, "e": 2.4, "f": 1.2e15, "g": 1}`)
+    if e != 0 {
+        t.Fatal(e)
+    }
+    assert.Equal(t, map[string]interface{}{"a": "123", "b": true, "c": false, "d": nil, "e": float64(2.4), "f": float64(1.2e15), "g": float64(1)}, i)
+    _,i,e = LoadsUseNumber(`{"a": "123", "b": true, "c": false, "d": null, "e": 2.4, "f": 1.2e15, "g": 1}`)
+    if e != 0 {
+        t.Fatal(e)
+    }
+    assert.Equal(t, map[string]interface{}{"a": "123", "b": true, "c": false, "d": nil, "e": json.Number("2.4"), "f": json.Number("1.2e15"), "g": json.Number("1")}, i)
 }
 
 func BenchmarkParser_StdLib(b *testing.B) {

--- a/ast/search.go
+++ b/ast/search.go
@@ -24,7 +24,6 @@ import (
 
 type Searcher struct {
     parser Parser
-    // cache map[string]*Node
 }
 
 func NewSearcher(str string) *Searcher {

--- a/ast/search_test.go
+++ b/ast/search_test.go
@@ -20,6 +20,7 @@ import (
     `testing`
 
     jsoniter `github.com/json-iterator/go`
+    `github.com/stretchr/testify/assert`
     `github.com/tidwall/gjson`
 )
 
@@ -83,6 +84,22 @@ func TestSearcher_GetByPathErr(t *testing.T) {
     if e == nil {
         t.Fatalf("node: %v, err: %v", node, e)
     }
+}
+
+func TestLoadIndex(t *testing.T) {
+    node, err := NewSearcher(`{"a":[-0, 1, -1.2, -1.2e-10]}`).GetByPath("a")
+    if err != nil {
+        t.Fatal(err)
+    }
+    a := node.Index(3).Float64()
+    assert.Equal(t, float64(-1.2e-10), a)
+    m := node.Array()
+    assert.Equal(t, m, []interface{}{
+        float64(0),    
+        float64(1),    
+        float64(-1.2),    
+        float64(-1.2e-10),    
+    })
 }
 
 func BenchmarkSearchOne_Gjson(b *testing.B) {


### PR DESCRIPTION
1. Decode numeric values into `V_NUMBER`, instead of `native.V_INTEGER/V_DOUBLE`
2. Interface{} is casted to `float64` by default.
3. Add `InterfaceUseNumber()\MapUseNumber()\ArrayUseNumber()\LoadsUseNumber()` to cast `interface{}` to  `json.Number`