### PR TITLE
Refactor benchmark for encoder

### DIFF
--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -17,357 +17,472 @@
 package encoder
 
 import (
-    `encoding/json`
-    `runtime`
-    `runtime/debug`
-    `strconv`
-    `sync`
-    `testing`
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"sync"
+	"testing"
 
-    gojson `github.com/goccy/go-json`
-    `github.com/json-iterator/go`
-    `github.com/stretchr/testify/require`
+	gojson "github.com/goccy/go-json"
+	"github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
-    go func ()  {
-        if !debugAsyncGC {
-            return 
-        }
-        println("Begin GC looping...")
-        for {
-            runtime.GC()
-            debug.FreeOSMemory() 
-        }
-        println("stop GC looping!")
-    }()
-    m.Run()
+	go func() {
+		if !debugAsyncGC {
+			return
+		}
+		println("Begin GC looping...")
+		for {
+			runtime.GC()
+			debug.FreeOSMemory()
+		}
+		println("stop GC looping!")
+	}()
+	m.Run()
 }
 
 func TestGC(t *testing.T) {
-    if debugSyncGC {
-        return 
-    }
-    out, err := Encode(_GenericValue, 0)
-    if err != nil {
-        t.Fatal(err)
-    }
-    n := len(out)
-    wg := &sync.WaitGroup{}
-    N := 10000
-    for i:=0; i<N; i++ {
-        wg.Add(1)
-        go func (wg *sync.WaitGroup, size int)  {
-            defer wg.Done()
-            out, err := Encode(_GenericValue, 0)
-            if err != nil {
-                t.Fatal(err)
-            }
-            if len(out) != size {
-                t.Fatal(len(out), size)
-            }
-            runtime.GC()
-            debug.FreeOSMemory()
-        }(wg, n)
-    }
-    wg.Wait()
+	if debugSyncGC {
+		return
+	}
+	out, err := Encode(_GenericValue, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := len(out)
+	wg := &sync.WaitGroup{}
+	N := 10000
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, size int) {
+			defer wg.Done()
+			out, err := Encode(_GenericValue, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out) != size {
+				t.Fatal(len(out), size)
+			}
+			runtime.GC()
+			debug.FreeOSMemory()
+		}(wg, n)
+	}
+	wg.Wait()
 }
 
