### PR TITLE
fix: keep arg `buf` alive

### DIFF
--- a/decoder/pools.go
+++ b/decoder/pools.go
@@ -84,7 +84,6 @@ var _KeepAlive struct {
 
 var errCallShadow = errors.New("DON'T CALL THIS!")
 
-//go:nosplit
 // Faker func of _Decoder, used to export its stackmap as _Decoder's
 func _Decoder_Shadow(s string, i int, vp unsafe.Pointer, sb *_Stack, fv uint64, sv string, vk unsafe.Pointer) (ret int, err error) {
     // align to assembler_amd64.go: _FP_offs
@@ -105,7 +104,6 @@ func _Decoder_Shadow(s string, i int, vp unsafe.Pointer, sb *_Stack, fv uint64, 
     return 0, errCallShadow
 }
 
-//go:nosplit
 // Faker func of _Decoder_Generic, used to export its stackmap
 func _Decoder_Generic_Shadow(sb *_Stack) {
     // align to generic_amd64.go: _VD_offs

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -109,6 +109,7 @@ func EncodeInto(buf *[]byte, val interface{}, opts Options) error {
     freeStack(stk)
 
     /* avoid GC ahead */
+    runtime.KeepAlive(buf)
     runtime.KeepAlive(efv)
     return err
 }

--- a/encoder/pools.go
+++ b/encoder/pools.go
@@ -71,7 +71,6 @@ var _KeepAlive struct {
 var errCallShadow = errors.New("DON'T CALL THIS!")
 
 // Faker func of _Encoder, used to export its stackmap as _Encoder's
-//go:nosplit
 func _Encoder_Shadow(rb *[]byte, vp unsafe.Pointer, sb *_Stack, fv uint64) (err error) {
     // align to assembler_amd64.go: _FP_offs
     var frame [_FP_offs]byte


### PR DESCRIPTION
ps: remove `go:nosplit` compile directive for fake func