### PR TITLE
feat: print SyntaxError.Description in one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ fn := root.Float64()
 fm := root.Interface().(float64) // jn == jm
  ```
 
+### Print Syntax Error
+```go
+import "github.com/bytedance/sonic/decoder"
+
+var data interface{}
+dc := decoder.NewDecoder("[[[}]]")
+if err := dc.Decode(&data); err != nil {
+    if e, ok := err.(decoder.SyntaxError); ok {
+        
+        /*Syntax error at index 3: invalid char
+
+            [[[}]]
+            ...^..
+        */
+        print(e.Description())
+
+        /*"Syntax error at index 3: invalid char\n\n\t[[}]\n\t..^.\n"*/
+        println(e.DescriptionLine(2))
+    }
+
+    /*Decode: Syntax error at index 3: invalid char*/
+    t.Fatalf("Decode: %v", err) 
+}
+```
+
 ## Tips
 
 ### Pretouch

--- a/decoder/errors.go
+++ b/decoder/errors.go
@@ -38,8 +38,23 @@ func (self SyntaxError) Error() string {
     return fmt.Sprintf("Syntax error at index %d: %s", self.Pos, self.Code.Message())
 }
 
+// DescriptionLine works like DescriptionWindow,
+// but prints entire string in one line
+func (self SyntaxError) DescriptionLine(window int) string {
+    return fmt.Sprintf("%q", self.DescriptionWindow(window))
+}
+
+// Description prints error message 
+// and invalid json near failing position
 func (self SyntaxError) Description() string {
-    i := 16
+    return self.DescriptionWindow(16)
+}
+
+// DescriptionWindow prints error message 
+// and invalid json near failing position,
+// with given window boundary
+func (self SyntaxError) DescriptionWindow(window int) string {
+    i := window
     p := self.Pos - i
     q := self.Pos + i
 
@@ -78,7 +93,6 @@ func (self SyntaxError) Description() string {
         strings.Repeat(".", y),
     )
 }
-
 func clamp_zero(v int) int {
     if v < 0 {
         return 0

--- a/decoder/errors_test.go
+++ b/decoder/errors_test.go
@@ -53,3 +53,10 @@ func TestErrors_ShortDescription(t *testing.T) {
 func TestErrors_EmptyDescription(t *testing.T) {
     println(make_err("", 0).Description())
 }
+
+func TestErros_DescriptionLine(t *testing.T) {
+    out := make_err("012345678980", 5).DescriptionLine(3)
+    if out != `"Syntax error at index 5: invalid char\n\n\t234567\n\t...^..\n"` {
+        t.Fatal(out)
+    }
+}


### PR DESCRIPTION
- Add `SyntaxError.DescriptionWindow()` and `SyntaxError.DescriptionLine()`