### PR TITLE
Update benchmark

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -134,7 +134,7 @@ func BenchmarkEncoder_Generic_GoJson(b *testing.B) {
     b.SetBytes(int64(len(TwitterJson)))
     b.ResetTimer()
     for i := 0; i < b.N; i++ {
-        _, _ = gojson.Marshal(_GenericValue)
+        _, _ = gojson.MarshalWithOption(_GenericValue, gojson.UnorderedMap())
     }
 }
 
@@ -170,7 +170,7 @@ func BenchmarkEncoder_Binding_GoJson(b *testing.B) {
     b.SetBytes(int64(len(TwitterJson)))
     b.ResetTimer()
     for i := 0; i < b.N; i++ {
-        _, _ = gojson.Marshal(&_BindingValue)
+        _, _ = gojson.MarshalWithOption(&_BindingValue, gojson.UnorderedMap())
     }
 }
 
@@ -211,7 +211,7 @@ func BenchmarkEncoder_Parallel_Generic_GoJson(b *testing.B) {
     b.ResetTimer()
     b.RunParallel(func(pb *testing.PB) {
         for pb.Next() {
-            _, _ = gojson.Marshal(_GenericValue)
+            _, _ = gojson.MarshalWithOption(_GenericValue, gojson.UnorderedMap())
         }
     })
 }
@@ -255,7 +255,7 @@ func BenchmarkEncoder_Parallel_Binding_GoJson(b *testing.B) {
     b.ResetTimer()
     b.RunParallel(func(pb *testing.PB) {
         for pb.Next() {
-            _, _ = gojson.Marshal(&_BindingValue)
+            _, _ = gojson.MarshalWithOption(&_BindingValue, gojson.UnorderedMap())
         }
     })
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/chenzhuoyu/base64x v0.0.0-20210528162528-3c6c11c43ee5
 	github.com/davecgh/go-spew v1.1.1
-	github.com/goccy/go-json v0.7.1
+	github.com/goccy/go-json v0.7.2
 	github.com/json-iterator/go v1.1.10
 	github.com/klauspost/cpuid/v2 v2.0.6
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20210528162528-3c6c11c43ee5/go.mod h1:NfDzX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.7.1 h1:VMhnh5gcc8De8f6m2DLvSqY1x8Jwl3btet+EqMP0QNs=
-github.com/goccy/go-json v0.7.1/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.7.2 h1:MY1gMmtCxRpaI8YGpeHCvXUb+FVIo09pnjqF9Rhh274=
+github.com/goccy/go-json v0.7.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
Currently, sonic and json-iterator/go use unordered map when encoding, so go-json also enables the option.
We also updated the module to v0.7.2.

Looking at the benchmark results, it seems that go-json is faster than json-iterator/go in all cases.

After benchmark result

### Encoder

```
goos: darwin
goarch: amd64
pkg: github.com/bytedance/sonic/encoder
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEncoder_Generic_Sonic-16                          48063             24041 ns/op         542.20 MB/s
BenchmarkEncoder_Generic_JsonIter-16                       26437             45242 ns/op         288.12 MB/s
BenchmarkEncoder_Generic_GoJson-16                         27621             42357 ns/op         307.74 MB/s
BenchmarkEncoder_Generic_StdLib-16                          9072            132162 ns/op          98.63 MB/s
BenchmarkEncoder_Binding_Sonic-16                         175012              5806 ns/op        2244.97 MB/s
BenchmarkEncoder_Binding_JsonIter-16                       55611             21292 ns/op         612.19 MB/s
BenchmarkEncoder_Binding_GoJson-16                        127252              9098 ns/op        1432.76 MB/s
BenchmarkEncoder_Binding_StdLib-16                         66856             17689 ns/op         736.91 MB/s
BenchmarkEncoder_Parallel_Generic_Sonic-16                326630              3643 ns/op        3578.02 MB/s
BenchmarkEncoder_Parallel_Generic_JsonIter-16             100838             11489 ns/op        1134.56 MB/s
BenchmarkEncoder_Parallel_Generic_GoJson-16               102033             11347 ns/op        1148.81 MB/s
BenchmarkEncoder_Parallel_Generic_StdLib-16                24129             43750 ns/op         297.94 MB/s
BenchmarkEncoder_Parallel_Binding_Sonic-16               1308734               895.1 ns/op      14562.23 MB/s
BenchmarkEncoder_Parallel_Binding_JsonIter-16             240200              4552 ns/op        2863.78 MB/s
BenchmarkEncoder_Parallel_Binding_GoJson-16               500446              2132 ns/op        6114.95 MB/s
BenchmarkEncoder_Parallel_Binding_StdLib-16               292932              3578 ns/op        3642.75 MB/s
PASS
```

### Decoder

```
goos: darwin
goarch: amd64
pkg: github.com/bytedance/sonic/decoder
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkDecoder_Generic_Sonic-16                          22437             53948 ns/op         241.62 MB/s
BenchmarkDecoder_Generic_StdLib-16                          8955            134350 ns/op          97.02 MB/s
BenchmarkDecoder_Generic_JsonIter-16                       10000            100658 ns/op         129.50 MB/s
BenchmarkDecoder_Generic_GoJson-16                         12310             98047 ns/op         132.95 MB/s
BenchmarkDecoder_Binding_Sonic-16                          40852             28748 ns/op         453.43 MB/s
BenchmarkDecoder_Binding_StdLib-16                         10000            118972 ns/op         109.56 MB/s
BenchmarkDecoder_Binding_JsonIter-16                       31077             37855 ns/op         344.34 MB/s
BenchmarkDecoder_Binding_GoJson-16                         35132             33881 ns/op         384.73 MB/s
BenchmarkDecoder_Parallel_Generic_Sonic-16                140882              8385 ns/op        1554.49 MB/s
BenchmarkDecoder_Parallel_Generic_StdLib-16                23689             44339 ns/op         293.99 MB/s
BenchmarkDecoder_Parallel_Generic_JsonIter-16              30918             37908 ns/op         343.86 MB/s
BenchmarkDecoder_Parallel_Generic_GoJson-16                35654             30666 ns/op         425.06 MB/s
BenchmarkDecoder_Parallel_Binding_Sonic-16                286458              3629 ns/op        3591.63 MB/s
BenchmarkDecoder_Parallel_Binding_StdLib-16                43940             27303 ns/op         477.42 MB/s
BenchmarkDecoder_Parallel_Binding_JsonIter-16              99324             11139 ns/op        1170.25 MB/s
BenchmarkDecoder_Parallel_Binding_GoJson-16               119160             10097 ns/op        1291.04 MB/s
BenchmarkGeneric_DecodeAST-16                              13604             85965 ns/op         151.63 MB/s
BenchmarkGeneric_DecodeGeneric-16                          22365             53364 ns/op         244.27 MB/s
BenchmarkGeneric_Parallel_DecodeAST-16                     33123             34727 ns/op         375.36 MB/s
BenchmarkGeneric_Parallel_DecodeGeneric-16                129037              8430 ns/op        1546.30 MB/s
PASS
```
