### PR TITLE
feat(ast): support Node.Unset() and optimize sub-node traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ junit.xml
 *.svg
 *.out
 ast/test.out
+ast/bench.sh

--- a/ast/iterator.go
+++ b/ast/iterator.go
@@ -31,11 +31,11 @@ func (self *Iterator) Pos() int {
 }
 
 func (self *Iterator) Len() int {
-    return self.p.Len()
+    return self.p.len()
 }
 
 func (self *Iterator) HasNext() bool {
-    return self.i < self.p.Len()
+    return self.i < self.p.len()
 }
 
 type ListIterator struct {

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -170,7 +170,7 @@ func (self *Parser) decodeArray(ret []Node) (Node, types.ParsingError) {
         /* check for the next character */
         switch self.s[self.p] {
             case ',' : self.p++
-            case ']' : self.p++; return newArray(ret), 0
+            case ']' : self.p++; return NewArray(ret), 0
         default:
             if val.isLazy() {
                 return newLazyArray(self, ret), 0
@@ -256,7 +256,7 @@ func (self *Parser) decodeObject(ret []Pair) (Node, types.ParsingError) {
         /* check for the next character */
         switch self.s[self.p] {
             case ',' : self.p++
-            case '}' : self.p++; return newObject(ret), 0
+            case '}' : self.p++; return NewObject(ret), 0
         default:
             if val.isLazy() {
                 return newLazyObject(self, ret), 0
@@ -272,7 +272,7 @@ func (self *Parser) decodeString(iv int64, ep int) (Node, types.ParsingError) {
 
     /* fast path: no escape sequence */
     if ep == -1 {
-        return newString(s), 0
+        return NewString(s), 0
     }
 
     /* unquote the string */
@@ -310,8 +310,8 @@ func (self *Parser) Parse() (Node, types.ParsingError) {
                 return self.decodeObject(make([]Pair, 0, _DEFAULT_NODE_CAP))
             }
             return newLazyObject(self, make([]Pair, 0, _DEFAULT_NODE_CAP)), 0
-        case types.V_DOUBLE  : return newNumber(self.s[val.Ep:self.p]), 0
-        case types.V_INTEGER : return newNumber(self.s[val.Ep:self.p]), 0
+        case types.V_DOUBLE  : return NewNumber(self.s[val.Ep:self.p]), 0
+        case types.V_INTEGER : return NewNumber(self.s[val.Ep:self.p]), 0
         default              : return Node{}, types.ParsingError(-val.Vt)
     }
 }
@@ -370,17 +370,3 @@ func (self *Parser) ExportError(err types.ParsingError) error {
         Code: err,
     }.Description())
 }
-
-// func (self *Parser) printNear(start int) string {
-//     end := self.p + 10
-//     if end > len(self.s) {
-//         end = len(self.s)
-//     }
-//     if start > end {
-//         start = end - 1
-//     }
-//     if start < 0 {
-//         start = 0
-//     }
-//     return self.s[start:end]
-// }

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -258,6 +258,7 @@ func BenchmarkParser_Parallel_Sonic(b *testing.B) {
 }
 
 func BenchmarkGetOne_Gjson(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     for i := 0; i < b.N; i++ {
         ast := gjson.Get(_TwitterJson, "statuses.2.id")
         node := ast.Int()
@@ -268,6 +269,7 @@ func BenchmarkGetOne_Gjson(b *testing.B) {
 }
 
 func BenchmarkGetOne_Jsoniter(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     data := []byte(_TwitterJson)
     for i := 0; i < b.N; i++ {
         ast := jsoniter.Get(data, "statuses", 2, "id")
@@ -279,6 +281,7 @@ func BenchmarkGetOne_Jsoniter(b *testing.B) {
 }
 
 func BenchmarkGetOne_Sonic(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     for i := 0; i < b.N; i++ {
         ast, _ := NewParser(_TwitterJson).Parse()
         node := ast.Get("statuses").Index(2).Get("id").Int64()
@@ -289,6 +292,7 @@ func BenchmarkGetOne_Sonic(b *testing.B) {
 }
 
 func BenchmarkGetSeven_Gjson(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     for i := 0; i < b.N; i++ {
         ast := gjson.Get(_TwitterJson, "statuses.3.id")
         ast = gjson.Get(_TwitterJson, "statuses.3.user.entities.description")
@@ -304,6 +308,7 @@ func BenchmarkGetSeven_Gjson(b *testing.B) {
 }
 
 func BenchmarkGetSeven_Jsoniter(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     data := []byte(_TwitterJson)
     for i := 0; i < b.N; i++ {
         ast := jsoniter.Get(data, "statuses", 3, "id")
@@ -320,6 +325,7 @@ func BenchmarkGetSeven_Jsoniter(b *testing.B) {
 }
 
 func BenchmarkGetSeven_SonicParser(b *testing.B) {
+    b.SetBytes(int64(len(_TwitterJson)))
     for i := 0; i < b.N; i++ {
         ast, _ := NewParser(_TwitterJson).Parse()
         node := ast.GetByPath( "statuses", 3, "id")

--- a/bench.sh
+++ b/bench.sh
@@ -10,5 +10,6 @@ go test -benchmem -run=^$ -benchtime=100000x -bench "^(BenchmarkDecoder_Generic_
 
 cd $pwd/ast
 go test -benchmem -run=^$ -benchtime=100000x -bench "^(BenchmarkSearchOne_Gjson|BenchmarkSearchOne_Jsoniter|BenchmarkSearchOne_Sonic|BenchmarkSearchOne_Parallel_Gjson|BenchmarkSearchOne_Parallel_Jsoniter|BenchmarkSearchOne_Parallel_Sonic)$"
+go test -benchmem -run=^$ -benchtime=10000x -bench "^(BenchmarkParser_StdLib|BenchmarkParser_JsonIter|BenchmarkParser_Sonic|BenchmarkParser_Parallel_StdLib|BenchmarkParser_Parallel_JsonIter|BenchmarkParser_Parallel_Sonic|BenchmarkGetOne_Gjson|BenchmarkGetOne_Jsoniter|BenchmarkGetOne_Sonic|BenchmarkGetSeven_Gjson|BenchmarkGetSeven_Jsoniter|BenchmarkGetSeven_SonicParser)$"
 
 cd $pwd

--- a/search_test.go
+++ b/search_test.go
@@ -613,7 +613,7 @@ func TestGetNotExist(t *testing.T) {
         t.Fatal()
     }
     v2 := ret.GetByPath("m1", "m2")
-    if !v2.Exists() || v2.IsRaw() || v2.Type() != ast.V_NUMBER {
+    if !v2.Exists() || !v2.IsRaw() || v2.Int64() != 3 {
         t.Fatal(ret.Type())
     }
 }


### PR DESCRIPTION
- add `Node.Unset()/UnsetByIndex()` API
- adjust the implementation of `Node.Index()/Get()` to support indexing children of object-type node, and use `skip()` instead of `decodeValue()` while loading sub-nodes
- according to benchmark, Node.Get() speeds up about 30%