-func runEncoderTest(t *testing.T, fn func(string)string, exp string, arg string) {
-    require.Equal(t, exp, fn(arg))
+func runEncoderTest(t *testing.T, fn func(string) string, exp string, arg string) {
+	require.Equal(t, exp, fn(arg))
 }
 
 func TestEncoder_String(t *testing.T) {
-    runEncoderTest(t, Quote, `""`                                                 , "")
-    runEncoderTest(t, Quote, `"hello, world"`                                     , "hello, world")
-    runEncoderTest(t, Quote, `"hello啊啊啊aa"`                                    , "hello啊啊啊aa")
-    runEncoderTest(t, Quote, `"hello\\\"world"`                                   , "hello\\\"world")
-    runEncoderTest(t, Quote, `"hello\n\tworld"`                                   , "hello\n\tworld")
-    runEncoderTest(t, Quote, `"hello\u0000\u0001world"`                           , "hello\x00\x01world")
-    runEncoderTest(t, Quote, `"hello\u0000\u0001world"`                           , "hello\x00\x01world")
-    runEncoderTest(t, Quote, `"Cartoonist, Illustrator, and T-Shirt connoisseur"` , "Cartoonist, Illustrator, and T-Shirt connoisseur")
+	runEncoderTest(t, Quote, `""`, "")
+	runEncoderTest(t, Quote, `"hello, world"`, "hello, world")
+	runEncoderTest(t, Quote, `"hello啊啊啊aa"`, "hello啊啊啊aa")
+	runEncoderTest(t, Quote, `"hello\\\"world"`, "hello\\\"world")
+	runEncoderTest(t, Quote, `"hello\n\tworld"`, "hello\n\tworld")
+	runEncoderTest(t, Quote, `"hello\u0000\u0001world"`, "hello\x00\x01world")
+	runEncoderTest(t, Quote, `"hello\u0000\u0001world"`, "hello\x00\x01world")
+	runEncoderTest(t, Quote, `"Cartoonist, Illustrator, and T-Shirt connoisseur"`, "Cartoonist, Illustrator, and T-Shirt connoisseur")
 }
 
 type StringStruct struct {
-    X *int        `json:"x,string,omitempty"`
-    Y []int       `json:"y"`
-    Z json.Number `json:"z,string"`
-    W string      `json:"w,string"`
+	X *int        `json:"x,string,omitempty"`
+	Y []int       `json:"y"`
+	Z json.Number `json:"z,string"`
+	W string      `json:"w,string"`
 }
 
 func TestEncoder_FieldStringize(t *testing.T) {
-    x := 12345
-    v := StringStruct{X: &x, Y: []int{1, 2, 3}, Z: "4567456", W: "asdf"}
-    r, e := Encode(v, 0)
-    require.NoError(t, e)
-    println(string(r))
+	x := 12345
+	v := StringStruct{X: &x, Y: []int{1, 2, 3}, Z: "4567456", W: "asdf"}
+	r, e := Encode(v, 0)
+	require.NoError(t, e)
+	println(string(r))
 }
 
 type MarshalerImpl struct {
-    X int
+	X int
 }
 
 func (self *MarshalerImpl) MarshalJSON() ([]byte, error) {
-    return []byte(strconv.Itoa(self.X)), nil
+	return []byte(strconv.Itoa(self.X)), nil
 }
 
 type MarshalerStruct struct {
-    V MarshalerImpl
+	V MarshalerImpl
 }
 
 func TestEncoder_Marshaler(t *testing.T) {
-    v := MarshalerStruct{V: MarshalerImpl{X: 12345}}
-    ret, err := Encode(&v, 0)
-    require.NoError(t, err)
-    require.Equal(t, `{"V":12345}`, string(ret))
-    ret, err = Encode(v, 0)
-    require.NoError(t, err)
-    require.Equal(t, `{"V":{"X":12345}}`, string(ret))
+	v := MarshalerStruct{V: MarshalerImpl{X: 12345}}
+	ret, err := Encode(&v, 0)
+	require.NoError(t, err)
+	require.Equal(t, `{"V":12345}`, string(ret))
+	ret, err = Encode(v, 0)
+	require.NoError(t, err)
+	require.Equal(t, `{"V":{"X":12345}}`, string(ret))
 }
 
 type RawMessageStruct struct {
-    X json.RawMessage
+	X json.RawMessage
 }
 
 func TestEncoder_RawMessage(t *testing.T) {
-    rms := RawMessageStruct{
-        X: json.RawMessage("123456"),
-    }
-    ret, err := Encode(&rms, 0)
-    require.NoError(t, err)
-    require.Equal(t, `{"X":123456}`, string(ret))
+	rms := RawMessageStruct{
+		X: json.RawMessage("123456"),
+	}
+	ret, err := Encode(&rms, 0)
+	require.NoError(t, err)
+	require.Equal(t, `{"X":123456}`, string(ret))
 }
 
-var _GenericValue interface{}
-var _BindingValue TwitterStruct
+var (
+	_mediumData         []byte
+	_largeData          []byte
+	_mediumGenericValue interface{}
+	_largeGenericValue  interface{}
+	_mediumBindingValue TwitterStruct
+	_largeBindingValue  TwitterStruct
+
+	_GenericValue interface{}
+	_BindingValue TwitterStruct
+)
 
 func init() {
-    _ = json.Unmarshal([]byte(TwitterJson), &_GenericValue)
-    _ = json.Unmarshal([]byte(TwitterJson), &_BindingValue)
+	mediumData := []byte(TwitterJson)
+	largeData, err := os.ReadFile(filepath.Join("..", "testdata", "twitter.json"))
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(mediumData, &_GenericValue); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(mediumData, &_BindingValue); err != nil {
+		panic(err)
+	}
+
+	if err := json.Unmarshal(mediumData, &_mediumGenericValue); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(mediumData, &_mediumBindingValue); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(largeData, &_largeGenericValue); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(largeData, &_largeBindingValue); err != nil {
+		panic(err)
+	}
+	_mediumData = mediumData
+	_largeData = largeData
 }
 
 func TestEncoder_Generic(t *testing.T) {
-    v, e := Encode(_GenericValue, 0)
-    require.NoError(t, e)
-    println(string(v))
+	v, e := Encode(_GenericValue, 0)
+	require.NoError(t, e)
+	println(string(v))
 }
 
 func TestEncoder_Binding(t *testing.T) {
-    v, e := Encode(_BindingValue, 0)
-    require.NoError(t, e)
-    println(string(v))
+	v, e := Encode(_BindingValue, 0)
+	require.NoError(t, e)
+	println(string(v))
 }
 
 func TestEncoder_MapSortKey(t *testing.T) {
-    m := map[string]string {
-        "C": "third",
-        "D": "forth",
-        "A": "first",
-        "F": "sixth",
-        "E": "fifth",
-        "B": "second",
-    }
-    v, e := Encode(m, SortMapKeys)
-    require.NoError(t, e)
-    require.Equal(t, `{"A":"first","B":"second","C":"third","D":"forth","E":"fifth","F":"sixth"}`, string(v))
+	m := map[string]string{
+		"C": "third",
+		"D": "forth",
+		"A": "first",
+		"F": "sixth",
+		"E": "fifth",
+		"B": "second",
+	}
+	v, e := Encode(m, SortMapKeys)
+	require.NoError(t, e)
+	require.Equal(t, `{"A":"first","B":"second","C":"third","D":"forth","E":"fifth","F":"sixth"}`, string(v))
+}
+
+func encodeWithSonic(b *testing.B, data []byte, v interface{}) {
+	_, _ = Encode(v, 0)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Encode(v, 0)
+	}
+}
+
+func encodeParallelWithSonic(b *testing.B, data []byte, v interface{}) {
+	_, _ = Encode(v, 0)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = Encode(v, 0)
+		}
+	})
+}
+
+func encodeWithSonicSortedMap(b *testing.B, data []byte, v interface{}) {
+	_, _ = Encode(v, SortMapKeys)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Encode(v, SortMapKeys)
+	}
+}
+
+func encodeParallelWithSonicSortedMap(b *testing.B, data []byte, v interface{}) {
+	_, _ = Encode(v, SortMapKeys)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = Encode(v, SortMapKeys)
+		}
+	})
+}
+
+func encodeWithJsonIter(b *testing.B, data []byte, v interface{}) {
+	_, _ = jsoniter.Marshal(v)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = jsoniter.Marshal(v)
+	}
+}
+
+func encodeParallelWithJsonIter(b *testing.B, data []byte, v interface{}) {
+	_, _ = jsoniter.Marshal(v)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = jsoniter.Marshal(v)
+		}
+	})
+}
+
+func encodeWithGoJson(b *testing.B, data []byte, v interface{}) {
+	_, _ = gojson.Marshal(data)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = gojson.MarshalWithOption(v, gojson.UnorderedMap())
+	}
+}
+
+func encodeParallelWithGoJson(b *testing.B, data []byte, v interface{}) {
+	_, _ = gojson.Marshal(data)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = gojson.MarshalWithOption(v, gojson.UnorderedMap())
+		}
+	})
+}
+
+func encodeWithStdLib(b *testing.B, data []byte, v interface{}) {
+	_, _ = json.Marshal(v)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = json.Marshal(v)
+	}
+}
+
+func encodeParallelWithStdLib(b *testing.B, data []byte, v interface{}) {
+	_, _ = json.Marshal(v)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = json.Marshal(v)
+		}
+	})
 }
 
 func BenchmarkEncoder_Generic_Sonic(b *testing.B) {
-    _, _ = Encode(_GenericValue, 0)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = Encode(_GenericValue, 0)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithSonic(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithSonic(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Generic_SonicSorted(b *testing.B) {
-    _, _ = Encode(_GenericValue, SortMapKeys)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = Encode(_GenericValue, SortMapKeys)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithSonicSortedMap(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithSonicSortedMap(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Generic_JsonIter(b *testing.B) {
-    _, _ = jsoniter.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = jsoniter.Marshal(_GenericValue)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithJsonIter(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithJsonIter(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Generic_GoJson(b *testing.B) {
-    _, _ = gojson.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = gojson.MarshalWithOption(_GenericValue, gojson.UnorderedMap())
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithGoJson(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithGoJson(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Generic_StdLib(b *testing.B) {
-    _, _ = json.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = json.Marshal(_GenericValue)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithStdLib(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithStdLib(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Binding_Sonic(b *testing.B) {
-    _, _ = Encode(&_BindingValue, 0)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = Encode(&_BindingValue, 0)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithSonic(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithSonic(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Binding_SonicSorted(b *testing.B) {
-    _, _ = Encode(&_BindingValue, SortMapKeys)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = Encode(&_BindingValue, SortMapKeys)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithSonicSortedMap(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithSonicSortedMap(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Binding_JsonIter(b *testing.B) {
-    _, _ = jsoniter.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = jsoniter.Marshal(&_BindingValue)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithJsonIter(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithJsonIter(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Binding_GoJson(b *testing.B) {
-    _, _ = gojson.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = gojson.MarshalWithOption(&_BindingValue, gojson.UnorderedMap())
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithGoJson(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithGoJson(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Binding_StdLib(b *testing.B) {
-    _, _ = json.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _, _ = json.Marshal(&_BindingValue)
-    }
+	b.Run("Medium", func(b *testing.B) {
+		encodeWithStdLib(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeWithStdLib(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Generic_Sonic(b *testing.B) {
-    _, _ = Encode(_GenericValue, 0)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = Encode(_GenericValue, 0)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithSonic(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithSonic(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Generic_SonicSorted(b *testing.B) {
-    _, _ = Encode(_GenericValue, SortMapKeys)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = Encode(_GenericValue, SortMapKeys)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithSonicSortedMap(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithSonicSortedMap(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Generic_JsonIter(b *testing.B) {
-    _, _ = jsoniter.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = jsoniter.Marshal(_GenericValue)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithJsonIter(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithJsonIter(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Generic_GoJson(b *testing.B) {
-    _, _ = gojson.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = gojson.MarshalWithOption(_GenericValue, gojson.UnorderedMap())
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithGoJson(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithGoJson(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Generic_StdLib(b *testing.B) {
-    _, _ = json.Marshal(_GenericValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = json.Marshal(_GenericValue)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithStdLib(b, _mediumData, &_mediumGenericValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithStdLib(b, _largeData, &_largeGenericValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Binding_Sonic(b *testing.B) {
-    _, _ = Encode(&_BindingValue, 0)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = Encode(&_BindingValue, 0)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithSonic(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithSonic(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Binding_SonicSorted(b *testing.B) {
-    _, _ = Encode(&_BindingValue, SortMapKeys)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = Encode(&_BindingValue, SortMapKeys)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithSonicSortedMap(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithSonicSortedMap(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Binding_JsonIter(b *testing.B) {
-    _, _ = jsoniter.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = jsoniter.Marshal(&_BindingValue)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithJsonIter(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithJsonIter(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Binding_GoJson(b *testing.B) {
-    _, _ = gojson.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = gojson.MarshalWithOption(&_BindingValue, gojson.UnorderedMap())
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithGoJson(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithGoJson(b, _largeData, &_largeBindingValue)
+	})
 }
 
 func BenchmarkEncoder_Parallel_Binding_StdLib(b *testing.B) {
-    _, _ = json.Marshal(&_BindingValue)
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = json.Marshal(&_BindingValue)
-        }
-    })
+	b.Run("Medium", func(b *testing.B) {
+		encodeParallelWithStdLib(b, _mediumData, &_mediumBindingValue)
+	})
+	b.Run("Large", func(b *testing.B) {
+		encodeParallelWithStdLib(b, _largeData, &_largeBindingValue)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06
 	github.com/davecgh/go-spew v1.1.1
-	github.com/goccy/go-json v0.7.2
+	github.com/goccy/go-json v0.8.0
 	github.com/json-iterator/go v1.1.10
 	github.com/klauspost/cpuid/v2 v2.0.9
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.7.2 h1:MY1gMmtCxRpaI8YGpeHCvXUb+FVIo09pnjqF9Rhh274=
-github.com/goccy/go-json v0.7.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.8.0 h1:NgAtpBKmo/q7M4NFKbxQ1J1f8SQPFX3mhVm/DsFYdXw=
+github.com/goccy/go-json v0.8.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
Makes benchmarks for medium and large data easily reproducible.
I understand that this project has a policy that doesn't apply `gofmt`.
But it's difficult to contribute..., so I'd appreciate it if you could just tolerate the test code.

Also, when I updated go-json and remeasured encoder's benchmark, the following results were obtained in my environment.
It seems that the score is better than json-iterator in all cases, so could you modify the graph of Large data in the README ?

```
goos: darwin
goarch: amd64
pkg: github.com/bytedance/sonic/encoder
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEncoder_Generic_Sonic/Medium-16                   15195             78027 ns/op         167.06 MB/s
BenchmarkEncoder_Generic_Sonic/Large-16                      408           2906846 ns/op         217.25 MB/s
BenchmarkEncoder_Generic_SonicSorted/Medium-16              8586            133062 ns/op          97.96 MB/s
BenchmarkEncoder_Generic_SonicSorted/Large-16                208           5582198 ns/op         113.13 MB/s
BenchmarkEncoder_Generic_JsonIter/Medium-16                 9340            124380 ns/op         104.80 MB/s
BenchmarkEncoder_Generic_JsonIter/Large-16                   205           5818474 ns/op         108.54 MB/s
BenchmarkEncoder_Generic_GoJson/Medium-16                  12133            100211 ns/op         130.08 MB/s
BenchmarkEncoder_Generic_GoJson/Large-16                     255           4575950 ns/op         138.01 MB/s
BenchmarkEncoder_Generic_StdLib/Medium-16                   3048            392847 ns/op          33.18 MB/s
BenchmarkEncoder_Generic_StdLib/Large-16                      63          17821851 ns/op          35.43 MB/s
BenchmarkEncoder_Binding_Sonic/Medium-16                   83350             13531 ns/op         963.37 MB/s
BenchmarkEncoder_Binding_Sonic/Large-16                     2566            423055 ns/op        1492.75 MB/s
BenchmarkEncoder_Binding_SonicSorted/Medium-16             88965             13770 ns/op         946.62 MB/s
BenchmarkEncoder_Binding_SonicSorted/Large-16               2286            484360 ns/op        1303.81 MB/s
BenchmarkEncoder_Binding_JsonIter/Medium-16                23289             51444 ns/op         253.38 MB/s
BenchmarkEncoder_Binding_JsonIter/Large-16                   663           1728974 ns/op         365.25 MB/s
BenchmarkEncoder_Binding_GoJson/Medium-16                  69692             17097 ns/op         762.40 MB/s
BenchmarkEncoder_Binding_GoJson/Large-16                    1497            840637 ns/op         751.23 MB/s
BenchmarkEncoder_Binding_StdLib/Medium-16                  30939             39711 ns/op         328.25 MB/s
BenchmarkEncoder_Binding_StdLib/Large-16                     619           1907733 ns/op         331.03 MB/s
BenchmarkEncoder_Parallel_Generic_Sonic/Medium-16         187628              7046 ns/op        1850.00 MB/s
BenchmarkEncoder_Parallel_Generic_Sonic/Large-16            4335            272190 ns/op        2320.12 MB/s
BenchmarkEncoder_Parallel_Generic_SonicSorted/Medium-16                   139945             11752 ns/op        1109.17 MB/s
BenchmarkEncoder_Parallel_Generic_SonicSorted/Large-16                      2286            473498 ns/op        1333.72 MB/s
BenchmarkEncoder_Parallel_Generic_JsonIter/Medium-16                      108038             11595 ns/op        1124.23 MB/s
BenchmarkEncoder_Parallel_Generic_JsonIter/Large-16                         2422            465797 ns/op        1355.77 MB/s
BenchmarkEncoder_Parallel_Generic_GoJson/Medium-16                        128676              9978 ns/op        1306.37 MB/s
BenchmarkEncoder_Parallel_Generic_GoJson/Large-16                           2518            407866 ns/op        1548.34 MB/s
BenchmarkEncoder_Parallel_Generic_StdLib/Medium-16                         27729             43670 ns/op         298.49 MB/s
BenchmarkEncoder_Parallel_Generic_StdLib/Large-16                            790           1625716 ns/op         388.45 MB/s
BenchmarkEncoder_Parallel_Binding_Sonic/Medium-16                         773497              1545 ns/op        8434.86 MB/s
BenchmarkEncoder_Parallel_Binding_Sonic/Large-16                           25862             45165 ns/op        13982.47 MB/s
BenchmarkEncoder_Parallel_Binding_SonicSorted/Medium-16                   831025              1454 ns/op        8963.14 MB/s
BenchmarkEncoder_Parallel_Binding_SonicSorted/Large-16                     22914             56516 ns/op        11174.16 MB/s
BenchmarkEncoder_Parallel_Binding_JsonIter/Medium-16                      233234              5019 ns/op        2597.07 MB/s
BenchmarkEncoder_Parallel_Binding_JsonIter/Large-16                         7843            152621 ns/op        4137.80 MB/s
BenchmarkEncoder_Parallel_Binding_GoJson/Medium-16                        455532              2656 ns/op        4907.66 MB/s
BenchmarkEncoder_Parallel_Binding_GoJson/Large-16                          11383             96819 ns/op        6522.60 MB/s
BenchmarkEncoder_Parallel_Binding_StdLib/Medium-16                        260574              4175 ns/op        3122.41 MB/s
BenchmarkEncoder_Parallel_Binding_StdLib/Large-16                           6391            191515 ns/op        3297.46 MB/s
BenchmarkSort_Sonic-16                                                      8071            144567 ns/op
BenchmarkSort_Std-16                                                        3198            357997 ns/op
BenchmarkSort_Parallel_Sonic-16                                           215102              5714 ns/op
BenchmarkSort_Parallel_Std-16                                              69751             16686 ns/op
PASS
ok      github.com/bytedance/sonic/encoder      72.922s
```