### PR TITLE
fix: make it return error when unmarshalling invalid base64-encoded strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bytedance/sonic
 go 1.15
 
 require (
-	github.com/chenzhuoyu/base64x v0.0.0-20210823082418-56861234f7ea
+	github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06
 	github.com/davecgh/go-spew v1.1.1
 	github.com/goccy/go-json v0.7.2
 	github.com/json-iterator/go v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/chenzhuoyu/base64x v0.0.0-20210823082418-56861234f7ea h1:r8ipanQ5M1I6zxG2VoJopkScCzM9p+Mypf8GWXj623Q=
 github.com/chenzhuoyu/base64x v0.0.0-20210823082418-56861234f7ea/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
+github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06 h1:1sDoSuDPWzhkdzNVxCxtIaKiAe96ESVPv8coGwc1gZ4=
+github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +17,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/issue_test/issue112_test.go
+++ b/issue_test/issue112_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package issue_test
+
+ import (
+    `testing`
+
+    . `github.com/bytedance/sonic`
+    `github.com/stretchr/testify/require`
+ )
+ 
+func TestUnmarshalInvalidBase64EncodedString(t *testing.T) {
+    var obj []byte
+    data := `"123456"`
+    err := Unmarshal([]byte(data), &obj)
+    require.Error(t, err)
+
+    data = `"1234;"`
+    err = Unmarshal([]byte(data), &obj)
+    require.Error(t, err)
+}
+ 
+ 


### PR DESCRIPTION
This fixes #112. 