### PR TITLE
support JSON validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ v := map[string]string{"&&":{"<>"}}
 ret, err := Encode(v, EscapeHTML) // ret == `{"\u0026\u0026":{"X":"\u003c\u003e"}}`
 ```
 ### Compact Format
-Sonic encods premitive objects (struct/map...) are as compact-format JSON, except marshaling `json.RawMessage` or `json.Marshaler`: sonic ensures validating their output JSON but **DONOT** compacting for performance concern. We provide option `encoder.CompactMarshaler` to add compacting process.
+Sonic encodes premitive objects (struct/map...) as compact-format JSON by default, except marshaling `json.RawMessage` or `json.Marshaler`: sonic ensures validating their output JSON but **DONOT** compacting them for performance concern. We provide option `encoder.CompactMarshaler` to add compacting process.
 
 ### Print Syntax Error
 ```go
@@ -249,7 +249,7 @@ import (
     err := sonic.Pretouch(reflect.TypeOf(v), option.WithCompileRecursiveDepth(depth))
 ```
 ### Accelerate `encoding.TextMarshaler`
-To ensure data security, sonic.Encoder quotes and escapes string values from `encoding.TextMarshaler` interfaces by default, which may degrade performance much if most of your data is in form of them. We provide `encoder.NoQuoteTextMarshaler` to avoid these operations, which means you **MUST** ensure their output string quoted and escaped by your own.
+To ensure data security, sonic.Encoder quotes and escapes string values from `encoding.TextMarshaler` interfaces by default, which may degrade performance much if most of your data is in form of them. We provide `encoder.NoQuoteTextMarshaler` to skip these operations, which means you **MUST** ensure their output string escaped and quoted in accordance with [RFC8259](https://datatracker.ietf.org/doc/html/rfc8259).
 
 ### Pass string or []byte?
 For alignment to `encoding/json`, we provide API to pass `[]byte` as an argument, but the string-to-bytes copy is conducted at the same time considering safety, which may lose performance when origin JSON is huge. Therefore, you can use `UnmarshalString` and `GetFromString` to pass a string, as long as your origin data is a string or **nocopy-cast** is safe for your []byte.

--- a/README.md
+++ b/README.md
@@ -146,13 +146,8 @@ import "github.com/bytedance/sonic"
 v := map[string]string{"&&":{"<>"}}
 ret, err := Encode(v, EscapeHTML) // ret == `{"\u0026\u0026":{"X":"\u003c\u003e"}}`
 ```
-### Optimization Options
-- encoder.NoCompactMarshaler
-
-When marshaling `json.RawMessage` or `json.Marshaler`, sonic ensures validating and compacting their output JSON string. The higher the ratio of these kinds of data is, the much this feature impacts encoding performance. Therefore, we provide option `encoder.NoCompactMarshaler` to skip the compacting process, which means your marshaler's outputs **MUST** be valid JSON. If not, **Undocumented Behavior** may happen.
-- encoder.NoQuoteTextMarshaler
-
-We also provide option `encoder.NoQuoteTextMarshaler` to avoid quoting the output string of `encoding.TextMarshaler`.
+### Compact Format
+Sonic encods premitive objects (struct/map...) are as compact-format JSON, except marshaling `json.RawMessage` or `json.Marshaler`: sonic ensures validating their output JSON but **DONOT** compacting for performance concern. We provide option `encoder.CompactMarshaler` to add compacting process.
 
 ### Print Syntax Error
 ```go
@@ -253,8 +248,8 @@ import (
     // you can set compile recursive depth in Pretouch for better stability in JIT.
     err := sonic.Pretouch(reflect.TypeOf(v), option.WithCompileRecursiveDepth(depth))
 ```
-### Accelerate `json.RawMessage\json.Marshaler\encoding.TextMarshaler`
-To ensure data security, sonic.Encoder validates and escapes JSON values from these interfaces by default, which may degrade performance much if most of your data is in form of them. We provide two options `encoder.NoCompactMarshaler` (for `json.RawMessage\json.Marshaler`) and `encoder.NoQuoteTextMarshaler` (for `encoding.TextMarshaler`) to avoid validating and escaping operations, which means you **MUST** ensure the validity of JSON values from these interfaces by your own.
+### Accelerate `encoding.TextMarshaler`
+To ensure data security, sonic.Encoder quotes and escapes string values from `encoding.TextMarshaler` interfaces by default, which may degrade performance much if most of your data is in form of them. We provide `encoder.NoQuoteTextMarshaler` to avoid these operations, which means you **MUST** ensure their output string quoted and escaped by your own.
 
 ### Pass string or []byte?
 For alignment to `encoding/json`, we provide API to pass `[]byte` as an argument, but the string-to-bytes copy is conducted at the same time considering safety, which may lose performance when origin JSON is huge. Therefore, you can use `UnmarshalString` and `GetFromString` to pass a string, as long as your origin data is a string or **nocopy-cast** is safe for your []byte.

--- a/ast/encode_test.go
+++ b/ast/encode_test.go
@@ -94,7 +94,7 @@ func TestEncodeValue(t *testing.T) {
         {NewObject([]Pair{}), `{}`, false},
         {NewBytes([]byte("hello, world")), `"aGVsbG8sIHdvcmxk"`, false},
         {NewAny(obj), string(buf), false},
-        {NewRaw(`[{ }]`), "[{}]", false},
+        {NewRaw(`[{ }]`), "[{ }]", false},
         {Node{}, "", true},
         {Node{t: types.ValueType(1)}, "", true},
     }

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -18,7 +18,6 @@ package ast
 
 import (
     `fmt`
-    `sync`
     `unsafe`
 
     `github.com/bytedance/sonic/decoder`
@@ -45,12 +44,6 @@ type Parser struct {
     s           string
     noLazy      bool
     skipValue   bool
-}
-
-var stackPool = sync.Pool{
-    New: func()interface{}{
-        return &types.StateMachine{}
-    },
 }
 
 /** Parser Private Methods **/
@@ -325,9 +318,9 @@ func (self *Parser) Parse() (Node, types.ParsingError) {
 }
 
 func (self *Parser) skip() (int, types.ParsingError) {
-    fsm := stackPool.Get().(*types.StateMachine)
+    fsm := types.NewStateMachine()
     start := native.SkipOne(&self.s, &self.p, fsm)
-    stackPool.Put(fsm)
+    types.FreeStateMachine(fsm)
     
     if start < 0 {
         return self.p, types.ParsingError(-start)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -22,6 +22,8 @@ import (
     `runtime`
 
     `github.com/bytedance/sonic/internal/rt`
+    `github.com/bytedance/sonic/internal/native`
+    `github.com/bytedance/sonic/internal/native/types`
     `github.com/bytedance/sonic/option`
 )
 
@@ -160,4 +162,15 @@ func pretouchRec(vtm map[reflect.Type]bool, opts option.CompileOptions) error {
     }
     opts.RecursiveDepth -= 1
     return pretouchRec(next, opts)
+}
+
+// Skip skips only one json value, and returns first non-blank character position and its ending position if it is valid.
+// Otherwise returns negative error code using start and invalid character position using end
+func Skip(data []byte) (start int, end int) {
+    s := rt.Mem2Str(data)
+    p := 0
+    m := types.NewStateMachine()
+    ret := native.SkipOne(&s, &p, m)
+    types.FreeStateMachine(m) 
+    return ret, p
 }

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -29,6 +29,7 @@ import (
     `github.com/json-iterator/go`
     `github.com/stretchr/testify/assert`
     `github.com/stretchr/testify/require`
+    `github.com/bytedance/sonic/internal/rt`
 )
 
 func TestMain(m *testing.M) {
@@ -333,3 +334,14 @@ func BenchmarkDecoder_Parallel_Binding_GoJson(b *testing.B) {
     })
 }
 
+func BenchmarkSkip_Sonic(b *testing.B) {
+    var data = rt.Str2Mem(TwitterJson)
+    if ret, _ := Skip(data); ret < 0 {
+        b.Fatal()
+    }
+    b.SetBytes(int64(len(TwitterJson)))
+    b.ResetTimer()
+    for i:=0; i<b.N; i++ {
+        _, _ = Skip(data)
+    }
+}

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -35,7 +35,7 @@ type Options uint64
 const (
     bitSortMapKeys          = iota
     bitEscapeHTML          
-    bitNoCompactMarshaler
+    bitCompactMarshaler
     bitNoQuoteTextMarshaler
 )
 
@@ -50,9 +50,9 @@ const (
     // WARNING: This hurts performance A LOT, USE WITH CARE.
     EscapeHTML           Options = 1 << bitEscapeHTML
 
-    // NoCompactMarshaler indicates that the output JSON from json.Marshaler 
+    // CompactMarshaler indicates that the output JSON from json.Marshaler 
     // is always compact and needs no validation 
-    NoCompactMarshaler   Options = 1 << bitNoCompactMarshaler
+    CompactMarshaler   Options = 1 << bitCompactMarshaler
 
     // NoQuoteTextMarshaler indicates that the output text from encoding.TextMarshaler 
     // is always escaped string and needs no quoting
@@ -279,16 +279,19 @@ func pretouchRec(vtm map[reflect.Type]bool, opts option.CompileOptions) error {
     return pretouchRec(next, opts)
 }
 
-
-func Valid(data []byte) bool {
+// Valid validates json and tells and returns first non-blank character position if it is ok.
+// Otherwise returns invalid character position (using negative value)
+func Valid(data []byte) (ok bool, start int) {
     s := rt.Mem2Str(data)
     p := 0
     m := types.NewStateMachine()
     ret := native.ValidateOne(&s, &p, m)
     types.FreeStateMachine(m) 
-    return ret >= 0
+    return ret >= 0, ret
 }
 
+// Skip skips only one json value, and returns first non-blank character position and its ending position if it is valid.
+// Otherwise returns negative start and invalid character position at end
 func Skip(data []byte) (start int, end int) {
     s := rt.Mem2Str(data)
     p := 0

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -24,6 +24,7 @@ import (
     `unsafe`
 
     `github.com/bytedance/sonic/internal/native`
+    `github.com/bytedance/sonic/internal/native/types`
     `github.com/bytedance/sonic/internal/rt`
     `github.com/bytedance/sonic/option`
 )
@@ -276,4 +277,23 @@ func pretouchRec(vtm map[reflect.Type]bool, opts option.CompileOptions) error {
     }
     opts.RecursiveDepth -= 1
     return pretouchRec(next, opts)
+}
+
+
+func Valid(data []byte) bool {
+    s := rt.Mem2Str(data)
+    p := 0
+    m := types.NewStateMachine()
+    ret := native.ValidateOne(&s, &p, m)
+    types.FreeStateMachine(m) 
+    return ret >= 0
+}
+
+func Skip(data []byte) (start int, end int) {
+    s := rt.Mem2Str(data)
+    p := 0
+    m := types.NewStateMachine()
+    ret := native.SkipOne(&s, &p, m)
+    types.FreeStateMachine(m) 
+    return ret, p
 }

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -136,6 +136,21 @@ func TestEncoder_Marshaler(t *testing.T) {
     require.Equal(t, `{"V":{"X":12345}}`, string(ret3))
 }
 
+type MarshalerErrorStruct struct {
+    V MarshalerImpl
+}
+
+func (self *MarshalerErrorStruct) MarshalJSON() ([]byte, error) {
+    return []byte(`[""] {`), nil
+}
+
+func TestMarshalerError(t *testing.T) {
+    v := MarshalerErrorStruct{}
+    ret, err := Encode(&v, 0)
+    require.EqualError(t, err, `invalid Marshaler output json syntax at 5: "[\"\"] {"`)
+    require.Equal(t, []byte(nil), ret)
+}
+
 type RawMessageStruct struct {
     X json.RawMessage
 }
@@ -469,18 +484,6 @@ func BenchmarkValidate_Sonic(b *testing.B) {
     b.ResetTimer()
     for i:=0; i<b.N; i++ {
         _, _ = Valid(data)
-    }
-}
-
-func BenchmarkSkip_Sonic(b *testing.B) {
-    var data = rt.Str2Mem(TwitterJson)
-    if ret, _ := Skip(data); ret < 0 {
-        b.Fatal()
-    }
-    b.SetBytes(int64(len(TwitterJson)))
-    b.ResetTimer()
-    for i:=0; i<b.N; i++ {
-        _, _ = Skip(data)
     }
 }
 

--- a/encoder/errors.go
+++ b/encoder/errors.go
@@ -18,9 +18,9 @@ package encoder
 
 import (
     `encoding/json`
+    `fmt`
     `reflect`
     `strconv`
-    `errors`
 )
 
 var _ERR_too_deep = &json.UnsupportedValueError {
@@ -44,9 +44,6 @@ func error_number(number json.Number) error {
     }
 }
 
-func error_marshaler(vtype reflect.Type, s int) error {
-    return &json.MarshalerError{
-        Type       :vtype,
-        Err        :errors.New("invalid json syntax at " + strconv.Itoa(s)),
-    }
+func error_marshaler(ret []byte, pos int) error {
+    return fmt.Errorf("invalid Marshaler output json syntax at %d: %q", pos, ret)
 }

--- a/encoder/errors.go
+++ b/encoder/errors.go
@@ -20,6 +20,7 @@ import (
     `encoding/json`
     `reflect`
     `strconv`
+    `errors`
 )
 
 var _ERR_too_deep = &json.UnsupportedValueError {
@@ -40,5 +41,12 @@ func error_number(number json.Number) error {
     return &json.UnsupportedValueError {
         Str   : "invalid number literal: " + strconv.Quote(string(number)),
         Value : reflect.ValueOf(number),
+    }
+}
+
+func error_marshaler(vtype reflect.Type, s int) error {
+    return &json.MarshalerError{
+        Type       :vtype,
+        Err        :errors.New("invalid json syntax at " + strconv.Itoa(s)),
     }
 }

--- a/encoder/primitives.go
+++ b/encoder/primitives.go
@@ -87,7 +87,7 @@ func encodeJsonMarshaler(buf *[]byte, val json.Marshaler, opt Options) error {
             return compact(buf, ret)
         }
         if ok, s := Valid(ret); !ok {
-            return error_marshaler(rt.UnpackIface(val).Itab.Vt.Pack(), s)
+            return error_marshaler(ret, s)
         }
         *buf = append(*buf, ret...)
         return nil

--- a/encoder/primitives.go
+++ b/encoder/primitives.go
@@ -83,11 +83,14 @@ func encodeJsonMarshaler(buf *[]byte, val json.Marshaler, opt Options) error {
     if ret, err := val.MarshalJSON(); err != nil {
         return err
     } else {
-        if opt & NoCompactMarshaler != 0 {
-            *buf = append(*buf, ret...)
-            return nil
+        if opt & CompactMarshaler != 0 {
+            return compact(buf, ret)
         }
-        return compact(buf, ret)
+        if ok, s := Valid(ret); !ok {
+            return error_marshaler(rt.UnpackIface(val).Itab.Vt.Pack(), s)
+        }
+        *buf = append(*buf, ret...)
+        return nil
     }
 }
 

--- a/internal/native/avx/native_amd64.go
+++ b/internal/native/avx/native_amd64.go
@@ -103,3 +103,8 @@ func __skip_array(s *string, p *int, m *types.StateMachine) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __skip_object(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -291,7 +291,7 @@ LBB2_5:
 	LONG    $0x4fdc6941; WORD $0x1293; BYTE $0x00 // imull        $1217359, %r12d, %ebx
 	MOVQ    R12, AX
 	SHLQ    $4, AX
-	LONG    $0x940d8d48; WORD $0x0075; BYTE $0x00 // leaq         $30100(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
+	LONG    $0x3b0d8d48; WORD $0x007d; BYTE $0x00 // leaq         $32059(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(AX)(CX*1), R10
@@ -378,7 +378,7 @@ LBB2_12:
 	SHRL    $19, BX
 	MOVLQSX AX, SI
 	SHLQ    $4, SI
-	LONG    $0xbf158d4c; WORD $0x0089; BYTE $0x00 // leaq         $35263(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
+	LONG    $0x66158d4c; WORD $0x0091; BYTE $0x00 // leaq         $37222(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(SI)(R10*1), R14
@@ -791,7 +791,7 @@ LBB2_61:
 	LEAQ 1(R13), BX
 	MOVQ BX, SI
 	MOVL R15, DX
-	LONG $0x003f32e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x0046d9e8; BYTE $0x00 // callq        _print_mantissa
 	MOVB 1(R13), AX
 	MOVB AX, 0(R13)
 	MOVL $1, AX
@@ -820,7 +820,7 @@ LBB2_66:
 	LEAL    0(CX)(CX*1), AX
 	LEAL    0(AX)(AX*4), AX
 	SUBL    AX, R14
-	LONG    $0x91058d48; WORD $0x0098; BYTE $0x00 // leaq         $39057(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0x38058d48; WORD $0x00a0; BYTE $0x00 // leaq         $41016(%rip), %rax  /* _Digits(%rip) */
 	MOVWLZX 0(AX)(CX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -856,7 +856,7 @@ LBB2_70:
 	CMPL    R14, $10
 	JL      LBB2_85
 	MOVLQSX R14, AX
-	LONG    $0x230d8d48; WORD $0x0098; BYTE $0x00 // leaq         $38947(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0xca0d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40906(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -875,7 +875,7 @@ LBB2_74:
 	MOVL  BX, SI
 	ADDQ  -64(BP), SI
 	MOVL  R15, DX
-	LONG  $0x003e2ee8; BYTE $0x00 // callq        _print_mantissa
+	LONG  $0x0045d5e8; BYTE $0x00 // callq        _print_mantissa
 	TESTL R13, R13
 	JE    LBB2_78
 	LEAL  0(R13)(BX*1), AX
@@ -1079,7 +1079,7 @@ LBB2_105:
 	MOVQ R13, SI
 	MOVL R15, DX
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x003b1ce8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x0042c3e8; BYTE $0x00 // callq        _print_mantissa
 	ADDL BX, R15
 	MOVL R15, BX
 
@@ -1172,7 +1172,7 @@ _u64toa:
 	ADDQ    AX, AX
 	CMPL    SI, $1000
 	JB      LBB4_3
-	LONG    $0xe50d8d48; WORD $0x0093; BYTE $0x00 // leaq         $37861(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x8c0d8d48; WORD $0x009b; BYTE $0x00 // leaq         $39820(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(DX)(CX*1), CX
 	MOVB    CX, 0(DI)
 	MOVL    $1, CX
@@ -1186,14 +1186,14 @@ LBB4_3:
 LBB4_4:
 	MOVWLZX DX, DX
 	ORQ     $1, DX
-	LONG    $0xc4358d48; WORD $0x0093; BYTE $0x00 // leaq         $37828(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0x6b358d48; WORD $0x009b; BYTE $0x00 // leaq         $39787(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(DX)(SI*1), DX
 	MOVL    CX, SI
 	INCL    CX
 	MOVB    DX, 0(DI)(SI*1)
 
 LBB4_6:
-	LONG $0xb3158d48; WORD $0x0093; BYTE $0x00 // leaq         $37811(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x5a158d48; WORD $0x009b; BYTE $0x00 // leaq         $39770(%rip), %rdx  /* _Digits(%rip) */
 	MOVB 0(AX)(DX*1), DX
 	MOVL CX, SI
 	INCL CX
@@ -1202,7 +1202,7 @@ LBB4_6:
 LBB4_7:
 	MOVWLZX AX, AX
 	ORQ     $1, AX
-	LONG    $0x9b158d48; WORD $0x0093; BYTE $0x00 // leaq         $37787(%rip), %rdx  /* _Digits(%rip) */
+	LONG    $0x42158d48; WORD $0x009b; BYTE $0x00 // leaq         $39746(%rip), %rdx  /* _Digits(%rip) */
 	MOVB    0(AX)(DX*1), AX
 	MOVL    CX, DX
 	INCL    CX
@@ -1249,7 +1249,7 @@ LBB4_8:
 	ADDQ    R11, R11
 	CMPL    SI, $10000000
 	JB      LBB4_11
-	LONG    $0x04058d48; WORD $0x0093; BYTE $0x00 // leaq         $37636(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0xab058d48; WORD $0x009a; BYTE $0x00 // leaq         $39595(%rip), %rax  /* _Digits(%rip) */
 	MOVB    0(R10)(AX*1), AX
 	MOVB    AX, 0(DI)
 	MOVL    $1, CX
@@ -1263,14 +1263,14 @@ LBB4_11:
 LBB4_12:
 	MOVL R10, AX
 	ORQ  $1, AX
-	LONG $0xdf358d48; WORD $0x0092; BYTE $0x00 // leaq         $37599(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x86358d48; WORD $0x009a; BYTE $0x00 // leaq         $39558(%rip), %rsi  /* _Digits(%rip) */
 	MOVB 0(AX)(SI*1), AX
 	MOVL CX, SI
 	INCL CX
 	MOVB AX, 0(DI)(SI*1)
 
 LBB4_14:
-	LONG $0xce058d48; WORD $0x0092; BYTE $0x00 // leaq         $37582(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x75058d48; WORD $0x009a; BYTE $0x00 // leaq         $39541(%rip), %rax  /* _Digits(%rip) */
 	MOVB 0(R9)(AX*1), AX
 	MOVL CX, SI
 	INCL CX
@@ -1279,7 +1279,7 @@ LBB4_14:
 LBB4_15:
 	MOVWLZX R9, AX
 	ORQ     $1, AX
-	LONG    $0xb4358d48; WORD $0x0092; BYTE $0x00 // leaq         $37556(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0x5b358d48; WORD $0x009a; BYTE $0x00 // leaq         $39515(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(AX)(SI*1), AX
 	MOVL    CX, DX
 	MOVB    AX, 0(DX)(DI*1)
@@ -1361,7 +1361,7 @@ LBB4_16:
 	MOVL $16, CX
 	SUBL AX, CX
 	SHLQ $4, AX
-	LONG $0x29158d48; WORD $0x0092; BYTE $0x00 // leaq         $37417(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0xd0158d48; WORD $0x0099; BYTE $0x00 // leaq         $39376(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	MOVL CX, AX
@@ -1387,7 +1387,7 @@ LBB4_20:
 	CMPL DX, $99
 	JA   LBB4_22
 	MOVL DX, AX
-	LONG $0x0c0d8d48; WORD $0x0091; BYTE $0x00 // leaq         $37132(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb30d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39091(%rip), %rcx  /* _Digits(%rip) */
 	MOVB 0(CX)(AX*2), DX
 	MOVB 1(CX)(AX*2), AX
 	MOVB DX, 0(DI)
@@ -1412,7 +1412,7 @@ LBB4_22:
 	WORD    $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	SUBL    CX, AX
 	MOVWLZX AX, AX
-	LONG    $0xbb0d8d48; WORD $0x0090; BYTE $0x00 // leaq         $37051(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x620d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39010(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(CX)(AX*2), DX
 	MOVB    1(CX)(AX*2), AX
 	MOVB    DX, 1(DI)
@@ -1424,7 +1424,7 @@ LBB4_24:
 	WORD    $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	SUBL    CX, DX
 	MOVWLZX AX, AX
-	LONG    $0x98058d4c; WORD $0x0090; BYTE $0x00 // leaq         $37016(%rip), %r8  /* _Digits(%rip) */
+	LONG    $0x3f058d4c; WORD $0x0098; BYTE $0x00 // leaq         $38975(%rip), %r8  /* _Digits(%rip) */
 	MOVB    0(R8)(AX*2), CX
 	MOVB    1(R8)(AX*2), AX
 	MOVB    CX, 0(DI)
@@ -1509,8 +1509,8 @@ _quote:
 	SUBQ  $32, SP
 	MOVQ  DX, R10
 	TESTB $1, R8
-	LONG  $0x9a058d48; WORD $0x0090; BYTE $0x00 // leaq         $37018(%rip), %rax  /* __SingleQuoteTab(%rip) */
-	LONG  $0x93158d48; WORD $0x00a0; BYTE $0x00 // leaq         $41107(%rip), %rdx  /* __DoubleQuoteTab(%rip) */
+	LONG  $0x41058d48; WORD $0x0098; BYTE $0x00 // leaq         $38977(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG  $0x3a158d48; WORD $0x00a8; BYTE $0x00 // leaq         $43066(%rip), %rdx  /* __DoubleQuoteTab(%rip) */
 	LONG  $0xd0440f48                           // cmoveq       %rax, %rdx
 	MOVQ  R10, R8
 	MOVQ  DI, AX
@@ -1600,7 +1600,7 @@ LBB5_10:
 	TESTQ R10, R10
 	MOVQ  -48(BP), CX
 	MOVQ  -56(BP), DI
-	LONG  $0x482d8d4c; WORD $0x008f; BYTE $0x00 // leaq         $36680(%rip), %r13  /* __SingleQuoteTab(%rip) */
+	LONG  $0xef2d8d4c; WORD $0x0096; BYTE $0x00 // leaq         $38639(%rip), %r13  /* __SingleQuoteTab(%rip) */
 	JLE   LBB5_39
 
 LBB5_35:
@@ -1867,7 +1867,7 @@ _unquote:
 	MOVQ  R8, -72(BP)
 	MOVL  R8, R10
 	ANDL  $1, R10
-	LONG  $0x69058d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44137(%rip), %r8  /* __UnquoteTab(%rip) */
+	LONG  $0x10058d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46096(%rip), %r8  /* __UnquoteTab(%rip) */
 	QUAD  $0xffffffb2056ffac5                   // vmovdqu      $-78(%rip), %xmm0  /* LCPI6_0(%rip) */
 	MOVQ  DI, R9
 	MOVQ  SI, R13
@@ -2550,7 +2550,7 @@ _html_escape:
 	QUAD  $0xffffff92156ffac5                   // vmovdqu      $-110(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD  $0xffffff9a1d6ffac5                   // vmovdqu      $-102(%rip), %xmm3  /* LCPI7_3(%rip) */
 	MOVQ  $5764607797912141824, R14
-	LONG  $0xcd3d8d4c; WORD $0x00a4; BYTE $0x00 // leaq         $42189(%rip), %r15  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x743d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44148(%rip), %r15  /* __HtmlQuoteTab(%rip) */
 	MOVQ  $12884901889, DI
 	MOVQ  -64(BP), AX
 	MOVQ  -48(BP), R10
@@ -2885,7 +2885,7 @@ LBB8_5:
 	SHLQ CX, DI
 	MOVL AX, CX
 	SHLQ $4, CX
-	LONG $0x583d8d4c; WORD $0x0029; BYTE $0x00 // leaq         $10584(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0xff3d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12543(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	MOVQ DI, AX
 	MULQ 8(CX)(R15*1)
 	MOVQ AX, R11
@@ -3008,7 +3008,7 @@ LBB9_7:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x0026a3e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002e4ae8; BYTE $0x00 // callq        _right_shift
 
 LBB9_8:
 	ADDL  R14, R15
@@ -3021,7 +3021,7 @@ LBB9_9:
 	CMPL AX, $8
 	JG   LBB9_11
 	MOVL AX, AX
-	LONG $0x540d8d48; WORD $0x0053; BYTE $0x00 // leaq         $21332(%rip), %rcx  /* _POW_TAB(%rip) */
+	LONG $0xfb0d8d48; WORD $0x005a; BYTE $0x00 // leaq         $23291(%rip), %rcx  /* _POW_TAB(%rip) */
 	MOVL 0(CX)(AX*4), R14
 
 LBB9_11:
@@ -3039,7 +3039,7 @@ LBB9_11:
 LBB9_15:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002651e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002df8e8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3053,7 +3053,7 @@ LBB9_16:
 LBB9_17:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x0024c3e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002c6ae8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3065,12 +3065,12 @@ LBB9_18:
 
 LBB9_19:
 	MOVQ R12, DI
-	LONG $0x0024ade8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002c54e8; BYTE $0x00 // callq        _left_shift
 	JMP  LBB9_8
 
 LBB9_20:
 	MOVQ R12, DI
-	LONG $0x0024a0e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002c47e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_21:
 	SUBL R14, R15
@@ -3093,7 +3093,7 @@ LBB9_25:
 LBB9_26:
 	NEGL AX
 	WORD $0x9848                               // cltq
-	LONG $0xae0d8d48; WORD $0x0052; BYTE $0x00 // leaq         $21166(%rip), %rcx  /* _POW_TAB(%rip) */
+	LONG $0x550d8d48; WORD $0x005a; BYTE $0x00 // leaq         $23125(%rip), %rcx  /* _POW_TAB(%rip) */
 	MOVL 0(CX)(AX*4), R14
 
 LBB9_27:
@@ -3111,7 +3111,7 @@ LBB9_27:
 LBB9_32:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x00243be8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002be2e8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3126,7 +3126,7 @@ LBB9_33:
 LBB9_34:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002588e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002d2fe8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3136,7 +3136,7 @@ LBB9_35:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x002572e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002d19e8; BYTE $0x00 // callq        _right_shift
 	JMP  LBB9_21
 
 LBB9_36:
@@ -3152,7 +3152,7 @@ LBB9_36:
 LBB9_40:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x00253be8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002ce2e8; BYTE $0x00 // callq        _right_shift
 	ADDL $60, R15
 	CMPL R15, $-120
 	JL   LBB9_40
@@ -3178,7 +3178,7 @@ LBB9_46:
 	NEGL R15
 	MOVQ R12, DI
 	MOVL R15, SI
-	LONG $0x0024f5e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002c9ce8; BYTE $0x00 // callq        _right_shift
 	MOVL $-1022, R14
 
 LBB9_47:
@@ -3186,7 +3186,7 @@ LBB9_47:
 	JE   LBB9_49
 	MOVQ R12, DI
 	MOVL $53, SI
-	LONG $0x00236be8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002b12e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_49:
 	MOVLQSX 20(R12), R8
@@ -4787,7 +4787,7 @@ LBB15_71:
 	CMPL    DI, $23
 	JL      LBB15_81
 	MOVLQSX DI, AX
-	LONG    $0xc90d8d48; WORD $0x00b4; BYTE $0x00 // leaq         $46281(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0x700d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48240(%rip), %rcx  /* _P10_TAB(%rip) */
 	QUAD    $0xffff50c18459fbc5; BYTE $0xff       // vmulsd       $-176(%rcx,%rax,8), %xmm0, %xmm0
 	LONG    $0x4511fbc5; BYTE $0xd0               // vmovsd       %xmm0, $-48(%rbp)
 	MOVL    $22, AX
@@ -4805,7 +4805,7 @@ LBB15_77:
 	JB      LBB15_60
 	NEGL    DI
 	MOVLQSX DI, AX
-	LONG    $0x870d8d48; WORD $0x00b4; BYTE $0x00 // leaq         $46215(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0x2e0d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48174(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG    $0x045efbc5; BYTE $0xc1               // vdivsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP     LBB15_65
 
@@ -4837,7 +4837,7 @@ LBB15_82:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	JA   LBB15_60
 	MOVL AX, AX
-	LONG $0x0e0d8d48; WORD $0x00b4; BYTE $0x00 // leaq         $46094(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0xb50d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $48053(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP  LBB15_65
 
@@ -5110,6 +5110,7 @@ _skip_one:
 	MOVQ DI, SI
 	MOVQ $1, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -5121,41 +5122,42 @@ _fsm_exec:
 	WORD $0x5541             // pushq        %r13
 	WORD $0x5441             // pushq        %r12
 	BYTE $0x53               // pushq        %rbx
-	SUBQ $24, SP
+	SUBQ $40, SP
 	CMPL 0(DI), $0
 	JE   LBB19_2
-	MOVQ SI, R15
-	MOVQ DI, R13
+	MOVQ DI, R12
+	MOVL CX, -60(BP)
+	MOVQ SI, -48(BP)
 	MOVQ DX, -56(BP)
 	MOVQ $-1, R14
-	MOVQ SI, -48(BP)
 	JMP  LBB19_4
 
 LBB19_2:
-	MOVQ $-1, BX
-	JMP  LBB19_60
+	MOVQ $-1, R13
+	JMP  LBB19_68
 
 LBB19_3:
 	LEAQ  3(AX), CX
-	MOVQ  CX, 0(SI)
+	MOVQ  CX, 0(BX)
 	TESTQ AX, AX
-	JLE   LBB19_57
+	JLE   LBB19_64
 
-LBB19_37:
-	MOVL  0(R13), CX
-	MOVQ  R14, BX
+LBB19_40:
+	MOVL  0(R12), CX
+	MOVQ  R14, R13
 	TESTL CX, CX
-	JE    LBB19_60
+	JE    LBB19_68
 
 LBB19_4:
-	MOVQ    0(R15), DI
-	MOVQ    8(R15), SI
+	MOVQ    -48(BP), R13
+	MOVQ    0(R13), DI
+	MOVQ    8(R13), SI
 	MOVQ    -56(BP), BX
 	MOVQ    BX, DX
-	LONG    $0xfff227e8; BYTE $0xff // callq        _advance_ns
-	MOVLQSX 0(R13), DX
+	LONG    $0xfff220e8; BYTE $0xff // callq        _advance_ns
+	MOVLQSX 0(R12), DX
 	LEAQ    -1(DX), CX
-	MOVL    0(R13)(DX*4), SI
+	MOVL    0(R12)(DX*4), SI
 	CMPQ    R14, $-1
 	JNE     LBB19_6
 	MOVQ    0(BX), R14
@@ -5165,7 +5167,7 @@ LBB19_6:
 	DECL    SI
 	CMPL    SI, $5
 	JA      LBB19_11
-	LONG    $0x3f3d8d48; WORD $0x0004; BYTE $0x00 // leaq         $1087(%rip), %rdi  /* LJTI19_0(%rip) */
+	LONG    $0x823d8d48; WORD $0x0004; BYTE $0x00 // leaq         $1154(%rip), %rdi  /* LJTI19_0(%rip) */
 	MOVLQSX 0(DI)(SI*4), SI
 	ADDQ    DI, SI
 	JMP     SI
@@ -5175,273 +5177,302 @@ LBB19_8:
 	CMPL    AX, $44
 	JE      LBB19_29
 	CMPL    AX, $93
-	JNE     LBB19_59
-	MOVL    CX, 0(R13)
-	MOVQ    R14, BX
+	JNE     LBB19_67
+	MOVL    CX, 0(R12)
+	MOVQ    R14, R13
 	TESTL   CX, CX
 	JNE     LBB19_4
-	JMP     LBB19_60
+	JMP     LBB19_68
 
 LBB19_11:
-	MOVL    CX, 0(R13)
+	MOVL    CX, 0(R12)
 	MOVBLSX AX, AX
 	CMPL    AX, $123
 	JBE     LBB19_27
-	JMP     LBB19_59
+	JMP     LBB19_67
 
 LBB19_12:
 	MOVBLSX AX, AX
 	CMPL    AX, $44
 	JE      LBB19_31
 	CMPL    AX, $125
-	JNE     LBB19_59
-	MOVL    CX, 0(R13)
-	MOVQ    R14, BX
+	JNE     LBB19_67
+	MOVL    CX, 0(R12)
+	MOVQ    R14, R13
 	TESTL   CX, CX
 	JNE     LBB19_4
-	JMP     LBB19_60
+	JMP     LBB19_68
 
 LBB19_15:
 	CMPB AX, $34
-	JNE  LBB19_59
-	MOVL $4, 0(R13)(DX*4)
-	MOVQ R15, DI
-	MOVQ BX, R15
-	MOVQ 0(BX), R12
+	JNE  LBB19_67
+	MOVL $4, 0(R12)(DX*4)
+	MOVQ 0(BX), R15
+	MOVQ R13, DI
 
 LBB19_17:
-	MOVQ  R12, SI
-	LEAQ  -64(BP), DX
-	LONG  $0xfff414e8; BYTE $0xff // callq        _advance_string
-	MOVQ  AX, BX
+	MOVQ  R15, SI
+	LEAQ  -72(BP), DX
+	LONG  $0xfff412e8; BYTE $0xff // callq        _advance_string
+	MOVQ  AX, R13
 	TESTQ AX, AX
-	JS    LBB19_52
-	MOVQ  BX, 0(R15)
-	TESTQ R12, R12
-	MOVQ  -48(BP), R15
-	JG    LBB19_37
-	JMP   LBB19_53
+	JS    LBB19_59
+	MOVQ  R13, 0(BX)
+	TESTQ R15, R15
+	JG    LBB19_40
+	JMP   LBB19_60
 
 LBB19_19:
 	CMPB AX, $58
-	JNE  LBB19_59
-	MOVL $0, 0(R13)(DX*4)
-	JMP  LBB19_37
+	JNE  LBB19_67
+	MOVL $0, 0(R12)(DX*4)
+	JMP  LBB19_40
 
 LBB19_21:
 	CMPB  AX, $93
 	JNE   LBB19_26
-	MOVL  CX, 0(R13)
-	MOVQ  R14, BX
+	MOVL  CX, 0(R12)
+	MOVQ  R14, R13
 	TESTL CX, CX
 	JNE   LBB19_4
-	JMP   LBB19_60
+	JMP   LBB19_68
 
 LBB19_23:
 	MOVBLSX AX, AX
 	CMPL    AX, $34
 	JE      LBB19_33
 	CMPL    AX, $125
-	JNE     LBB19_59
-	MOVL    CX, 0(R13)
-	MOVQ    R14, BX
+	JNE     LBB19_67
+	MOVL    CX, 0(R12)
+	MOVQ    R14, R13
 	TESTL   CX, CX
 	JNE     LBB19_4
-	JMP     LBB19_60
+	JMP     LBB19_68
 
 LBB19_26:
-	MOVL    $1, 0(R13)(DX*4)
+	MOVL    $1, 0(R12)(DX*4)
 	MOVBLSX AX, AX
 	CMPL    AX, $123
-	JA      LBB19_59
+	JA      LBB19_67
 
 LBB19_27:
-	MOVQ    $-1, BX
-	LONG    $0x2a0d8d48; WORD $0x0003; BYTE $0x00 // leaq         $810(%rip), %rcx  /* LJTI19_1(%rip) */
+	MOVQ    $-1, R13
+	LONG    $0x770d8d48; WORD $0x0003; BYTE $0x00 // leaq         $887(%rip), %rcx  /* LJTI19_1(%rip) */
 	MOVLQSX 0(CX)(AX*4), AX
 	ADDQ    CX, AX
 	JMP     AX
 
 LBB19_28:
-	MOVQ  -56(BP), R15
-	MOVQ  0(R15), R12
-	LEAQ  -1(R12), BX
+	MOVQ  -56(BP), BX
+	MOVQ  0(BX), R15
+	LEAQ  -1(R15), R13
 	MOVQ  -48(BP), AX
 	MOVQ  0(AX), DI
-	ADDQ  BX, DI
-	MOVQ  -48(BP), AX
+	ADDQ  R13, DI
 	MOVQ  8(AX), SI
-	SUBQ  BX, SI
-	LONG  $0x00062ce8; BYTE $0x00 // callq        _skip_number
+	SUBQ  R13, SI
+	LONG  $0x000d43e8; BYTE $0x00 // callq        _skip_number
 	MOVQ  $-2, CX
 	SUBQ  AX, CX
 	TESTQ AX, AX
 	LEAQ  -1(AX), AX
 	LONG  $0xc1480f48             // cmovsq       %rcx, %rax
 	MOVQ  $-2, CX
-	LONG  $0xd9480f48             // cmovsq       %rcx, %rbx
-	ADDQ  R12, AX
-	MOVQ  AX, 0(R15)
-	MOVQ  -48(BP), R15
-	TESTQ BX, BX
-	JNS   LBB19_37
-	JMP   LBB19_60
+	LONG  $0xe9480f4c             // cmovsq       %rcx, %r13
+	ADDQ  R15, AX
+	MOVQ  AX, 0(BX)
+	TESTQ R13, R13
+	JNS   LBB19_40
+	JMP   LBB19_68
 
 LBB19_29:
 	CMPL DX, $65535
-	JG   LBB19_54
+	JG   LBB19_61
 	LEAL 1(DX), AX
-	MOVL AX, 0(R13)
-	MOVL $0, 4(R13)(DX*4)
-	JMP  LBB19_37
+	MOVL AX, 0(R12)
+	MOVL $0, 4(R12)(DX*4)
+	JMP  LBB19_40
 
 LBB19_31:
 	CMPL DX, $65535
-	JG   LBB19_54
+	JG   LBB19_61
 	LEAL 1(DX), AX
-	MOVL AX, 0(R13)
-	MOVL $3, 4(R13)(DX*4)
-	JMP  LBB19_37
+	MOVL AX, 0(R12)
+	MOVL $3, 4(R12)(DX*4)
+	JMP  LBB19_40
 
 LBB19_33:
-	MOVL    $2, 0(R13)(DX*4)
-	MOVQ    R15, DI
-	MOVQ    BX, R15
-	MOVQ    0(BX), R12
-	MOVQ    R12, SI
-	LEAQ    -64(BP), DX
-	LONG    $0xfff2b2e8; BYTE $0xff // callq        _advance_string
-	MOVQ    AX, BX
-	TESTQ   AX, AX
-	JS      LBB19_52
-	MOVQ    BX, 0(R15)
-	TESTQ   R12, R12
-	JLE     LBB19_53
-	MOVLQSX 0(R13), AX
-	CMPQ    AX, $65535
-	JG      LBB19_54
-	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $4, 4(R13)(AX*4)
-	MOVQ    -48(BP), R15
-	JMP     LBB19_37
+	MOVL  $2, 0(R12)(DX*4)
+	MOVL  -60(BP), AX
+	CMPL  AX, $1
+	JE    LBB19_37
+	TESTL AX, AX
+	JNE   LBB19_38
+	MOVQ  -56(BP), BX
+	MOVQ  0(BX), R15
+	MOVQ  -48(BP), DI
+	MOVQ  R15, SI
+	LEAQ  -72(BP), DX
+	LONG  $0xfff2b2e8; BYTE $0xff // callq        _advance_string
+	MOVQ  AX, R13
+	TESTQ AX, AX
+	JS    LBB19_59
+	MOVQ  R13, 0(BX)
+	TESTQ R15, R15
+	JG    LBB19_38
+	JMP   LBB19_60
+
+LBB19_37:
+	MOVQ  R13, DI
+	MOVQ  BX, SI
+	LONG  $0x000533e8; BYTE $0x00 // callq        _validate_string
+	TESTQ AX, AX
+	JS    LBB19_65
 
 LBB19_38:
-	MOVQ R15, DI
-	MOVQ -56(BP), R15
-	MOVQ 0(R15), R12
-	JMP  LBB19_17
-
-LBB19_39:
-	MOVQ  -56(BP), R12
-	MOVQ  0(R12), BX
-	MOVQ  0(R15), DI
-	ADDQ  BX, DI
-	MOVQ  8(R15), SI
-	SUBQ  BX, SI
-	LONG  $0x00052ae8; BYTE $0x00 // callq        _skip_number
-	TESTQ AX, AX
-	JS    LBB19_58
-	ADDQ  BX, AX
-	MOVQ  AX, 0(R12)
-	TESTQ BX, BX
-	JG    LBB19_37
-	JMP   LBB19_61
+	MOVLQSX 0(R12), AX
+	CMPQ    AX, $65535
+	JG      LBB19_61
+	LEAL    1(AX), CX
+	MOVL    CX, 0(R12)
+	MOVL    $4, 4(R12)(AX*4)
+	JMP     LBB19_40
 
 LBB19_41:
-	MOVLQSX 0(R13), AX
-	CMPQ    AX, $65535
-	JG      LBB19_54
-	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $5, 4(R13)(AX*4)
-	JMP     LBB19_37
+	MOVL  -60(BP), AX
+	CMPL  AX, $1
+	JE    LBB19_57
+	TESTL AX, AX
+	JNE   LBB19_40
+	MOVQ  -56(BP), BX
+	MOVQ  0(BX), R15
+	MOVQ  -48(BP), DI
+	JMP   LBB19_17
 
-LBB19_43:
-	MOVQ  -56(BP), SI
-	MOVQ  0(SI), AX
-	MOVQ  8(R15), CX
-	LEAQ  -4(CX), DX
-	CMPQ  AX, DX
-	JA    LBB19_67
-	MOVQ  0(R15), CX
-	MOVL  0(CX)(AX*1), DX
-	CMPL  DX, $1702063201
-	JNE   LBB19_64
-	LEAQ  4(AX), CX
-	MOVQ  CX, 0(SI)
+LBB19_44:
+	MOVQ  -56(BP), BX
+	MOVQ  0(BX), R13
+	MOVQ  -48(BP), AX
+	MOVQ  0(AX), DI
+	ADDQ  R13, DI
+	MOVQ  8(AX), SI
+	SUBQ  R13, SI
+	LONG  $0x000c0fe8; BYTE $0x00 // callq        _skip_number
 	TESTQ AX, AX
-	JG    LBB19_37
-	JMP   LBB19_57
+	JS    LBB19_66
+	ADDQ  R13, AX
+	MOVQ  AX, 0(BX)
+	TESTQ R13, R13
+	JG    LBB19_40
+	JMP   LBB19_69
 
 LBB19_46:
-	MOVQ -56(BP), SI
-	MOVQ 0(SI), AX
-	MOVQ 8(R15), CX
-	LEAQ -3(CX), DX
-	CMPQ AX, DX
-	JA   LBB19_67
-	MOVQ 0(R15), CX
-	CMPL -1(CX)(AX*1), $1819047278
-	JE   LBB19_3
-	JMP  LBB19_73
+	MOVLQSX 0(R12), AX
+	CMPQ    AX, $65535
+	JG      LBB19_61
+	LEAL    1(AX), CX
+	MOVL    CX, 0(R12)
+	MOVL    $5, 4(R12)(AX*4)
+	JMP     LBB19_40
 
 LBB19_48:
-	MOVQ -56(BP), SI
-	MOVQ 0(SI), AX
-	MOVQ 8(R15), CX
+	MOVQ  -56(BP), BX
+	MOVQ  0(BX), AX
+	MOVQ  -48(BP), SI
+	MOVQ  8(SI), CX
+	LEAQ  -4(CX), DX
+	CMPQ  AX, DX
+	JA    LBB19_75
+	MOVQ  0(SI), CX
+	MOVL  0(CX)(AX*1), DX
+	CMPL  DX, $1702063201
+	JNE   LBB19_72
+	LEAQ  4(AX), CX
+	MOVQ  CX, 0(BX)
+	TESTQ AX, AX
+	JG    LBB19_40
+	JMP   LBB19_64
+
+LBB19_51:
+	MOVQ -56(BP), BX
+	MOVQ 0(BX), AX
+	MOVQ -48(BP), SI
+	MOVQ 8(SI), CX
 	LEAQ -3(CX), DX
 	CMPQ AX, DX
-	JA   LBB19_67
-	MOVQ 0(R15), CX
-	CMPL -1(CX)(AX*1), $1702195828
+	JA   LBB19_75
+	MOVQ 0(SI), CX
+	CMPL -1(CX)(AX*1), $1819047278
 	JE   LBB19_3
-	JMP  LBB19_69
-
-LBB19_50:
-	MOVLQSX 0(R13), AX
-	CMPQ    AX, $65535
-	JG      LBB19_54
-	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $6, 4(R13)(AX*4)
-	JMP     LBB19_37
-
-LBB19_54:
-	MOVQ $-7, BX
-	JMP  LBB19_60
-
-LBB19_52:
-	MOVQ -48(BP), AX
-	MOVQ 8(AX), AX
-	MOVQ AX, 0(R15)
-	JMP  LBB19_60
+	JMP  LBB19_76
 
 LBB19_53:
-	DECQ R12
-	MOVQ R12, BX
-	JMP  LBB19_60
+	MOVQ -56(BP), BX
+	MOVQ 0(BX), AX
+	MOVQ -48(BP), SI
+	MOVQ 8(SI), CX
+	LEAQ -3(CX), DX
+	CMPQ AX, DX
+	JA   LBB19_75
+	MOVQ 0(SI), CX
+	CMPL -1(CX)(AX*1), $1702195828
+	JE   LBB19_3
+	JMP  LBB19_80
 
-LBB19_67:
-	MOVQ CX, 0(SI)
-	JMP  LBB19_60
+LBB19_55:
+	MOVLQSX 0(R12), AX
+	CMPQ    AX, $65535
+	JG      LBB19_61
+	LEAL    1(AX), CX
+	MOVL    CX, 0(R12)
+	MOVL    $6, 4(R12)(AX*4)
+	JMP     LBB19_40
 
 LBB19_57:
-	DECQ AX
-	MOVQ AX, BX
-	JMP  LBB19_60
+	MOVQ  -48(BP), DI
+	MOVQ  -56(BP), SI
+	LONG  $0x0003b1e8; BYTE $0x00 // callq        _validate_string
+	TESTQ AX, AX
+	JNS   LBB19_40
+	JMP   LBB19_65
 
-LBB19_58:
-	NOTQ AX
-	ADDQ AX, BX
-	MOVQ BX, 0(R12)
+LBB19_61:
+	MOVQ $-7, R13
+	JMP  LBB19_68
 
 LBB19_59:
-	MOVQ $-2, BX
+	MOVQ -48(BP), AX
+	MOVQ 8(AX), AX
+	MOVQ AX, 0(BX)
+	JMP  LBB19_68
 
 LBB19_60:
-	MOVQ BX, AX
-	ADDQ $24, SP
+	DECQ R15
+	MOVQ R15, R13
+	JMP  LBB19_68
+
+LBB19_75:
+	MOVQ CX, 0(BX)
+	JMP  LBB19_68
+
+LBB19_64:
+	DECQ AX
+
+LBB19_65:
+	MOVQ AX, R13
+	JMP  LBB19_68
+
+LBB19_66:
+	NOTQ AX
+	ADDQ AX, R13
+	MOVQ R13, 0(BX)
+
+LBB19_67:
+	MOVQ $-2, R13
+
+LBB19_68:
+	MOVQ R13, AX
+	ADDQ $40, SP
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5c41 // popq         %r12
 	WORD $0x5d41 // popq         %r13
@@ -5450,62 +5481,62 @@ LBB19_60:
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LBB19_61:
-	DECQ BX
-	JMP  LBB19_60
+LBB19_69:
+	DECQ R13
+	JMP  LBB19_68
 
-LBB19_64:
-	MOVQ $-2, BX
+LBB19_72:
+	MOVQ $-2, R13
 	CMPB DX, $97
-	JNE  LBB19_60
+	JNE  LBB19_68
 	INCQ AX
 	MOVL $1702063201, DX
 
-LBB19_66:
+LBB19_74:
 	SHRL    $8, DX
-	MOVQ    AX, 0(SI)
-	MOVBLSX 0(CX)(AX*1), R8
+	MOVQ    AX, 0(BX)
+	MOVBLSX 0(CX)(AX*1), SI
 	MOVBLZX DX, DI
 	INCQ    AX
-	CMPL    DI, R8
-	JE      LBB19_66
-	JMP     LBB19_60
+	CMPL    DI, SI
+	JE      LBB19_74
+	JMP     LBB19_68
 
-LBB19_69:
+LBB19_76:
 	LEAQ -1(AX), DX
-	MOVQ DX, 0(SI)
-	MOVQ $-2, BX
-	CMPB -1(CX)(AX*1), $116
-	JNE  LBB19_60
-	MOVL $1702195828, DX
-
-LBB19_71:
-	SHRL    $8, DX
-	MOVQ    AX, 0(SI)
-	MOVBLSX 0(CX)(AX*1), R8
-	MOVBLZX DX, DI
-	INCQ    AX
-	CMPL    DI, R8
-	JE      LBB19_71
-	JMP     LBB19_60
-
-LBB19_73:
-	LEAQ -1(AX), DX
-	MOVQ DX, 0(SI)
-	MOVQ $-2, BX
+	MOVQ DX, 0(BX)
+	MOVQ $-2, R13
 	CMPB -1(CX)(AX*1), $110
-	JNE  LBB19_60
+	JNE  LBB19_68
 	MOVL $1819047278, DX
 
-LBB19_75:
+LBB19_78:
 	SHRL    $8, DX
-	MOVQ    AX, 0(SI)
-	MOVBLSX 0(CX)(AX*1), R8
+	MOVQ    AX, 0(BX)
+	MOVBLSX 0(CX)(AX*1), SI
 	MOVBLZX DX, DI
 	INCQ    AX
-	CMPL    DI, R8
-	JE      LBB19_75
-	JMP     LBB19_60
+	CMPL    DI, SI
+	JE      LBB19_78
+	JMP     LBB19_68
+
+LBB19_80:
+	LEAQ -1(AX), DX
+	MOVQ DX, 0(BX)
+	MOVQ $-2, R13
+	CMPB -1(CX)(AX*1), $116
+	JNE  LBB19_68
+	MOVL $1702195828, DX
+
+LBB19_82:
+	SHRL    $8, DX
+	MOVQ    AX, 0(BX)
+	MOVBLSX 0(CX)(AX*1), SI
+	MOVBLZX DX, DI
+	INCQ    AX
+	CMPL    DI, SI
+	JE      LBB19_82
+	JMP     LBB19_68
 
 // .set L19_0_set_8, LBB19_8-LJTI19_0
 // .set L19_0_set_12, LBB19_12-LJTI19_0
@@ -5514,148 +5545,148 @@ LBB19_75:
 // .set L19_0_set_21, LBB19_21-LJTI19_0
 // .set L19_0_set_23, LBB19_23-LJTI19_0
 LJTI19_0:
-	LONG $0xfffffbca // .long L19_0_set_8
-	LONG $0xfffffc04 // .long L19_0_set_12
-	LONG $0xfffffc2d // .long L19_0_set_15
-	LONG $0xfffffc74 // .long L19_0_set_19
-	LONG $0xfffffc8a // .long L19_0_set_21
-	LONG $0xfffffca2 // .long L19_0_set_23
+	LONG $0xfffffb87 // .long L19_0_set_8
+	LONG $0xfffffbc1 // .long L19_0_set_12
+	LONG $0xfffffbea // .long L19_0_set_15
+	LONG $0xfffffc29 // .long L19_0_set_19
+	LONG $0xfffffc3e // .long L19_0_set_21
+	LONG $0xfffffc56 // .long L19_0_set_23
 
-	// .set L19_1_set_60, LBB19_60-LJTI19_1
-	// .set L19_1_set_59, LBB19_59-LJTI19_1
-	// .set L19_1_set_38, LBB19_38-LJTI19_1
-	// .set L19_1_set_39, LBB19_39-LJTI19_1
-	// .set L19_1_set_28, LBB19_28-LJTI19_1
+	// .set L19_1_set_68, LBB19_68-LJTI19_1
+	// .set L19_1_set_67, LBB19_67-LJTI19_1
 	// .set L19_1_set_41, LBB19_41-LJTI19_1
-	// .set L19_1_set_43, LBB19_43-LJTI19_1
+	// .set L19_1_set_44, LBB19_44-LJTI19_1
+	// .set L19_1_set_28, LBB19_28-LJTI19_1
 	// .set L19_1_set_46, LBB19_46-LJTI19_1
 	// .set L19_1_set_48, LBB19_48-LJTI19_1
-	// .set L19_1_set_50, LBB19_50-LJTI19_1
+	// .set L19_1_set_51, LBB19_51-LJTI19_1
+	// .set L19_1_set_53, LBB19_53-LJTI19_1
+	// .set L19_1_set_55, LBB19_55-LJTI19_1
 LJTI19_1:
-	LONG $0xffffff3a // .long L19_1_set_60
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffdde // .long L19_1_set_38
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffded // .long L19_1_set_39
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xfffffcdf // .long L19_1_set_28
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffe25 // .long L19_1_set_41
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffe4a // .long L19_1_set_43
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffe89 // .long L19_1_set_46
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffeb3 // .long L19_1_set_48
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xffffff33 // .long L19_1_set_59
-	LONG $0xfffffedd // .long L19_1_set_50
+	LONG $0xffffff40 // .long L19_1_set_68
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffda6 // .long L19_1_set_41
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffdca // .long L19_1_set_44
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xfffffc92 // .long L19_1_set_28
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffe04 // .long L19_1_set_46
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffe29 // .long L19_1_set_48
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffe6c // .long L19_1_set_51
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffe9e // .long L19_1_set_53
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xffffff39 // .long L19_1_set_67
+	LONG $0xfffffecc // .long L19_1_set_55
 
 _skip_array:
 	BYTE $0x55               // pushq        %rbp
@@ -5666,6 +5697,7 @@ _skip_array:
 	MOVQ $21474836481, CX
 	MOVQ CX, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -5678,6 +5710,7 @@ _skip_object:
 	MOVQ $25769803777, CX
 	MOVQ CX, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -5693,7 +5726,7 @@ _skip_string:
 	MOVQ  0(SI), BX
 	LEAQ  -32(BP), DX
 	MOVQ  BX, SI
-	LONG  $0xffedfae8; BYTE $0xff // callq        _advance_string
+	LONG  $0xffedade8; BYTE $0xff // callq        _advance_string
 	TESTQ AX, AX
 	JS    LBB22_2
 	DECQ  BX
@@ -5713,6 +5746,549 @@ LBB22_3:
 	BYTE $0x5d      // popq         %rbp
 	RET
 
+LCPI23_0:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI23_1:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+LCPI23_2:
+	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
+
+_validate_string:
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	WORD $0x5741             // pushq        %r15
+	WORD $0x5641             // pushq        %r14
+	WORD $0x5541             // pushq        %r13
+	WORD $0x5441             // pushq        %r12
+	BYTE $0x53               // pushq        %rbx
+	SUBQ $40, SP
+	MOVQ SI, -80(BP)
+	MOVQ 0(SI), R15
+	MOVQ 8(DI), DX
+	MOVQ DX, -72(BP)
+	SUBQ R15, DX
+	JE   LBB23_47
+	MOVQ 0(DI), AX
+	MOVQ AX, -48(BP)
+	LEAQ 0(AX)(R15*1), R12
+	CMPQ DX, $64
+	MOVQ R12, -56(BP)
+	JB   LBB23_2
+	MOVL DX, AX
+	ANDL $63, AX
+	MOVQ AX, -64(BP)
+	MOVQ $-1, R13
+	XORL R9, R9
+	QUAD $0xffffff73056f7ac5 // vmovdqu      $-141(%rip), %xmm8  /* LCPI23_0(%rip) */
+	QUAD $0xffffff7b0d6ffac5 // vmovdqu      $-133(%rip), %xmm1  /* LCPI23_1(%rip) */
+	QUAD $0xffffff83156ffac5 // vmovdqu      $-125(%rip), %xmm2  /* LCPI23_2(%rip) */
+	LONG $0xdb76e1c5         // vpcmpeqd     %xmm3, %xmm3, %xmm3
+	MOVQ DX, AX
+
+LBB23_4:
+	LONG  $0x6f7ac1c4; WORD $0x243c             // vmovdqu      (%r12), %xmm7
+	LONG  $0x6f7ac1c4; WORD $0x2474; BYTE $0x10 // vmovdqu      $16(%r12), %xmm6
+	LONG  $0x6f7ac1c4; WORD $0x246c; BYTE $0x20 // vmovdqu      $32(%r12), %xmm5
+	LONG  $0x6f7ac1c4; WORD $0x2464; BYTE $0x30 // vmovdqu      $48(%r12), %xmm4
+	LONG  $0xc774b9c5                           // vpcmpeqb     %xmm7, %xmm8, %xmm0
+	LONG  $0xc8d7f9c5                           // vpmovmskb    %xmm0, %ecx
+	LONG  $0xc674b9c5                           // vpcmpeqb     %xmm6, %xmm8, %xmm0
+	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
+	LONG  $0xc574b9c5                           // vpcmpeqb     %xmm5, %xmm8, %xmm0
+	LONG  $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
+	LONG  $0xc474b9c5                           // vpcmpeqb     %xmm4, %xmm8, %xmm0
+	LONG  $0xc0d779c5                           // vpmovmskb    %xmm0, %r8d
+	LONG  $0xc174c1c5                           // vpcmpeqb     %xmm1, %xmm7, %xmm0
+	LONG  $0xd8d779c5                           // vpmovmskb    %xmm0, %r11d
+	LONG  $0xc174c9c5                           // vpcmpeqb     %xmm1, %xmm6, %xmm0
+	LONG  $0xf0d7f9c5                           // vpmovmskb    %xmm0, %esi
+	LONG  $0xc174d1c5                           // vpcmpeqb     %xmm1, %xmm5, %xmm0
+	SHLQ  $16, BX
+	ORQ   BX, CX
+	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
+	LONG  $0xc174d9c5                           // vpcmpeqb     %xmm1, %xmm4, %xmm0
+	SHLQ  $32, DI
+	ORQ   DI, CX
+	LONG  $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
+	LONG  $0xc764e9c5                           // vpcmpgtb     %xmm7, %xmm2, %xmm0
+	LONG  $0xfb64c1c5                           // vpcmpgtb     %xmm3, %xmm7, %xmm7
+	LONG  $0xc0dbc1c5                           // vpand        %xmm0, %xmm7, %xmm0
+	SHLQ  $16, SI
+	ORQ   SI, R11
+	LONG  $0xd0d779c5                           // vpmovmskb    %xmm0, %r10d
+	LONG  $0xc664e9c5                           // vpcmpgtb     %xmm6, %xmm2, %xmm0
+	LONG  $0xf364c9c5                           // vpcmpgtb     %xmm3, %xmm6, %xmm6
+	LONG  $0xc0dbc9c5                           // vpand        %xmm0, %xmm6, %xmm0
+	SHLQ  $32, BX
+	ORQ   BX, R11
+	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
+	LONG  $0xc564e9c5                           // vpcmpgtb     %xmm5, %xmm2, %xmm0
+	LONG  $0xeb64d1c5                           // vpcmpgtb     %xmm3, %xmm5, %xmm5
+	LONG  $0xc0dbd1c5                           // vpand        %xmm0, %xmm5, %xmm0
+	SHLQ  $48, DI
+	ORQ   DI, R11
+	LONG  $0xf0d7f9c5                           // vpmovmskb    %xmm0, %esi
+	LONG  $0xc464e9c5                           // vpcmpgtb     %xmm4, %xmm2, %xmm0
+	LONG  $0xe364d9c5                           // vpcmpgtb     %xmm3, %xmm4, %xmm4
+	LONG  $0xc0dbd9c5                           // vpand        %xmm0, %xmm4, %xmm0
+	SHLQ  $16, BX
+	ORQ   BX, R10
+	LONG  $0xf0d779c5                           // vpmovmskb    %xmm0, %r14d
+	SHLQ  $48, R8
+	SHLQ  $32, SI
+	CMPQ  R13, $-1
+	JNE   LBB23_7
+	TESTQ R11, R11
+	JNE   LBB23_6
+
+LBB23_7:
+	SHLQ  $48, R14
+	ORQ   SI, R10
+	ORQ   R8, CX
+	MOVQ  R11, SI
+	ORQ   R9, SI
+	JNE   LBB23_8
+	ORQ   R14, R10
+	TESTQ CX, CX
+	JNE   LBB23_10
+
+LBB23_14:
+	TESTQ R10, R10
+	JNE   LBB23_15
+	ADDQ  $64, R12
+	ADDQ  $-64, AX
+	CMPQ  AX, $63
+	JA    LBB23_4
+	JMP   LBB23_18
+
+LBB23_8:
+	MOVQ  R9, SI
+	NOTQ  SI
+	ANDQ  R11, SI
+	LEAQ  0(SI)(SI*1), R8
+	ORQ   R9, R8
+	MOVQ  R8, DI
+	NOTQ  DI
+	ANDQ  R11, DI
+	MOVQ  $-6148914691236517206, BX
+	ANDQ  BX, DI
+	XORL  R9, R9
+	ADDQ  SI, DI
+	SETCS R9
+	ADDQ  DI, DI
+	MOVQ  $6148914691236517205, SI
+	XORQ  SI, DI
+	ANDQ  R8, DI
+	NOTQ  DI
+	ANDQ  DI, CX
+	ORQ   R14, R10
+	TESTQ CX, CX
+	JE    LBB23_14
+	JMP   LBB23_10
+
+LBB23_6:
+	MOVQ R12, DI
+	SUBQ -48(BP), DI
+	BSFQ R11, R13
+	ADDQ DI, R13
+	JMP  LBB23_7
+
+LBB23_10:
+	SUBQ  -48(BP), R12
+	BSFQ  CX, CX
+	LEAQ  1(R12)(CX*1), BX
+	TESTQ R10, R10
+	JE    LBB23_45
+	BSFQ  R10, AX
+	CMPQ  AX, CX
+	JBE   LBB23_13
+
+LBB23_45:
+	MOVQ  -56(BP), DI
+	TESTQ BX, BX
+	JS    LBB23_46
+	MOVQ  R15, SI
+	NOTQ  SI
+	ADDQ  BX, SI
+	LONG  $0x0002afe8; BYTE $0x00 // callq        _utf8_validate
+	LEAQ  0(AX)(R15*1), R13
+	TESTQ AX, AX
+	LONG  $0xeb480f4c             // cmovsq       %rbx, %r13
+	LEAQ  -1(R15), BX
+	MOVQ  $-2, AX
+	LONG  $0xd8490f48             // cmovnsq      %rax, %rbx
+	JMP   LBB23_53
+
+LBB23_46:
+	CMPQ BX, $-1
+	JNE  LBB23_53
+
+LBB23_47:
+	MOVQ $-1, BX
+	MOVQ -72(BP), R13
+
+LBB23_53:
+	MOVQ -80(BP), AX
+	MOVQ R13, 0(AX)
+	MOVQ BX, AX
+	ADDQ $40, SP
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	RET
+
+LBB23_15:
+	MOVQ $-2, BX
+	CMPQ R13, $-1
+	JNE  LBB23_53
+	SUBQ -48(BP), R12
+	BSFQ R10, R13
+	ADDQ R12, R13
+	JMP  LBB23_53
+
+LBB23_18:
+	MOVQ -64(BP), DI
+	CMPQ DI, $32
+	JB   LBB23_32
+
+LBB23_20:
+	LONG  $0x6f7ac1c4; WORD $0x2404             // vmovdqu      (%r12), %xmm0
+	LONG  $0x6f7ac1c4; WORD $0x244c; BYTE $0x10 // vmovdqu      $16(%r12), %xmm1
+	QUAD  $0xfffffd23156ffac5                   // vmovdqu      $-733(%rip), %xmm2  /* LCPI23_0(%rip) */
+	LONG  $0xda74f9c5                           // vpcmpeqb     %xmm2, %xmm0, %xmm3
+	LONG  $0xdbd779c5                           // vpmovmskb    %xmm3, %r11d
+	LONG  $0xd274f1c5                           // vpcmpeqb     %xmm2, %xmm1, %xmm2
+	LONG  $0xcad7f9c5                           // vpmovmskb    %xmm2, %ecx
+	QUAD  $0xfffffd1b156ffac5                   // vmovdqu      $-741(%rip), %xmm2  /* LCPI23_1(%rip) */
+	LONG  $0xda74f9c5                           // vpcmpeqb     %xmm2, %xmm0, %xmm3
+	LONG  $0xc3d7f9c5                           // vpmovmskb    %xmm3, %eax
+	LONG  $0xd274f1c5                           // vpcmpeqb     %xmm2, %xmm1, %xmm2
+	LONG  $0xf2d7f9c5                           // vpmovmskb    %xmm2, %esi
+	QUAD  $0xfffffd13156ffac5                   // vmovdqu      $-749(%rip), %xmm2  /* LCPI23_2(%rip) */
+	LONG  $0xd864e9c5                           // vpcmpgtb     %xmm0, %xmm2, %xmm3
+	LONG  $0xe476d9c5                           // vpcmpeqd     %xmm4, %xmm4, %xmm4
+	LONG  $0xc464f9c5                           // vpcmpgtb     %xmm4, %xmm0, %xmm0
+	LONG  $0xc3dbf9c5                           // vpand        %xmm3, %xmm0, %xmm0
+	LONG  $0xd0d779c5                           // vpmovmskb    %xmm0, %r10d
+	LONG  $0xc164e9c5                           // vpcmpgtb     %xmm1, %xmm2, %xmm0
+	LONG  $0xcc64f1c5                           // vpcmpgtb     %xmm4, %xmm1, %xmm1
+	LONG  $0xc0dbf1c5                           // vpand        %xmm0, %xmm1, %xmm0
+	LONG  $0xc0d779c5                           // vpmovmskb    %xmm0, %r8d
+	SHLQ  $16, CX
+	SHLQ  $16, SI
+	ORQ   SI, AX
+	CMPQ  R13, $-1
+	JNE   LBB23_23
+	TESTQ AX, AX
+	JNE   LBB23_22
+
+LBB23_23:
+	SHLQ  $16, R8
+	ORQ   R11, CX
+	MOVQ  AX, SI
+	ORQ   R9, SI
+	JNE   LBB23_24
+	ORQ   R10, R8
+	TESTQ CX, CX
+	JE    LBB23_28
+
+LBB23_26:
+	SUBQ  -48(BP), R12
+	BSFQ  CX, CX
+	LEAQ  1(R12)(CX*1), BX
+	TESTQ R8, R8
+	JE    LBB23_45
+	BSFQ  R8, AX
+	CMPQ  AX, CX
+	JA    LBB23_45
+
+LBB23_13:
+	ADDQ R12, AX
+	CMPQ R13, $-1
+	LONG $0xe8440f4c // cmoveq       %rax, %r13
+	MOVQ $-2, BX
+	JMP  LBB23_53
+
+LBB23_2:
+	MOVQ $-1, R13
+	XORL R9, R9
+	MOVQ DX, DI
+	CMPQ DI, $32
+	JAE  LBB23_20
+	JMP  LBB23_32
+
+LBB23_24:
+	MOVL  R9, SI
+	NOTL  SI
+	ANDL  AX, SI
+	LEAL  0(SI)(SI*1), R11
+	ORL   R9, R11
+	MOVL  R11, BX
+	NOTL  BX
+	ANDL  AX, BX
+	ANDL  $-1431655766, BX
+	XORL  R9, R9
+	ADDL  SI, BX
+	SETCS R9
+	ADDL  BX, BX
+	XORL  $1431655765, BX
+	ANDL  R11, BX
+	NOTL  BX
+	ANDL  BX, CX
+	ORQ   R10, R8
+	TESTQ CX, CX
+	JNE   LBB23_26
+
+LBB23_28:
+	TESTQ R8, R8
+	JNE   LBB23_29
+	ADDQ  $32, R12
+	ADDQ  $-32, DI
+
+LBB23_32:
+	TESTQ R9, R9
+	JNE   LBB23_33
+	TESTQ DI, DI
+	JE    LBB23_44
+
+LBB23_36:
+	MOVQ -48(BP), AX
+	NOTQ AX
+
+LBB23_37:
+	LEAQ    1(R12), SI
+	MOVBLZX 0(R12), CX
+	CMPB    CX, $34
+	JE      LBB23_38
+	LEAQ    -1(DI), BX
+	CMPB    CX, $92
+	JE      LBB23_40
+	CMPB    CX, $31
+	JBE     LBB23_50
+	MOVQ    SI, R12
+	MOVQ    BX, DI
+	TESTQ   BX, BX
+	JNE     LBB23_37
+	JMP     LBB23_43
+
+LBB23_40:
+	TESTQ BX, BX
+	JE    LBB23_47
+	ADDQ  AX, SI
+	CMPQ  R13, $-1
+	LONG  $0xee440f4c // cmoveq       %rsi, %r13
+	ADDQ  $2, R12
+	ADDQ  $-2, DI
+	MOVQ  DI, BX
+	TESTQ BX, BX
+	JNE   LBB23_37
+
+LBB23_43:
+	CMPB CX, $34
+	JNE  LBB23_47
+	JMP  LBB23_44
+
+LBB23_38:
+	MOVQ SI, R12
+
+LBB23_44:
+	SUBQ -48(BP), R12
+	MOVQ R12, BX
+	JMP  LBB23_45
+
+LBB23_22:
+	MOVQ R12, SI
+	SUBQ -48(BP), SI
+	BSFQ AX, R13
+	ADDQ SI, R13
+	JMP  LBB23_23
+
+LBB23_29:
+	MOVQ $-2, BX
+	CMPQ R13, $-1
+	JNE  LBB23_53
+	SUBQ -48(BP), R12
+	BSFQ R8, R13
+	ADDQ R12, R13
+	JMP  LBB23_53
+
+LBB23_33:
+	TESTQ DI, DI
+	JE    LBB23_47
+	MOVQ  DI, CX
+	MOVQ  -48(BP), AX
+	NOTQ  AX
+	ADDQ  R12, AX
+	CMPQ  R13, $-1
+	LONG  $0xe8440f4c // cmoveq       %rax, %r13
+	INCQ  R12
+	DECQ  DI
+	TESTQ DI, DI
+	JNE   LBB23_36
+	JMP   LBB23_44
+
+LBB23_50:
+	MOVQ $-2, BX
+	CMPQ R13, $-1
+	JNE  LBB23_53
+	ADDQ AX, SI
+	MOVQ SI, R13
+	JMP  LBB23_53
+
+_utf8_validate:
+	BYTE  $0x55               // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	WORD  $0x5641             // pushq        %r14
+	BYTE  $0x53               // pushq        %rbx
+	MOVQ  $-1, AX
+	TESTQ SI, SI
+	JLE   LBB24_30
+	MOVQ  DI, R10
+
+LBB24_2:
+	CMPB 0(R10), $0
+	JS   LBB24_3
+	MOVQ SI, BX
+	MOVQ R10, CX
+	MOVQ DX, R8
+	CMPQ DX, $16
+	JL   LBB24_5
+
+LBB24_8:
+	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
+	LONG  $0xc8d779c5 // vpmovmskb    %xmm0, %r9d
+	TESTW R9, R9
+	JNE   LBB24_9
+	ADDQ  $16, CX
+	CMPQ  BX, $17
+	LEAQ  -16(BX), BX
+	JL    LBB24_4
+	CMPQ  R8, $31
+	LEAQ  -16(R8), R8
+	JG    LBB24_8
+	JMP   LBB24_4
+
+LBB24_3:
+	XORL R8, R8
+	JMP  LBB24_13
+
+LBB24_9:
+	MOVWLZX R9, BX
+	SUBQ    R10, CX
+	BSFQ    BX, R8
+	ADDQ    CX, R8
+	JMP     LBB24_13
+
+LBB24_4:
+	TESTQ BX, BX
+	JE    LBB24_30
+
+LBB24_5:
+	CMPB 0(CX), $0
+	JS   LBB24_12
+	DECQ BX
+	INCQ CX
+	JMP  LBB24_4
+
+LBB24_12:
+	SUBQ R10, CX
+	MOVQ CX, R8
+
+LBB24_13:
+	CMPQ    R8, $-1
+	JE      LBB24_30
+	SUBQ    R8, SI
+	JLE     LBB24_30
+	LEAQ    0(R10)(R8*1), R9
+	CMPQ    SI, $2
+	JB      LBB24_29
+	MOVBLZX 1(R10)(R8*1), R11
+	MOVL    R11, CX
+	ANDL    $-64, CX
+	CMPL    CX, $128
+	JNE     LBB24_29
+	MOVBLZX 0(R9), R14
+	MOVL    R14, CX
+	ANDL    $-32, CX
+	CMPL    CX, $192
+	JE      LBB24_18
+	CMPQ    SI, $3
+	JB      LBB24_29
+	MOVBLZX 2(R10)(R8*1), CX
+	MOVL    CX, BX
+	ANDL    $-64, BX
+	CMPL    BX, $128
+	JNE     LBB24_29
+	CMPB    R14, $-17
+	JA      LBB24_25
+	SHLL    $12, R14
+	MOVWLZX R14, R10
+	ANDL    $63, R11
+	SHLL    $6, R11
+	ANDL    $63, CX
+	ORL     R11, CX
+	LEAL    0(CX)(R10*1), BX
+	MOVL    $3, R11
+	CMPL    BX, $57343
+	JA      LBB24_24
+	LEAL    -2048(R10)(CX*1), CX
+	CMPL    CX, $53248
+	JAE     LBB24_29
+
+LBB24_24:
+	SUBQ R8, DX
+	SUBQ R11, DX
+	ADDQ R11, R9
+	MOVQ R9, R10
+	SUBQ R11, SI
+	JG   LBB24_2
+	JMP  LBB24_30
+
+LBB24_18:
+	MOVL  $2, R11
+	TESTB $30, R14
+	JNE   LBB24_24
+	JMP   LBB24_29
+
+LBB24_25:
+	CMPQ    SI, $4
+	JB      LBB24_29
+	MOVBLZX 3(R10)(R8*1), R10
+	MOVL    R10, BX
+	ANDL    $-64, BX
+	CMPL    BX, $128
+	JNE     LBB24_29
+	CMPB    R14, $-9
+	JA      LBB24_29
+	ANDL    $7, R14
+	SHLL    $18, R14
+	ANDL    $63, R11
+	SHLL    $12, R11
+	ANDL    $63, CX
+	SHLL    $6, CX
+	ORL     R11, CX
+	ANDL    $63, R10
+	ORL     CX, R10
+	LEAL    -65536(R14)(R10*1), CX
+	MOVL    $4, R11
+	CMPL    CX, $1048576
+	JB      LBB24_24
+
+LBB24_29:
+	SUBQ DI, R9
+	MOVQ R9, AX
+
+LBB24_30:
+	BYTE $0x5b   // popq         %rbx
+	WORD $0x5e41 // popq         %r14
+	BYTE $0x5d   // popq         %rbp
+	RET
+
 _skip_negative:
 	BYTE  $0x55                   // pushq        %rbp
 	WORD  $0x8948; BYTE $0xe5     // movq         %rsp, %rbp
@@ -5727,44 +6303,44 @@ _skip_negative:
 	MOVQ  AX, DI
 	LONG  $0x000098e8; BYTE $0x00 // callq        _skip_number
 	TESTQ AX, AX
-	JS    LBB23_1
+	JS    LBB25_1
 	ADDQ  BX, AX
 	MOVQ  AX, 0(R14)
 	DECQ  BX
-	JMP   LBB23_3
+	JMP   LBB25_3
 
-LBB23_1:
+LBB25_1:
 	NOTQ AX
 	ADDQ AX, BX
 	MOVQ BX, 0(R14)
 	MOVQ $-2, BX
 
-LBB23_3:
+LBB25_3:
 	MOVQ BX, AX
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LCPI24_0:
+LCPI26_0:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI24_1:
+LCPI26_1:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI24_2:
+LCPI26_2:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI24_3:
+LCPI26_3:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI24_4:
+LCPI26_4:
 	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
 
-LCPI24_5:
+LCPI26_5:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI24_6:
+LCPI26_6:
 	QUAD $0x6565656565656565; QUAD $0x6565656565656565 // .space 16, 'eeeeeeeeeeeeeeee'
 
 _skip_number:
@@ -5776,43 +6352,43 @@ _skip_number:
 	WORD    $0x5441                // pushq        %r12
 	BYTE    $0x53                  // pushq        %rbx
 	TESTQ   SI, SI
-	JE      LBB24_34
+	JE      LBB26_34
 	CMPB    0(DI), $48
-	JNE     LBB24_5
+	JNE     LBB26_5
 	MOVL    $1, DX
 	CMPQ    SI, $1
-	JE      LBB24_52
+	JE      LBB26_52
 	MOVB    1(DI), AX
 	ADDB    $-46, AX
 	CMPB    AX, $55
-	JA      LBB24_52
+	JA      LBB26_52
 	MOVBLZX AX, AX
 	MOVQ    $36028797027352577, CX
 	BTQ     AX, CX
-	JAE     LBB24_52
+	JAE     LBB26_52
 
-LBB24_5:
+LBB26_5:
 	CMPQ SI, $16
-	JB   LBB24_57
+	JB   LBB26_57
 	LEAQ -16(SI), R11
 	MOVQ R11, AX
 	ANDQ $-16, AX
 	LEAQ 16(AX)(DI*1), R10
 	ANDL $15, R11
 	MOVQ $-1, R9
-	QUAD $0xffffff15056f7ac5 // vmovdqu      $-235(%rip), %xmm8  /* LCPI24_0(%rip) */
-	QUAD $0xffffff1d0d6f7ac5 // vmovdqu      $-227(%rip), %xmm9  /* LCPI24_1(%rip) */
-	QUAD $0xffffff25156f7ac5 // vmovdqu      $-219(%rip), %xmm10  /* LCPI24_2(%rip) */
-	QUAD $0xffffff2d1d6f7ac5 // vmovdqu      $-211(%rip), %xmm11  /* LCPI24_3(%rip) */
-	QUAD $0xffffff35256ffac5 // vmovdqu      $-203(%rip), %xmm4  /* LCPI24_4(%rip) */
-	QUAD $0xffffff3d2d6ffac5 // vmovdqu      $-195(%rip), %xmm5  /* LCPI24_5(%rip) */
-	QUAD $0xffffff45356ffac5 // vmovdqu      $-187(%rip), %xmm6  /* LCPI24_6(%rip) */
+	QUAD $0xffffff15056f7ac5 // vmovdqu      $-235(%rip), %xmm8  /* LCPI26_0(%rip) */
+	QUAD $0xffffff1d0d6f7ac5 // vmovdqu      $-227(%rip), %xmm9  /* LCPI26_1(%rip) */
+	QUAD $0xffffff25156f7ac5 // vmovdqu      $-219(%rip), %xmm10  /* LCPI26_2(%rip) */
+	QUAD $0xffffff2d1d6f7ac5 // vmovdqu      $-211(%rip), %xmm11  /* LCPI26_3(%rip) */
+	QUAD $0xffffff35256ffac5 // vmovdqu      $-203(%rip), %xmm4  /* LCPI26_4(%rip) */
+	QUAD $0xffffff3d2d6ffac5 // vmovdqu      $-195(%rip), %xmm5  /* LCPI26_5(%rip) */
+	QUAD $0xffffff45356ffac5 // vmovdqu      $-187(%rip), %xmm6  /* LCPI26_6(%rip) */
 	MOVL $4294967295, R14
 	MOVQ $-1, AX
 	MOVQ $-1, R8
 	MOVQ DI, R15
 
-LBB24_7:
+LBB26_7:
 	LONG $0x6f7ac1c4; BYTE $0x3f // vmovdqu      (%r15), %xmm7
 	LONG $0x6441c1c4; BYTE $0xc0 // vpcmpgtb     %xmm8, %xmm7, %xmm0
 	LONG $0xcf64b1c5             // vpcmpgtb     %xmm7, %xmm9, %xmm1
@@ -5833,7 +6409,7 @@ LBB24_7:
 	XORQ R14, CX
 	BSFQ CX, CX
 	CMPL CX, $16
-	JE   LBB24_9
+	JE   LBB26_9
 	MOVL $-1, BX
 	SHLL CX, BX
 	NOTL BX
@@ -5842,180 +6418,180 @@ LBB24_7:
 	ANDL R12, BX
 	MOVL BX, R12
 
-LBB24_9:
+LBB26_9:
 	LEAL  -1(DX), BX
 	ANDL  DX, BX
-	JNE   LBB24_50
+	JNE   LBB26_50
 	LEAL  -1(R13), BX
 	ANDL  R13, BX
-	JNE   LBB24_50
+	JNE   LBB26_50
 	LEAL  -1(R12), BX
 	ANDL  R12, BX
-	JNE   LBB24_50
+	JNE   LBB26_50
 	TESTL DX, DX
-	JE    LBB24_15
+	JE    LBB26_15
 	MOVQ  R15, BX
 	SUBQ  DI, BX
 	BSFL  DX, DX
 	ADDQ  BX, DX
 	CMPQ  R8, $-1
-	JNE   LBB24_51
+	JNE   LBB26_51
 	MOVQ  DX, R8
 
-LBB24_15:
+LBB26_15:
 	TESTL R13, R13
-	JE    LBB24_18
+	JE    LBB26_18
 	MOVQ  R15, BX
 	SUBQ  DI, BX
 	BSFL  R13, DX
 	ADDQ  BX, DX
 	CMPQ  AX, $-1
-	JNE   LBB24_51
+	JNE   LBB26_51
 	MOVQ  DX, AX
 
-LBB24_18:
+LBB26_18:
 	TESTL R12, R12
-	JE    LBB24_21
+	JE    LBB26_21
 	MOVQ  R15, BX
 	SUBQ  DI, BX
 	BSFL  R12, DX
 	ADDQ  BX, DX
 	CMPQ  R9, $-1
-	JNE   LBB24_51
+	JNE   LBB26_51
 	MOVQ  DX, R9
 
-LBB24_21:
+LBB26_21:
 	CMPL  CX, $16
-	JNE   LBB24_35
+	JNE   LBB26_35
 	ADDQ  $16, R15
 	ADDQ  $-16, SI
 	CMPQ  SI, $15
-	JA    LBB24_7
+	JA    LBB26_7
 	TESTQ R11, R11
-	JE    LBB24_36
+	JE    LBB26_36
 
-LBB24_24:
+LBB26_24:
 	LEAQ 0(R10)(R11*1), CX
-	LONG $0x5b358d48; WORD $0x0001; BYTE $0x00 // leaq         $347(%rip), %rsi  /* LJTI24_0(%rip) */
-	JMP  LBB24_26
+	LONG $0x5b358d48; WORD $0x0001; BYTE $0x00 // leaq         $347(%rip), %rsi  /* LJTI26_0(%rip) */
+	JMP  LBB26_26
 
-LBB24_25:
+LBB26_25:
 	MOVQ BX, R10
 	DECQ R11
-	JE   LBB24_54
+	JE   LBB26_54
 
-LBB24_26:
+LBB26_26:
 	MOVBLSX 0(R10), DX
 	ADDL    $-43, DX
 	CMPL    DX, $58
-	JA      LBB24_36
+	JA      LBB26_36
 	LEAQ    1(R10), BX
 	MOVLQSX 0(SI)(DX*4), DX
 	ADDQ    SI, DX
 	JMP     DX
 
-LBB24_28:
+LBB26_28:
 	MOVQ BX, DX
 	SUBQ DI, DX
 	CMPQ R9, $-1
-	JNE  LBB24_58
+	JNE  LBB26_58
 	DECQ DX
 	MOVQ DX, R9
-	JMP  LBB24_25
+	JMP  LBB26_25
 
-LBB24_30:
+LBB26_30:
 	MOVQ BX, DX
 	SUBQ DI, DX
 	CMPQ AX, $-1
-	JNE  LBB24_58
+	JNE  LBB26_58
 	DECQ DX
 	MOVQ DX, AX
-	JMP  LBB24_25
+	JMP  LBB26_25
 
-LBB24_32:
+LBB26_32:
 	MOVQ BX, DX
 	SUBQ DI, DX
 	CMPQ R8, $-1
-	JNE  LBB24_58
+	JNE  LBB26_58
 	DECQ DX
 	MOVQ DX, R8
-	JMP  LBB24_25
+	JMP  LBB26_25
 
-LBB24_34:
+LBB26_34:
 	MOVQ $-1, AX
-	JMP  LBB24_53
+	JMP  LBB26_53
 
-LBB24_35:
+LBB26_35:
 	ADDQ CX, R15
 	MOVQ R15, R10
 
-LBB24_36:
+LBB26_36:
 	MOVQ  $-1, DX
 	TESTQ AX, AX
-	JE    LBB24_52
+	JE    LBB26_52
 
-LBB24_37:
+LBB26_37:
 	TESTQ R9, R9
-	JE    LBB24_52
+	JE    LBB26_52
 	TESTQ R8, R8
-	JE    LBB24_52
+	JE    LBB26_52
 	SUBQ  DI, R10
 	LEAQ  -1(R10), CX
 	CMPQ  AX, CX
-	JE    LBB24_45
+	JE    LBB26_45
 	CMPQ  R8, CX
-	JE    LBB24_45
+	JE    LBB26_45
 	CMPQ  R9, CX
-	JE    LBB24_45
+	JE    LBB26_45
 	TESTQ R9, R9
-	JLE   LBB24_46
+	JLE   LBB26_46
 	LEAQ  -1(R9), CX
 	CMPQ  AX, CX
-	JE    LBB24_46
+	JE    LBB26_46
 	NOTQ  R9
 	MOVQ  R9, DX
 	MOVQ  R9, AX
-	JMP   LBB24_53
+	JMP   LBB26_53
 
-LBB24_45:
+LBB26_45:
 	NEGQ R10
 	MOVQ R10, DX
 	MOVQ R10, AX
-	JMP  LBB24_53
+	JMP  LBB26_53
 
-LBB24_46:
+LBB26_46:
 	MOVQ  R8, CX
 	ORQ   AX, CX
 	CMPQ  R8, AX
-	JL    LBB24_49
+	JL    LBB26_49
 	TESTQ CX, CX
-	JS    LBB24_49
+	JS    LBB26_49
 	NOTQ  R8
 	MOVQ  R8, DX
 	MOVQ  R8, AX
-	JMP   LBB24_53
+	JMP   LBB26_53
 
-LBB24_49:
+LBB26_49:
 	TESTQ CX, CX
 	LEAQ  -1(AX), CX
 	NOTQ  AX
 	LONG  $0xc2480f49 // cmovsq       %r10, %rax
 	CMPQ  R8, CX
 	LONG  $0xc2450f49 // cmovneq      %r10, %rax
-	JMP   LBB24_53
+	JMP   LBB26_53
 
-LBB24_50:
+LBB26_50:
 	SUBQ DI, R15
 	BSFL BX, DX
 	ADDQ R15, DX
 
-LBB24_51:
+LBB26_51:
 	NOTQ DX
 
-LBB24_52:
+LBB26_52:
 	MOVQ DX, AX
 
-LBB24_53:
+LBB26_53:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5c41 // popq         %r12
 	WORD $0x5d41 // popq         %r13
@@ -6024,90 +6600,90 @@ LBB24_53:
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LBB24_54:
+LBB26_54:
 	MOVQ  CX, R10
 	MOVQ  $-1, DX
 	TESTQ AX, AX
-	JNE   LBB24_37
-	JMP   LBB24_52
+	JNE   LBB26_37
+	JMP   LBB26_52
 
-LBB24_58:
+LBB26_58:
 	NEGQ DX
-	JMP  LBB24_52
+	JMP  LBB26_52
 
-LBB24_57:
+LBB26_57:
 	MOVQ $-1, R8
 	MOVQ DI, R10
 	MOVQ SI, R11
 	MOVQ $-1, AX
 	MOVQ $-1, R9
-	JMP  LBB24_24
+	JMP  LBB26_24
 
-// .set L24_0_set_28, LBB24_28-LJTI24_0
-// .set L24_0_set_36, LBB24_36-LJTI24_0
-// .set L24_0_set_32, LBB24_32-LJTI24_0
-// .set L24_0_set_25, LBB24_25-LJTI24_0
-// .set L24_0_set_30, LBB24_30-LJTI24_0
-LJTI24_0:
-	LONG $0xfffffecc // .long L24_0_set_28
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xfffffecc // .long L24_0_set_28
-	LONG $0xfffffefc // .long L24_0_set_32
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xfffffea7 // .long L24_0_set_25
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xfffffee4 // .long L24_0_set_30
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xffffff26 // .long L24_0_set_36
-	LONG $0xfffffee4 // .long L24_0_set_30
+// .set L26_0_set_28, LBB26_28-LJTI26_0
+// .set L26_0_set_36, LBB26_36-LJTI26_0
+// .set L26_0_set_32, LBB26_32-LJTI26_0
+// .set L26_0_set_25, LBB26_25-LJTI26_0
+// .set L26_0_set_30, LBB26_30-LJTI26_0
+LJTI26_0:
+	LONG $0xfffffecc // .long L26_0_set_28
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xfffffecc // .long L26_0_set_28
+	LONG $0xfffffefc // .long L26_0_set_32
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xfffffea7 // .long L26_0_set_25
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xfffffee4 // .long L26_0_set_30
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xffffff26 // .long L26_0_set_36
+	LONG $0xfffffee4 // .long L26_0_set_30
 
 _skip_positive:
 	BYTE  $0x55                   // pushq        %rbp
@@ -6142,6 +6718,77 @@ _skip_positive:
 	BYTE  $0x5d                   // popq         %rbp
 	RET
 
+_validate_one:
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	MOVQ DX, AX
+	MOVQ SI, DX
+	MOVQ DI, SI
+	MOVQ $1, 0(AX)
+	MOVQ AX, DI
+	MOVL $1, CX
+	BYTE $0x5d               // popq         %rbp
+	JMP  _fsm_exec
+
+_find_non_ascii:
+	BYTE  $0x55               // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	CMPQ  DX, $16
+	JL    LBB29_1
+	TESTQ SI, SI
+	JLE   LBB29_1
+	MOVQ  DI, CX
+
+LBB29_8:
+	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
+	LONG  $0xc0d7f9c5 // vpmovmskb    %xmm0, %eax
+	TESTW AX, AX
+	JNE   LBB29_9
+	LEAQ  -16(SI), R8
+	ADDQ  $16, CX
+	CMPQ  DX, $32
+	JL    LBB29_2
+	ADDQ  $-16, DX
+	CMPQ  SI, $16
+	MOVQ  R8, SI
+	JG    LBB29_8
+	JMP   LBB29_2
+
+LBB29_1:
+	MOVQ SI, R8
+	MOVQ DI, CX
+
+LBB29_2:
+	MOVQ  $-1, AX
+	TESTQ R8, R8
+	JE    LBB29_13
+
+LBB29_4:
+	CMPB  0(CX), $0
+	JS    LBB29_12
+	DECQ  R8
+	INCQ  CX
+	TESTQ R8, R8
+	JNE   LBB29_4
+
+LBB29_13:
+	BYTE $0x5d // popq         %rbp
+	RET
+
+LBB29_12:
+	SUBQ DI, CX
+	MOVQ CX, AX
+	BYTE $0x5d  // popq         %rbp
+	RET
+
+LBB29_9:
+	MOVWLZX AX, AX
+	SUBQ    DI, CX
+	BSFQ    AX, AX
+	ADDQ    CX, AX
+	BYTE    $0x5d  // popq         %rbp
+	RET
+
 _print_mantissa:
 	BYTE    $0x55                                 // pushq        %rbp
 	WORD    $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
@@ -6151,7 +6798,7 @@ _print_mantissa:
 	ADDQ    SI, R14
 	MOVQ    DI, AX
 	SHRQ    $32, AX
-	JE      LBB26_2
+	JE      LBB30_2
 	MOVQ    $-6067343680855748867, DX
 	MOVQ    DI, AX
 	MULQ    DX
@@ -6195,13 +6842,13 @@ _print_mantissa:
 	ADDQ    $-8, R14
 	MOVQ    DX, DI
 
-LBB26_2:
+LBB30_2:
 	CMPL DI, $10000
-	JB   LBB26_3
+	JB   LBB30_3
 	MOVL $3518437209, R8
 	LONG $0xcc0d8d4c; WORD $0x0058; BYTE $0x00 // leaq         $22732(%rip), %r9  /* _Digits(%rip) */
 
-LBB26_5:
+LBB30_5:
 	MOVL    DI, AX
 	IMULQ   R8, AX
 	SHRQ    $45, AX
@@ -6218,11 +6865,11 @@ LBB26_5:
 	ADDQ    $-4, R14
 	CMPL    DI, $99999999
 	MOVL    AX, DI
-	JA      LBB26_5
+	JA      LBB30_5
 	CMPL    AX, $100
-	JB      LBB26_8
+	JB      LBB30_8
 
-LBB26_7:
+LBB30_7:
 	MOVWLZX AX, CX
 	SHRL    $2, CX
 	LONG    $0x147bc969; WORD $0x0000             // imull        $5243, %ecx, %ecx
@@ -6236,9 +6883,9 @@ LBB26_7:
 	ADDQ    $-2, R14
 	MOVL    CX, AX
 
-LBB26_8:
+LBB30_8:
 	CMPL    AX, $10
-	JB      LBB26_10
+	JB      LBB30_10
 	MOVL    AX, AX
 	LONG    $0x480d8d48; WORD $0x0058; BYTE $0x00 // leaq         $22600(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
@@ -6248,13 +6895,13 @@ LBB26_8:
 	BYTE    $0x5d                                 // popq         %rbp
 	RET
 
-LBB26_3:
+LBB30_3:
 	MOVL DI, AX
 	CMPL AX, $100
-	JAE  LBB26_7
-	JMP  LBB26_8
+	JAE  LBB30_7
+	JMP  LBB30_8
 
-LBB26_10:
+LBB30_10:
 	ADDB $48, AX
 	MOVB AX, 0(SI)
 	BYTE $0x5b     // popq         %rbx
@@ -6275,37 +6922,37 @@ _left_shift:
 	MOVLQSX 16(DI), R9
 	MOVB    4(DX)(SI*1), AX
 	TESTQ   R9, R9
-	JE      LBB27_6
+	JE      LBB31_6
 	LEAQ    5(DX)(SI*1), DX
 	XORL    SI, SI
 
-LBB27_3:
+LBB31_3:
 	TESTB   AX, AX
-	JE      LBB27_8
+	JE      LBB31_8
 	CMPB    0(R10)(SI*1), AX
-	JNE     LBB27_5
+	JNE     LBB31_5
 	MOVBLZX 0(DX)(SI*1), AX
 	INCQ    SI
 	CMPQ    R9, SI
-	JNE     LBB27_3
+	JNE     LBB31_3
 
-LBB27_6:
+LBB31_6:
 	TESTB AX, AX
-	JE    LBB27_8
+	JE    LBB31_8
 
-LBB27_7:
+LBB31_7:
 	DECL R8
 
-LBB27_8:
+LBB31_8:
 	TESTL   R9, R9
-	JLE     LBB27_23
+	JLE     LBB31_23
 	LEAL    0(R8)(R9*1), AX
 	MOVLQSX AX, R14
 	DECQ    R14
 	XORL    DX, DX
 	MOVQ    $-3689348814741910323, R11
 
-LBB27_10:
+LBB31_10:
 	MOVBQSX -1(R10)(R9*1), SI
 	ADDQ    $-48, SI
 	SHLQ    CX, SI
@@ -6318,83 +6965,83 @@ LBB27_10:
 	MOVQ    SI, AX
 	SUBQ    BX, AX
 	CMPQ    8(DI), R14
-	JBE     LBB27_16
+	JBE     LBB31_16
 	ADDB    $48, AX
 	MOVB    AX, 0(R10)(R14*1)
-	JMP     LBB27_18
+	JMP     LBB31_18
 
-LBB27_16:
+LBB31_16:
 	TESTQ AX, AX
-	JE    LBB27_18
+	JE    LBB31_18
 	MOVL  $1, 28(DI)
 
-LBB27_18:
+LBB31_18:
 	CMPQ R9, $2
-	JL   LBB27_12
+	JL   LBB31_12
 	DECQ R9
 	MOVQ 0(DI), R10
 	DECQ R14
-	JMP  LBB27_10
+	JMP  LBB31_10
 
-LBB27_12:
+LBB31_12:
 	CMPQ SI, $10
-	JAE  LBB27_13
+	JAE  LBB31_13
 
-LBB27_23:
+LBB31_23:
 	MOVLQSX 16(DI), CX
 	MOVLQSX R8, AX
 	ADDQ    CX, AX
 	MOVL    AX, 16(DI)
 	MOVQ    8(DI), CX
 	CMPQ    CX, AX
-	JA      LBB27_25
+	JA      LBB31_25
 	MOVL    CX, 16(DI)
 	MOVL    CX, AX
 
-LBB27_25:
+LBB31_25:
 	ADDL  R8, 20(DI)
 	TESTL AX, AX
-	JLE   LBB27_29
+	JLE   LBB31_29
 	MOVQ  0(DI), CX
 	MOVL  AX, AX
 
-LBB27_27:
+LBB31_27:
 	CMPB -1(CX)(AX*1), $48
-	JNE  LBB27_31
+	JNE  LBB31_31
 	MOVL AX, DX
 	DECQ AX
 	DECL DX
 	MOVL DX, 16(DI)
 	LEAQ 1(AX), DX
 	CMPQ DX, $1
-	JG   LBB27_27
+	JG   LBB31_27
 
-LBB27_29:
+LBB31_29:
 	TESTL AX, AX
-	JE    LBB27_30
+	JE    LBB31_30
 
-LBB27_31:
+LBB31_31:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LBB27_13:
+LBB31_13:
 	MOVLQSX R14, SI
 	DECQ    SI
-	JMP     LBB27_14
+	JMP     LBB31_14
 
-LBB27_15:
+LBB31_15:
 	ADDB $48, AX
 	MOVQ 0(DI), BX
 	MOVB AX, 0(BX)(SI*1)
 
-LBB27_22:
+LBB31_22:
 	DECQ SI
 	CMPQ CX, $9
-	JBE  LBB27_23
+	JBE  LBB31_23
 
-LBB27_14:
+LBB31_14:
 	MOVQ  DX, CX
 	MOVQ  DX, AX
 	MULQ  R11
@@ -6404,22 +7051,22 @@ LBB27_14:
 	MOVQ  CX, AX
 	SUBQ  BX, AX
 	CMPQ  8(DI), SI
-	JA    LBB27_15
+	JA    LBB31_15
 	TESTQ AX, AX
-	JE    LBB27_22
+	JE    LBB31_22
 	MOVL  $1, 28(DI)
-	JMP   LBB27_22
+	JMP   LBB31_22
 
-LBB27_30:
+LBB31_30:
 	MOVL $0, 20(DI)
 	BYTE $0x5b      // popq         %rbx
 	WORD $0x5e41    // popq         %r14
 	BYTE $0x5d      // popq         %rbp
 	RET
 
-LBB27_5:
-	JL  LBB27_7
-	JMP LBB27_8
+LBB31_5:
+	JL  LBB31_7
+	JMP LBB31_8
 
 _right_shift:
 	BYTE    $0x55               // pushq        %rbp
@@ -6429,9 +7076,9 @@ _right_shift:
 	XORL    SI, SI
 	XORL    AX, AX
 
-LBB28_1:
+LBB32_1:
 	CMPQ    SI, R9
-	JGE     LBB28_2
+	JGE     LBB32_2
 	LEAQ    0(AX)(AX*4), AX
 	MOVQ    0(DI), DX
 	MOVBQSX 0(DX)(SI*1), DX
@@ -6440,9 +7087,9 @@ LBB28_1:
 	MOVQ    AX, DX
 	SHRQ    CX, DX
 	TESTQ   DX, DX
-	JE      LBB28_1
+	JE      LBB32_1
 
-LBB28_6:
+LBB32_6:
 	MOVL    20(DI), DX
 	SUBL    SI, DX
 	INCL    DX
@@ -6452,12 +7099,12 @@ LBB28_6:
 	NOTQ    R8
 	XORL    R10, R10
 	CMPL    SI, R9
-	JGE     LBB28_9
+	JGE     LBB32_9
 	MOVLQSX SI, R9
 	MOVQ    0(DI), SI
 	XORL    R10, R10
 
-LBB28_8:
+LBB32_8:
 	MOVQ    AX, DX
 	SHRQ    CX, DX
 	ANDQ    R8, AX
@@ -6472,84 +7119,84 @@ LBB28_8:
 	LEAQ    1(R9)(R10*1), DX
 	INCQ    R10
 	CMPQ    DX, R11
-	JL      LBB28_8
-	JMP     LBB28_9
+	JL      LBB32_8
+	JMP     LBB32_9
 
-LBB28_11:
+LBB32_11:
 	ADDB $48, SI
 	MOVQ 0(DI), DX
 	MOVB SI, 0(DX)(R9*1)
 	INCL R9
 	MOVL R9, R10
 
-LBB28_14:
+LBB32_14:
 	ADDQ AX, AX
 	LEAQ 0(AX)(AX*4), AX
 
-LBB28_9:
+LBB32_9:
 	TESTQ   AX, AX
-	JE      LBB28_15
+	JE      LBB32_15
 	MOVQ    AX, SI
 	SHRQ    CX, SI
 	ANDQ    R8, AX
 	MOVLQSX R10, R9
 	CMPQ    8(DI), R9
-	JA      LBB28_11
+	JA      LBB32_11
 	TESTQ   SI, SI
-	JE      LBB28_14
+	JE      LBB32_14
 	MOVL    $1, 28(DI)
-	JMP     LBB28_14
+	JMP     LBB32_14
 
-LBB28_15:
+LBB32_15:
 	MOVL  R10, 16(DI)
 	TESTL R10, R10
-	JLE   LBB28_19
+	JLE   LBB32_19
 	MOVQ  0(DI), AX
 	MOVL  R10, R10
 
-LBB28_17:
+LBB32_17:
 	CMPB -1(AX)(R10*1), $48
-	JNE  LBB28_21
+	JNE  LBB32_21
 	MOVL R10, CX
 	DECQ R10
 	DECL CX
 	MOVL CX, 16(DI)
 	LEAQ 1(R10), CX
 	CMPQ CX, $1
-	JG   LBB28_17
+	JG   LBB32_17
 
-LBB28_19:
+LBB32_19:
 	TESTL R10, R10
-	JE    LBB28_20
+	JE    LBB32_20
 
-LBB28_21:
+LBB32_21:
 	BYTE $0x5d // popq         %rbp
 	RET
 
-LBB28_2:
+LBB32_2:
 	TESTQ AX, AX
-	JE    LBB28_22
+	JE    LBB32_22
 	MOVQ  AX, DX
 	SHRQ  CX, DX
 	TESTQ DX, DX
-	JNE   LBB28_6
+	JNE   LBB32_6
 
-LBB28_4:
+LBB32_4:
 	ADDQ  AX, AX
 	LEAQ  0(AX)(AX*4), AX
 	INCL  SI
 	MOVQ  AX, DX
 	SHRQ  CX, DX
 	TESTQ DX, DX
-	JE    LBB28_4
-	JMP   LBB28_6
+	JE    LBB32_4
+	JMP   LBB32_6
 
-LBB28_20:
+LBB32_20:
 	MOVL $0, 20(DI)
 	BYTE $0x5d      // popq         %rbp
 	RET
 
-LBB28_22:
+LBB32_22:
 	MOVL $0, 16(DI)
 	BYTE $0x5d      // popq         %rbp
 	RET
@@ -10836,7 +11483,7 @@ TEXT ·__skip_array(SB), NOSPLIT | NOFRAME, $0 - 32
 
 _entry:
 	MOVQ (TLS), R14
-	LEAQ -144(SP), R12
+	LEAQ -160(SP), R12
 	CMPQ R12, 16(R14)
 	JBE  _stack_grow
 
@@ -10844,7 +11491,7 @@ _skip_array:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+17223(SB) // _skip_array
+	CALL ·__native_entry__+17296(SB) // _skip_array
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -10857,7 +11504,7 @@ TEXT ·__skip_object(SB), NOSPLIT | NOFRAME, $0 - 32
 
 _entry:
 	MOVQ (TLS), R14
-	LEAQ -144(SP), R12
+	LEAQ -160(SP), R12
 	CMPQ R12, 16(R14)
 	JBE  _stack_grow
 
@@ -10865,7 +11512,7 @@ _skip_object:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+17258(SB) // _skip_object
+	CALL ·__native_entry__+17333(SB) // _skip_object
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -10878,7 +11525,7 @@ TEXT ·__skip_one(SB), NOSPLIT | NOFRAME, $0 - 32
 
 _entry:
 	MOVQ (TLS), R14
-	LEAQ -144(SP), R12
+	LEAQ -160(SP), R12
 	CMPQ R12, 16(R14)
 	JBE  _stack_grow
 
@@ -10931,6 +11578,27 @@ _unquote:
 	MOVQ flags+32(FP), R8
 	CALL ·__native_entry__+6005(SB) // _unquote
 	MOVQ AX, ret+40(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__validate_one(SB), NOSPLIT | NOFRAME, $0 - 32
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -160(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_validate_one:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	MOVQ m+16(FP), DX
+	CALL ·__native_entry__+20498(SB) // _validate_one
+	MOVQ AX, ret+24(FP)
 	RET
 
 _stack_grow:

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -291,7 +291,7 @@ LBB2_5:
 	LONG    $0x4fdc6941; WORD $0x1293; BYTE $0x00 // imull        $1217359, %r12d, %ebx
 	MOVQ    R12, AX
 	SHLQ    $4, AX
-	LONG    $0x3b0d8d48; WORD $0x007d; BYTE $0x00 // leaq         $32059(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
+	LONG    $0xd10d8d48; WORD $0x007c; BYTE $0x00 // leaq         $31953(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(AX)(CX*1), R10
@@ -378,7 +378,7 @@ LBB2_12:
 	SHRL    $19, BX
 	MOVLQSX AX, SI
 	SHLQ    $4, SI
-	LONG    $0x66158d4c; WORD $0x0091; BYTE $0x00 // leaq         $37222(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
+	LONG    $0xfc158d4c; WORD $0x0090; BYTE $0x00 // leaq         $37116(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(SI)(R10*1), R14
@@ -791,7 +791,7 @@ LBB2_61:
 	LEAQ 1(R13), BX
 	MOVQ BX, SI
 	MOVL R15, DX
-	LONG $0x0046d9e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x00466fe8; BYTE $0x00 // callq        _print_mantissa
 	MOVB 1(R13), AX
 	MOVB AX, 0(R13)
 	MOVL $1, AX
@@ -820,7 +820,7 @@ LBB2_66:
 	LEAL    0(CX)(CX*1), AX
 	LEAL    0(AX)(AX*4), AX
 	SUBL    AX, R14
-	LONG    $0x38058d48; WORD $0x00a0; BYTE $0x00 // leaq         $41016(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0xce058d48; WORD $0x009f; BYTE $0x00 // leaq         $40910(%rip), %rax  /* _Digits(%rip) */
 	MOVWLZX 0(AX)(CX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -856,7 +856,7 @@ LBB2_70:
 	CMPL    R14, $10
 	JL      LBB2_85
 	MOVLQSX R14, AX
-	LONG    $0xca0d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40906(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x600d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40800(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -875,7 +875,7 @@ LBB2_74:
 	MOVL  BX, SI
 	ADDQ  -64(BP), SI
 	MOVL  R15, DX
-	LONG  $0x0045d5e8; BYTE $0x00 // callq        _print_mantissa
+	LONG  $0x00456be8; BYTE $0x00 // callq        _print_mantissa
 	TESTL R13, R13
 	JE    LBB2_78
 	LEAL  0(R13)(BX*1), AX
@@ -1079,7 +1079,7 @@ LBB2_105:
 	MOVQ R13, SI
 	MOVL R15, DX
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x0042c3e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x004259e8; BYTE $0x00 // callq        _print_mantissa
 	ADDL BX, R15
 	MOVL R15, BX
 
@@ -1172,7 +1172,7 @@ _u64toa:
 	ADDQ    AX, AX
 	CMPL    SI, $1000
 	JB      LBB4_3
-	LONG    $0x8c0d8d48; WORD $0x009b; BYTE $0x00 // leaq         $39820(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x220d8d48; WORD $0x009b; BYTE $0x00 // leaq         $39714(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(DX)(CX*1), CX
 	MOVB    CX, 0(DI)
 	MOVL    $1, CX
@@ -1186,14 +1186,14 @@ LBB4_3:
 LBB4_4:
 	MOVWLZX DX, DX
 	ORQ     $1, DX
-	LONG    $0x6b358d48; WORD $0x009b; BYTE $0x00 // leaq         $39787(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0x01358d48; WORD $0x009b; BYTE $0x00 // leaq         $39681(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(DX)(SI*1), DX
 	MOVL    CX, SI
 	INCL    CX
 	MOVB    DX, 0(DI)(SI*1)
 
 LBB4_6:
-	LONG $0x5a158d48; WORD $0x009b; BYTE $0x00 // leaq         $39770(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xf0158d48; WORD $0x009a; BYTE $0x00 // leaq         $39664(%rip), %rdx  /* _Digits(%rip) */
 	MOVB 0(AX)(DX*1), DX
 	MOVL CX, SI
 	INCL CX
@@ -1202,7 +1202,7 @@ LBB4_6:
 LBB4_7:
 	MOVWLZX AX, AX
 	ORQ     $1, AX
-	LONG    $0x42158d48; WORD $0x009b; BYTE $0x00 // leaq         $39746(%rip), %rdx  /* _Digits(%rip) */
+	LONG    $0xd8158d48; WORD $0x009a; BYTE $0x00 // leaq         $39640(%rip), %rdx  /* _Digits(%rip) */
 	MOVB    0(AX)(DX*1), AX
 	MOVL    CX, DX
 	INCL    CX
@@ -1249,7 +1249,7 @@ LBB4_8:
 	ADDQ    R11, R11
 	CMPL    SI, $10000000
 	JB      LBB4_11
-	LONG    $0xab058d48; WORD $0x009a; BYTE $0x00 // leaq         $39595(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0x41058d48; WORD $0x009a; BYTE $0x00 // leaq         $39489(%rip), %rax  /* _Digits(%rip) */
 	MOVB    0(R10)(AX*1), AX
 	MOVB    AX, 0(DI)
 	MOVL    $1, CX
@@ -1263,14 +1263,14 @@ LBB4_11:
 LBB4_12:
 	MOVL R10, AX
 	ORQ  $1, AX
-	LONG $0x86358d48; WORD $0x009a; BYTE $0x00 // leaq         $39558(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x1c358d48; WORD $0x009a; BYTE $0x00 // leaq         $39452(%rip), %rsi  /* _Digits(%rip) */
 	MOVB 0(AX)(SI*1), AX
 	MOVL CX, SI
 	INCL CX
 	MOVB AX, 0(DI)(SI*1)
 
 LBB4_14:
-	LONG $0x75058d48; WORD $0x009a; BYTE $0x00 // leaq         $39541(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x0b058d48; WORD $0x009a; BYTE $0x00 // leaq         $39435(%rip), %rax  /* _Digits(%rip) */
 	MOVB 0(R9)(AX*1), AX
 	MOVL CX, SI
 	INCL CX
@@ -1279,7 +1279,7 @@ LBB4_14:
 LBB4_15:
 	MOVWLZX R9, AX
 	ORQ     $1, AX
-	LONG    $0x5b358d48; WORD $0x009a; BYTE $0x00 // leaq         $39515(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0xf1358d48; WORD $0x0099; BYTE $0x00 // leaq         $39409(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(AX)(SI*1), AX
 	MOVL    CX, DX
 	MOVB    AX, 0(DX)(DI*1)
@@ -1361,7 +1361,7 @@ LBB4_16:
 	MOVL $16, CX
 	SUBL AX, CX
 	SHLQ $4, AX
-	LONG $0xd0158d48; WORD $0x0099; BYTE $0x00 // leaq         $39376(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x66158d48; WORD $0x0099; BYTE $0x00 // leaq         $39270(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	MOVL CX, AX
@@ -1387,7 +1387,7 @@ LBB4_20:
 	CMPL DX, $99
 	JA   LBB4_22
 	MOVL DX, AX
-	LONG $0xb30d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39091(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x490d8d48; WORD $0x0098; BYTE $0x00 // leaq         $38985(%rip), %rcx  /* _Digits(%rip) */
 	MOVB 0(CX)(AX*2), DX
 	MOVB 1(CX)(AX*2), AX
 	MOVB DX, 0(DI)
@@ -1412,7 +1412,7 @@ LBB4_22:
 	WORD    $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	SUBL    CX, AX
 	MOVWLZX AX, AX
-	LONG    $0x620d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39010(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0xf80d8d48; WORD $0x0097; BYTE $0x00 // leaq         $38904(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(CX)(AX*2), DX
 	MOVB    1(CX)(AX*2), AX
 	MOVB    DX, 1(DI)
@@ -1424,7 +1424,7 @@ LBB4_24:
 	WORD    $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	SUBL    CX, DX
 	MOVWLZX AX, AX
-	LONG    $0x3f058d4c; WORD $0x0098; BYTE $0x00 // leaq         $38975(%rip), %r8  /* _Digits(%rip) */
+	LONG    $0xd5058d4c; WORD $0x0097; BYTE $0x00 // leaq         $38869(%rip), %r8  /* _Digits(%rip) */
 	MOVB    0(R8)(AX*2), CX
 	MOVB    1(R8)(AX*2), AX
 	MOVB    CX, 0(DI)
@@ -1509,8 +1509,8 @@ _quote:
 	SUBQ  $32, SP
 	MOVQ  DX, R10
 	TESTB $1, R8
-	LONG  $0x41058d48; WORD $0x0098; BYTE $0x00 // leaq         $38977(%rip), %rax  /* __SingleQuoteTab(%rip) */
-	LONG  $0x3a158d48; WORD $0x00a8; BYTE $0x00 // leaq         $43066(%rip), %rdx  /* __DoubleQuoteTab(%rip) */
+	LONG  $0xd7058d48; WORD $0x0097; BYTE $0x00 // leaq         $38871(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG  $0xd0158d48; WORD $0x00a7; BYTE $0x00 // leaq         $42960(%rip), %rdx  /* __DoubleQuoteTab(%rip) */
 	LONG  $0xd0440f48                           // cmoveq       %rax, %rdx
 	MOVQ  R10, R8
 	MOVQ  DI, AX
@@ -1600,7 +1600,7 @@ LBB5_10:
 	TESTQ R10, R10
 	MOVQ  -48(BP), CX
 	MOVQ  -56(BP), DI
-	LONG  $0xef2d8d4c; WORD $0x0096; BYTE $0x00 // leaq         $38639(%rip), %r13  /* __SingleQuoteTab(%rip) */
+	LONG  $0x852d8d4c; WORD $0x0096; BYTE $0x00 // leaq         $38533(%rip), %r13  /* __SingleQuoteTab(%rip) */
 	JLE   LBB5_39
 
 LBB5_35:
@@ -1867,7 +1867,7 @@ _unquote:
 	MOVQ  R8, -72(BP)
 	MOVL  R8, R10
 	ANDL  $1, R10
-	LONG  $0x10058d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46096(%rip), %r8  /* __UnquoteTab(%rip) */
+	LONG  $0xa6058d4c; WORD $0x00b3; BYTE $0x00 // leaq         $45990(%rip), %r8  /* __UnquoteTab(%rip) */
 	QUAD  $0xffffffb2056ffac5                   // vmovdqu      $-78(%rip), %xmm0  /* LCPI6_0(%rip) */
 	MOVQ  DI, R9
 	MOVQ  SI, R13
@@ -2550,7 +2550,7 @@ _html_escape:
 	QUAD  $0xffffff92156ffac5                   // vmovdqu      $-110(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD  $0xffffff9a1d6ffac5                   // vmovdqu      $-102(%rip), %xmm3  /* LCPI7_3(%rip) */
 	MOVQ  $5764607797912141824, R14
-	LONG  $0x743d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44148(%rip), %r15  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x0a3d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44042(%rip), %r15  /* __HtmlQuoteTab(%rip) */
 	MOVQ  $12884901889, DI
 	MOVQ  -64(BP), AX
 	MOVQ  -48(BP), R10
@@ -2885,7 +2885,7 @@ LBB8_5:
 	SHLQ CX, DI
 	MOVL AX, CX
 	SHLQ $4, CX
-	LONG $0xff3d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12543(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0x953d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12437(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	MOVQ DI, AX
 	MULQ 8(CX)(R15*1)
 	MOVQ AX, R11
@@ -3008,7 +3008,7 @@ LBB9_7:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x002e4ae8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002de0e8; BYTE $0x00 // callq        _right_shift
 
 LBB9_8:
 	ADDL  R14, R15
@@ -3021,7 +3021,7 @@ LBB9_9:
 	CMPL AX, $8
 	JG   LBB9_11
 	MOVL AX, AX
-	LONG $0xfb0d8d48; WORD $0x005a; BYTE $0x00 // leaq         $23291(%rip), %rcx  /* _POW_TAB(%rip) */
+	LONG $0x910d8d48; WORD $0x005a; BYTE $0x00 // leaq         $23185(%rip), %rcx  /* _POW_TAB(%rip) */
 	MOVL 0(CX)(AX*4), R14
 
 LBB9_11:
@@ -3039,7 +3039,7 @@ LBB9_11:
 LBB9_15:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002df8e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002d8ee8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3053,7 +3053,7 @@ LBB9_16:
 LBB9_17:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002c6ae8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002c00e8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3065,12 +3065,12 @@ LBB9_18:
 
 LBB9_19:
 	MOVQ R12, DI
-	LONG $0x002c54e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002beae8; BYTE $0x00 // callq        _left_shift
 	JMP  LBB9_8
 
 LBB9_20:
 	MOVQ R12, DI
-	LONG $0x002c47e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002bdde8; BYTE $0x00 // callq        _left_shift
 
 LBB9_21:
 	SUBL R14, R15
@@ -3093,7 +3093,7 @@ LBB9_25:
 LBB9_26:
 	NEGL AX
 	WORD $0x9848                               // cltq
-	LONG $0x550d8d48; WORD $0x005a; BYTE $0x00 // leaq         $23125(%rip), %rcx  /* _POW_TAB(%rip) */
+	LONG $0xeb0d8d48; WORD $0x0059; BYTE $0x00 // leaq         $23019(%rip), %rcx  /* _POW_TAB(%rip) */
 	MOVL 0(CX)(AX*4), R14
 
 LBB9_27:
@@ -3111,7 +3111,7 @@ LBB9_27:
 LBB9_32:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002be2e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002b78e8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3126,7 +3126,7 @@ LBB9_33:
 LBB9_34:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002d2fe8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002cc5e8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3136,7 +3136,7 @@ LBB9_35:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x002d19e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002cafe8; BYTE $0x00 // callq        _right_shift
 	JMP  LBB9_21
 
 LBB9_36:
@@ -3152,7 +3152,7 @@ LBB9_36:
 LBB9_40:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002ce2e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002c78e8; BYTE $0x00 // callq        _right_shift
 	ADDL $60, R15
 	CMPL R15, $-120
 	JL   LBB9_40
@@ -3178,7 +3178,7 @@ LBB9_46:
 	NEGL R15
 	MOVQ R12, DI
 	MOVL R15, SI
-	LONG $0x002c9ce8; BYTE $0x00 // callq        _right_shift
+	LONG $0x002c32e8; BYTE $0x00 // callq        _right_shift
 	MOVL $-1022, R14
 
 LBB9_47:
@@ -3186,7 +3186,7 @@ LBB9_47:
 	JE   LBB9_49
 	MOVQ R12, DI
 	MOVL $53, SI
-	LONG $0x002b12e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x002aa8e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_49:
 	MOVLQSX 20(R12), R8
@@ -4787,7 +4787,7 @@ LBB15_71:
 	CMPL    DI, $23
 	JL      LBB15_81
 	MOVLQSX DI, AX
-	LONG    $0x700d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48240(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0x060d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48134(%rip), %rcx  /* _P10_TAB(%rip) */
 	QUAD    $0xffff50c18459fbc5; BYTE $0xff       // vmulsd       $-176(%rcx,%rax,8), %xmm0, %xmm0
 	LONG    $0x4511fbc5; BYTE $0xd0               // vmovsd       %xmm0, $-48(%rbp)
 	MOVL    $22, AX
@@ -4805,7 +4805,7 @@ LBB15_77:
 	JB      LBB15_60
 	NEGL    DI
 	MOVLQSX DI, AX
-	LONG    $0x2e0d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48174(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0xc40d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $48068(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG    $0x045efbc5; BYTE $0xc1               // vdivsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP     LBB15_65
 
@@ -4837,7 +4837,7 @@ LBB15_82:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	JA   LBB15_60
 	MOVL AX, AX
-	LONG $0xb50d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $48053(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x4b0d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $47947(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP  LBB15_65
 
@@ -5271,7 +5271,7 @@ LBB19_28:
 	ADDQ  R13, DI
 	MOVQ  8(AX), SI
 	SUBQ  R13, SI
-	LONG  $0x000d43e8; BYTE $0x00 // callq        _skip_number
+	LONG  $0x000cefe8; BYTE $0x00 // callq        _skip_number
 	MOVQ  $-2, CX
 	SUBQ  AX, CX
 	TESTQ AX, AX
@@ -5357,7 +5357,7 @@ LBB19_44:
 	ADDQ  R13, DI
 	MOVQ  8(AX), SI
 	SUBQ  R13, SI
-	LONG  $0x000c0fe8; BYTE $0x00 // callq        _skip_number
+	LONG  $0x000bbbe8; BYTE $0x00 // callq        _skip_number
 	TESTQ AX, AX
 	JS    LBB19_66
 	ADDQ  R13, AX
@@ -5764,174 +5764,173 @@ _validate_string:
 	WORD $0x5441             // pushq        %r12
 	BYTE $0x53               // pushq        %rbx
 	SUBQ $40, SP
-	MOVQ SI, -80(BP)
+	MOVQ SI, R14
 	MOVQ 0(SI), R15
-	MOVQ 8(DI), DX
-	MOVQ DX, -72(BP)
-	SUBQ R15, DX
-	JE   LBB23_47
+	MOVQ 8(DI), R12
+	MOVQ R12, -64(BP)
+	SUBQ R15, R12
+	JE   LBB23_16
+	MOVQ R14, -48(BP)
 	MOVQ 0(DI), AX
-	MOVQ AX, -48(BP)
-	LEAQ 0(AX)(R15*1), R12
-	CMPQ DX, $64
-	MOVQ R12, -56(BP)
-	JB   LBB23_2
-	MOVL DX, AX
-	ANDL $63, AX
-	MOVQ AX, -64(BP)
+	MOVQ AX, -56(BP)
+	LEAQ 0(AX)(R15*1), SI
+	CMPQ R12, $64
+	MOVQ SI, -72(BP)
+	JB   LBB23_31
+	MOVL R12, R9
+	ANDL $63, R9
 	MOVQ $-1, R13
-	XORL R9, R9
-	QUAD $0xffffff73056f7ac5 // vmovdqu      $-141(%rip), %xmm8  /* LCPI23_0(%rip) */
-	QUAD $0xffffff7b0d6ffac5 // vmovdqu      $-133(%rip), %xmm1  /* LCPI23_1(%rip) */
-	QUAD $0xffffff83156ffac5 // vmovdqu      $-125(%rip), %xmm2  /* LCPI23_2(%rip) */
+	XORL R14, R14
+	QUAD $0xffffff72056f7ac5 // vmovdqu      $-142(%rip), %xmm8  /* LCPI23_0(%rip) */
+	QUAD $0xffffff7a0d6ffac5 // vmovdqu      $-134(%rip), %xmm1  /* LCPI23_1(%rip) */
+	QUAD $0xffffff82156ffac5 // vmovdqu      $-126(%rip), %xmm2  /* LCPI23_2(%rip) */
 	LONG $0xdb76e1c5         // vpcmpeqd     %xmm3, %xmm3, %xmm3
-	MOVQ DX, AX
 
-LBB23_4:
-	LONG  $0x6f7ac1c4; WORD $0x243c             // vmovdqu      (%r12), %xmm7
-	LONG  $0x6f7ac1c4; WORD $0x2474; BYTE $0x10 // vmovdqu      $16(%r12), %xmm6
-	LONG  $0x6f7ac1c4; WORD $0x246c; BYTE $0x20 // vmovdqu      $32(%r12), %xmm5
-	LONG  $0x6f7ac1c4; WORD $0x2464; BYTE $0x30 // vmovdqu      $48(%r12), %xmm4
-	LONG  $0xc774b9c5                           // vpcmpeqb     %xmm7, %xmm8, %xmm0
-	LONG  $0xc8d7f9c5                           // vpmovmskb    %xmm0, %ecx
-	LONG  $0xc674b9c5                           // vpcmpeqb     %xmm6, %xmm8, %xmm0
-	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
-	LONG  $0xc574b9c5                           // vpcmpeqb     %xmm5, %xmm8, %xmm0
-	LONG  $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
-	LONG  $0xc474b9c5                           // vpcmpeqb     %xmm4, %xmm8, %xmm0
-	LONG  $0xc0d779c5                           // vpmovmskb    %xmm0, %r8d
-	LONG  $0xc174c1c5                           // vpcmpeqb     %xmm1, %xmm7, %xmm0
-	LONG  $0xd8d779c5                           // vpmovmskb    %xmm0, %r11d
-	LONG  $0xc174c9c5                           // vpcmpeqb     %xmm1, %xmm6, %xmm0
-	LONG  $0xf0d7f9c5                           // vpmovmskb    %xmm0, %esi
-	LONG  $0xc174d1c5                           // vpcmpeqb     %xmm1, %xmm5, %xmm0
-	SHLQ  $16, BX
-	ORQ   BX, CX
-	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
-	LONG  $0xc174d9c5                           // vpcmpeqb     %xmm1, %xmm4, %xmm0
-	SHLQ  $32, DI
-	ORQ   DI, CX
-	LONG  $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
-	LONG  $0xc764e9c5                           // vpcmpgtb     %xmm7, %xmm2, %xmm0
-	LONG  $0xfb64c1c5                           // vpcmpgtb     %xmm3, %xmm7, %xmm7
-	LONG  $0xc0dbc1c5                           // vpand        %xmm0, %xmm7, %xmm0
-	SHLQ  $16, SI
-	ORQ   SI, R11
-	LONG  $0xd0d779c5                           // vpmovmskb    %xmm0, %r10d
-	LONG  $0xc664e9c5                           // vpcmpgtb     %xmm6, %xmm2, %xmm0
-	LONG  $0xf364c9c5                           // vpcmpgtb     %xmm3, %xmm6, %xmm6
-	LONG  $0xc0dbc9c5                           // vpand        %xmm0, %xmm6, %xmm0
+LBB23_3:
+	LONG  $0x3e6ffac5             // vmovdqu      (%rsi), %xmm7
+	LONG  $0x766ffac5; BYTE $0x10 // vmovdqu      $16(%rsi), %xmm6
+	LONG  $0x6e6ffac5; BYTE $0x20 // vmovdqu      $32(%rsi), %xmm5
+	LONG  $0x666ffac5; BYTE $0x30 // vmovdqu      $48(%rsi), %xmm4
+	LONG  $0xc774b9c5             // vpcmpeqb     %xmm7, %xmm8, %xmm0
+	LONG  $0xd0d7f9c5             // vpmovmskb    %xmm0, %edx
+	LONG  $0xc674b9c5             // vpcmpeqb     %xmm6, %xmm8, %xmm0
+	LONG  $0xc0d7f9c5             // vpmovmskb    %xmm0, %eax
+	LONG  $0xc574b9c5             // vpcmpeqb     %xmm5, %xmm8, %xmm0
+	LONG  $0xd8d7f9c5             // vpmovmskb    %xmm0, %ebx
+	LONG  $0xc474b9c5             // vpcmpeqb     %xmm4, %xmm8, %xmm0
+	LONG  $0xd8d779c5             // vpmovmskb    %xmm0, %r11d
+	LONG  $0xc174c1c5             // vpcmpeqb     %xmm1, %xmm7, %xmm0
+	LONG  $0xd0d779c5             // vpmovmskb    %xmm0, %r10d
+	LONG  $0xc174c9c5             // vpcmpeqb     %xmm1, %xmm6, %xmm0
+	LONG  $0xc8d7f9c5             // vpmovmskb    %xmm0, %ecx
+	LONG  $0xc174d1c5             // vpcmpeqb     %xmm1, %xmm5, %xmm0
+	SHLQ  $16, AX
+	ORQ   AX, DX
+	LONG  $0xc0d7f9c5             // vpmovmskb    %xmm0, %eax
+	LONG  $0xc174d9c5             // vpcmpeqb     %xmm1, %xmm4, %xmm0
 	SHLQ  $32, BX
-	ORQ   BX, R11
-	LONG  $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
-	LONG  $0xc564e9c5                           // vpcmpgtb     %xmm5, %xmm2, %xmm0
-	LONG  $0xeb64d1c5                           // vpcmpgtb     %xmm3, %xmm5, %xmm5
-	LONG  $0xc0dbd1c5                           // vpand        %xmm0, %xmm5, %xmm0
-	SHLQ  $48, DI
-	ORQ   DI, R11
-	LONG  $0xf0d7f9c5                           // vpmovmskb    %xmm0, %esi
-	LONG  $0xc464e9c5                           // vpcmpgtb     %xmm4, %xmm2, %xmm0
-	LONG  $0xe364d9c5                           // vpcmpgtb     %xmm3, %xmm4, %xmm4
-	LONG  $0xc0dbd9c5                           // vpand        %xmm0, %xmm4, %xmm0
-	SHLQ  $16, BX
+	ORQ   BX, DX
+	LONG  $0xd8d7f9c5             // vpmovmskb    %xmm0, %ebx
+	LONG  $0xc764e9c5             // vpcmpgtb     %xmm7, %xmm2, %xmm0
+	LONG  $0xfb64c1c5             // vpcmpgtb     %xmm3, %xmm7, %xmm7
+	LONG  $0xc0dbc1c5             // vpand        %xmm0, %xmm7, %xmm0
+	SHLQ  $16, CX
+	ORQ   CX, R10
+	LONG  $0xc8d7f9c5             // vpmovmskb    %xmm0, %ecx
+	LONG  $0xc664e9c5             // vpcmpgtb     %xmm6, %xmm2, %xmm0
+	LONG  $0xf364c9c5             // vpcmpgtb     %xmm3, %xmm6, %xmm6
+	LONG  $0xc0dbc9c5             // vpand        %xmm0, %xmm6, %xmm0
+	SHLQ  $32, AX
+	ORQ   AX, R10
+	LONG  $0xf8d7f9c5             // vpmovmskb    %xmm0, %edi
+	LONG  $0xc564e9c5             // vpcmpgtb     %xmm5, %xmm2, %xmm0
+	LONG  $0xeb64d1c5             // vpcmpgtb     %xmm3, %xmm5, %xmm5
+	LONG  $0xc0dbd1c5             // vpand        %xmm0, %xmm5, %xmm0
+	SHLQ  $48, BX
 	ORQ   BX, R10
-	LONG  $0xf0d779c5                           // vpmovmskb    %xmm0, %r14d
-	SHLQ  $48, R8
-	SHLQ  $32, SI
+	LONG  $0xc0d7f9c5             // vpmovmskb    %xmm0, %eax
+	LONG  $0xc464e9c5             // vpcmpgtb     %xmm4, %xmm2, %xmm0
+	LONG  $0xe364d9c5             // vpcmpgtb     %xmm3, %xmm4, %xmm4
+	LONG  $0xc0dbd9c5             // vpand        %xmm0, %xmm4, %xmm0
+	SHLQ  $16, DI
+	ORQ   DI, CX
+	LONG  $0xc0d779c5             // vpmovmskb    %xmm0, %r8d
+	SHLQ  $48, R11
+	SHLQ  $32, AX
 	CMPQ  R13, $-1
-	JNE   LBB23_7
-	TESTQ R11, R11
-	JNE   LBB23_6
-
-LBB23_7:
-	SHLQ  $48, R14
-	ORQ   SI, R10
-	ORQ   R8, CX
-	MOVQ  R11, SI
-	ORQ   R9, SI
-	JNE   LBB23_8
-	ORQ   R14, R10
-	TESTQ CX, CX
+	JNE   LBB23_5
+	TESTQ R10, R10
 	JNE   LBB23_10
 
-LBB23_14:
-	TESTQ R10, R10
-	JNE   LBB23_15
-	ADDQ  $64, R12
-	ADDQ  $-64, AX
-	CMPQ  AX, $63
-	JA    LBB23_4
-	JMP   LBB23_18
+LBB23_5:
+	SHLQ  $48, R8
+	ORQ   AX, CX
+	ORQ   R11, DX
+	MOVQ  R10, AX
+	ORQ   R14, AX
+	JNE   LBB23_9
+	ORQ   R8, CX
+	TESTQ DX, DX
+	JNE   LBB23_11
 
-LBB23_8:
-	MOVQ  R9, SI
-	NOTQ  SI
-	ANDQ  R11, SI
-	LEAQ  0(SI)(SI*1), R8
-	ORQ   R9, R8
-	MOVQ  R8, DI
+LBB23_7:
+	TESTQ CX, CX
+	JNE   LBB23_18
+	ADDQ  $64, SI
+	ADDQ  $-64, R12
+	CMPQ  R12, $63
+	JA    LBB23_3
+	JMP   LBB23_20
+
+LBB23_9:
+	MOVQ  R14, AX
+	NOTQ  AX
+	ANDQ  R10, AX
+	LEAQ  0(AX)(AX*1), R11
+	ORQ   R14, R11
+	MOVQ  R11, DI
 	NOTQ  DI
-	ANDQ  R11, DI
+	ANDQ  R10, DI
 	MOVQ  $-6148914691236517206, BX
 	ANDQ  BX, DI
-	XORL  R9, R9
-	ADDQ  SI, DI
-	SETCS R9
+	XORL  R14, R14
+	ADDQ  AX, DI
+	SETCS R14
 	ADDQ  DI, DI
-	MOVQ  $6148914691236517205, SI
-	XORQ  SI, DI
-	ANDQ  R8, DI
+	MOVQ  $6148914691236517205, AX
+	XORQ  AX, DI
+	ANDQ  R11, DI
 	NOTQ  DI
-	ANDQ  DI, CX
-	ORQ   R14, R10
-	TESTQ CX, CX
-	JE    LBB23_14
-	JMP   LBB23_10
-
-LBB23_6:
-	MOVQ R12, DI
-	SUBQ -48(BP), DI
-	BSFQ R11, R13
-	ADDQ DI, R13
-	JMP  LBB23_7
+	ANDQ  DI, DX
+	ORQ   R8, CX
+	TESTQ DX, DX
+	JE    LBB23_7
+	JMP   LBB23_11
 
 LBB23_10:
-	SUBQ  -48(BP), R12
-	BSFQ  CX, CX
-	LEAQ  1(R12)(CX*1), BX
-	TESTQ R10, R10
-	JE    LBB23_45
-	BSFQ  R10, AX
-	CMPQ  AX, CX
-	JBE   LBB23_13
+	MOVQ SI, DI
+	SUBQ -56(BP), DI
+	BSFQ R10, R13
+	ADDQ DI, R13
+	JMP  LBB23_5
 
-LBB23_45:
-	MOVQ  -56(BP), DI
+LBB23_11:
+	SUBQ  -56(BP), SI
+	BSFQ  DX, DX
+	LEAQ  1(SI)(DX*1), BX
+	TESTQ CX, CX
+	MOVQ  -48(BP), R14
+	JE    LBB23_13
+	BSFQ  CX, AX
+	CMPQ  AX, DX
+	JBE   LBB23_27
+
+LBB23_13:
 	TESTQ BX, BX
-	JS    LBB23_46
+	JS    LBB23_15
 	MOVQ  R15, SI
 	NOTQ  SI
 	ADDQ  BX, SI
-	LONG  $0x0002afe8; BYTE $0x00 // callq        _utf8_validate
+	MOVQ  -72(BP), DI
+	LONG  $0x0002bee8; BYTE $0x00 // callq        _utf8_validate
 	LEAQ  0(AX)(R15*1), R13
 	TESTQ AX, AX
 	LONG  $0xeb480f4c             // cmovsq       %rbx, %r13
 	LEAQ  -1(R15), BX
 	MOVQ  $-2, AX
 	LONG  $0xd8490f48             // cmovnsq      %rax, %rbx
-	JMP   LBB23_53
+	JMP   LBB23_17
 
-LBB23_46:
+LBB23_15:
 	CMPQ BX, $-1
-	JNE  LBB23_53
+	JNE  LBB23_17
 
-LBB23_47:
+LBB23_16:
 	MOVQ $-1, BX
-	MOVQ -72(BP), R13
+	MOVQ -64(BP), R13
 
-LBB23_53:
-	MOVQ -80(BP), AX
-	MOVQ R13, 0(AX)
+LBB23_17:
+	MOVQ R13, 0(R14)
 	MOVQ BX, AX
 	ADDQ $40, SP
 	BYTE $0x5b       // popq         %rbx
@@ -5942,352 +5941,357 @@ LBB23_53:
 	BYTE $0x5d       // popq         %rbp
 	RET
 
-LBB23_15:
+LBB23_18:
 	MOVQ $-2, BX
 	CMPQ R13, $-1
-	JNE  LBB23_53
-	SUBQ -48(BP), R12
-	BSFQ R10, R13
-	ADDQ R12, R13
-	JMP  LBB23_53
+	JE   LBB23_28
 
-LBB23_18:
-	MOVQ -64(BP), DI
-	CMPQ DI, $32
-	JB   LBB23_32
+LBB23_19:
+	MOVQ -48(BP), R14
+	JMP  LBB23_17
 
 LBB23_20:
-	LONG  $0x6f7ac1c4; WORD $0x2404             // vmovdqu      (%r12), %xmm0
-	LONG  $0x6f7ac1c4; WORD $0x244c; BYTE $0x10 // vmovdqu      $16(%r12), %xmm1
-	QUAD  $0xfffffd23156ffac5                   // vmovdqu      $-733(%rip), %xmm2  /* LCPI23_0(%rip) */
-	LONG  $0xda74f9c5                           // vpcmpeqb     %xmm2, %xmm0, %xmm3
-	LONG  $0xdbd779c5                           // vpmovmskb    %xmm3, %r11d
-	LONG  $0xd274f1c5                           // vpcmpeqb     %xmm2, %xmm1, %xmm2
-	LONG  $0xcad7f9c5                           // vpmovmskb    %xmm2, %ecx
-	QUAD  $0xfffffd1b156ffac5                   // vmovdqu      $-741(%rip), %xmm2  /* LCPI23_1(%rip) */
-	LONG  $0xda74f9c5                           // vpcmpeqb     %xmm2, %xmm0, %xmm3
-	LONG  $0xc3d7f9c5                           // vpmovmskb    %xmm3, %eax
-	LONG  $0xd274f1c5                           // vpcmpeqb     %xmm2, %xmm1, %xmm2
-	LONG  $0xf2d7f9c5                           // vpmovmskb    %xmm2, %esi
-	QUAD  $0xfffffd13156ffac5                   // vmovdqu      $-749(%rip), %xmm2  /* LCPI23_2(%rip) */
-	LONG  $0xd864e9c5                           // vpcmpgtb     %xmm0, %xmm2, %xmm3
-	LONG  $0xe476d9c5                           // vpcmpeqd     %xmm4, %xmm4, %xmm4
-	LONG  $0xc464f9c5                           // vpcmpgtb     %xmm4, %xmm0, %xmm0
-	LONG  $0xc3dbf9c5                           // vpand        %xmm3, %xmm0, %xmm0
-	LONG  $0xd0d779c5                           // vpmovmskb    %xmm0, %r10d
-	LONG  $0xc164e9c5                           // vpcmpgtb     %xmm1, %xmm2, %xmm0
-	LONG  $0xcc64f1c5                           // vpcmpgtb     %xmm4, %xmm1, %xmm1
-	LONG  $0xc0dbf1c5                           // vpand        %xmm0, %xmm1, %xmm0
-	LONG  $0xc0d779c5                           // vpmovmskb    %xmm0, %r8d
-	SHLQ  $16, CX
-	SHLQ  $16, SI
-	ORQ   SI, AX
+	MOVQ R9, R12
+	CMPQ R12, $32
+	JB   LBB23_35
+
+LBB23_21:
+	LONG  $0x066ffac5             // vmovdqu      (%rsi), %xmm0
+	LONG  $0x4e6ffac5; BYTE $0x10 // vmovdqu      $16(%rsi), %xmm1
+	QUAD  $0xfffffd35156ffac5     // vmovdqu      $-715(%rip), %xmm2  /* LCPI23_0(%rip) */
+	LONG  $0xda74f9c5             // vpcmpeqb     %xmm2, %xmm0, %xmm3
+	LONG  $0xdbd779c5             // vpmovmskb    %xmm3, %r11d
+	LONG  $0xd274f1c5             // vpcmpeqb     %xmm2, %xmm1, %xmm2
+	LONG  $0xd2d7f9c5             // vpmovmskb    %xmm2, %edx
+	QUAD  $0xfffffd2d156ffac5     // vmovdqu      $-723(%rip), %xmm2  /* LCPI23_1(%rip) */
+	LONG  $0xda74f9c5             // vpcmpeqb     %xmm2, %xmm0, %xmm3
+	LONG  $0xcbd7f9c5             // vpmovmskb    %xmm3, %ecx
+	LONG  $0xd274f1c5             // vpcmpeqb     %xmm2, %xmm1, %xmm2
+	LONG  $0xc2d7f9c5             // vpmovmskb    %xmm2, %eax
+	QUAD  $0xfffffd25156ffac5     // vmovdqu      $-731(%rip), %xmm2  /* LCPI23_2(%rip) */
+	LONG  $0xd864e9c5             // vpcmpgtb     %xmm0, %xmm2, %xmm3
+	LONG  $0xe476d9c5             // vpcmpeqd     %xmm4, %xmm4, %xmm4
+	LONG  $0xc464f9c5             // vpcmpgtb     %xmm4, %xmm0, %xmm0
+	LONG  $0xc3dbf9c5             // vpand        %xmm3, %xmm0, %xmm0
+	LONG  $0xc0d779c5             // vpmovmskb    %xmm0, %r8d
+	LONG  $0xc164e9c5             // vpcmpgtb     %xmm1, %xmm2, %xmm0
+	LONG  $0xcc64f1c5             // vpcmpgtb     %xmm4, %xmm1, %xmm1
+	LONG  $0xc0dbf1c5             // vpand        %xmm0, %xmm1, %xmm0
+	LONG  $0xd0d779c5             // vpmovmskb    %xmm0, %r10d
+	SHLQ  $16, DX
+	SHLQ  $16, AX
+	ORQ   AX, CX
 	CMPQ  R13, $-1
 	JNE   LBB23_23
-	TESTQ AX, AX
-	JNE   LBB23_22
+	TESTQ CX, CX
+	JNE   LBB23_47
 
 LBB23_23:
-	SHLQ  $16, R8
-	ORQ   R11, CX
-	MOVQ  AX, SI
-	ORQ   R9, SI
-	JNE   LBB23_24
-	ORQ   R10, R8
-	TESTQ CX, CX
-	JE    LBB23_28
+	SHLQ  $16, R10
+	ORQ   R11, DX
+	MOVQ  CX, AX
+	ORQ   R14, AX
+	JNE   LBB23_32
+	ORQ   R8, R10
+	TESTQ DX, DX
+	JE    LBB23_33
 
-LBB23_26:
-	SUBQ  -48(BP), R12
-	BSFQ  CX, CX
-	LEAQ  1(R12)(CX*1), BX
-	TESTQ R8, R8
-	JE    LBB23_45
-	BSFQ  R8, AX
+LBB23_25:
+	SUBQ  -56(BP), SI
+	BSFQ  DX, CX
+	LEAQ  1(SI)(CX*1), BX
+	TESTQ R10, R10
+	JE    LBB23_30
+	BSFQ  R10, AX
 	CMPQ  AX, CX
-	JA    LBB23_45
+	MOVQ  -48(BP), R14
+	JA    LBB23_13
 
-LBB23_13:
-	ADDQ R12, AX
+LBB23_27:
+	ADDQ SI, AX
 	CMPQ R13, $-1
 	LONG $0xe8440f4c // cmoveq       %rax, %r13
 	MOVQ $-2, BX
-	JMP  LBB23_53
-
-LBB23_2:
-	MOVQ $-1, R13
-	XORL R9, R9
-	MOVQ DX, DI
-	CMPQ DI, $32
-	JAE  LBB23_20
-	JMP  LBB23_32
-
-LBB23_24:
-	MOVL  R9, SI
-	NOTL  SI
-	ANDL  AX, SI
-	LEAL  0(SI)(SI*1), R11
-	ORL   R9, R11
-	MOVL  R11, BX
-	NOTL  BX
-	ANDL  AX, BX
-	ANDL  $-1431655766, BX
-	XORL  R9, R9
-	ADDL  SI, BX
-	SETCS R9
-	ADDL  BX, BX
-	XORL  $1431655765, BX
-	ANDL  R11, BX
-	NOTL  BX
-	ANDL  BX, CX
-	ORQ   R10, R8
-	TESTQ CX, CX
-	JNE   LBB23_26
+	JMP  LBB23_17
 
 LBB23_28:
-	TESTQ R8, R8
-	JNE   LBB23_29
-	ADDQ  $32, R12
-	ADDQ  $-32, DI
-
-LBB23_32:
-	TESTQ R9, R9
-	JNE   LBB23_33
-	TESTQ DI, DI
-	JE    LBB23_44
-
-LBB23_36:
-	MOVQ -48(BP), AX
-	NOTQ AX
-
-LBB23_37:
-	LEAQ    1(R12), SI
-	MOVBLZX 0(R12), CX
-	CMPB    CX, $34
-	JE      LBB23_38
-	LEAQ    -1(DI), BX
-	CMPB    CX, $92
-	JE      LBB23_40
-	CMPB    CX, $31
-	JBE     LBB23_50
-	MOVQ    SI, R12
-	MOVQ    BX, DI
-	TESTQ   BX, BX
-	JNE     LBB23_37
-	JMP     LBB23_43
-
-LBB23_40:
-	TESTQ BX, BX
-	JE    LBB23_47
-	ADDQ  AX, SI
-	CMPQ  R13, $-1
-	LONG  $0xee440f4c // cmoveq       %rsi, %r13
-	ADDQ  $2, R12
-	ADDQ  $-2, DI
-	MOVQ  DI, BX
-	TESTQ BX, BX
-	JNE   LBB23_37
-
-LBB23_43:
-	CMPB CX, $34
-	JNE  LBB23_47
-	JMP  LBB23_44
-
-LBB23_38:
-	MOVQ SI, R12
-
-LBB23_44:
-	SUBQ -48(BP), R12
-	MOVQ R12, BX
-	JMP  LBB23_45
-
-LBB23_22:
-	MOVQ R12, SI
-	SUBQ -48(BP), SI
-	BSFQ AX, R13
-	ADDQ SI, R13
-	JMP  LBB23_23
+	SUBQ -56(BP), SI
+	BSFQ CX, R13
 
 LBB23_29:
-	MOVQ $-2, BX
-	CMPQ R13, $-1
-	JNE  LBB23_53
-	SUBQ -48(BP), R12
-	BSFQ R8, R13
-	ADDQ R12, R13
-	JMP  LBB23_53
+	ADDQ SI, R13
+	MOVQ -48(BP), R14
+	JMP  LBB23_17
+
+LBB23_30:
+	MOVQ -48(BP), R14
+	JMP  LBB23_13
+
+LBB23_31:
+	MOVQ $-1, R13
+	XORL R14, R14
+	CMPQ R12, $32
+	JAE  LBB23_21
+	JMP  LBB23_35
+
+LBB23_32:
+	MOVL  R14, AX
+	NOTL  AX
+	ANDL  CX, AX
+	LEAL  0(AX)(AX*1), BX
+	ORL   R14, BX
+	MOVL  BX, DI
+	NOTL  DI
+	ANDL  CX, DI
+	ANDL  $-1431655766, DI
+	XORL  R14, R14
+	ADDL  AX, DI
+	SETCS R14
+	ADDL  DI, DI
+	XORL  $1431655765, DI
+	ANDL  BX, DI
+	NOTL  DI
+	ANDL  DI, DX
+	ORQ   R8, R10
+	TESTQ DX, DX
+	JNE   LBB23_25
 
 LBB23_33:
-	TESTQ DI, DI
-	JE    LBB23_47
-	MOVQ  DI, CX
-	MOVQ  -48(BP), AX
-	NOTQ  AX
-	ADDQ  R12, AX
+	TESTQ R10, R10
+	JNE   LBB23_48
+	ADDQ  $32, SI
+	ADDQ  $-32, R12
+
+LBB23_35:
+	TESTQ R14, R14
+	JNE   LBB23_50
+	MOVQ  -48(BP), R14
+	TESTQ R12, R12
+	JE    LBB23_46
+
+LBB23_37:
+	MOVQ -56(BP), CX
+	NOTQ CX
+
+LBB23_38:
+	LEAQ    1(SI), AX
+	MOVBLZX 0(SI), DX
+	CMPB    DX, $34
+	JE      LBB23_45
+	LEAQ    -1(R12), BX
+	CMPB    DX, $92
+	JE      LBB23_42
+	CMPB    DX, $31
+	JBE     LBB23_52
+	MOVQ    AX, SI
+	MOVQ    BX, R12
+	TESTQ   BX, BX
+	JNE     LBB23_38
+	JMP     LBB23_44
+
+LBB23_42:
+	TESTQ BX, BX
+	JE    LBB23_16
+	ADDQ  CX, AX
 	CMPQ  R13, $-1
 	LONG  $0xe8440f4c // cmoveq       %rax, %r13
-	INCQ  R12
-	DECQ  DI
-	TESTQ DI, DI
-	JNE   LBB23_36
-	JMP   LBB23_44
+	ADDQ  $2, SI
+	ADDQ  $-2, R12
+	MOVQ  R12, BX
+	TESTQ BX, BX
+	JNE   LBB23_38
 
-LBB23_50:
+LBB23_44:
+	CMPB DX, $34
+	JNE  LBB23_16
+	JMP  LBB23_46
+
+LBB23_45:
+	MOVQ AX, SI
+
+LBB23_46:
+	SUBQ -56(BP), SI
+	MOVQ SI, BX
+	JMP  LBB23_13
+
+LBB23_47:
+	MOVQ SI, AX
+	SUBQ -56(BP), AX
+	BSFQ CX, R13
+	ADDQ AX, R13
+	JMP  LBB23_23
+
+LBB23_48:
 	MOVQ $-2, BX
 	CMPQ R13, $-1
-	JNE  LBB23_53
-	ADDQ AX, SI
-	MOVQ SI, R13
-	JMP  LBB23_53
+	JNE  LBB23_19
+	SUBQ -56(BP), SI
+	BSFQ R10, R13
+	JMP  LBB23_29
+
+LBB23_50:
+	TESTQ R12, R12
+	MOVQ  -48(BP), R14
+	JE    LBB23_16
+	MOVQ  -56(BP), AX
+	NOTQ  AX
+	ADDQ  SI, AX
+	CMPQ  R13, $-1
+	LONG  $0xe8440f4c  // cmoveq       %rax, %r13
+	INCQ  SI
+	DECQ  R12
+	TESTQ R12, R12
+	JNE   LBB23_37
+	JMP   LBB23_46
+
+LBB23_52:
+	MOVQ $-2, BX
+	CMPQ R13, $-1
+	JNE  LBB23_19
+	ADDQ CX, AX
+	MOVQ AX, R13
+	MOVQ -48(BP), R14
+	JMP  LBB23_17
 
 _utf8_validate:
-	BYTE  $0x55               // pushq        %rbp
-	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
-	WORD  $0x5641             // pushq        %r14
-	BYTE  $0x53               // pushq        %rbx
+	BYTE  $0x55                                 // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD  $0x5741                               // pushq        %r15
+	WORD  $0x5641                               // pushq        %r14
+	BYTE  $0x53                                 // pushq        %rbx
 	MOVQ  $-1, AX
 	TESTQ SI, SI
-	JLE   LBB24_30
-	MOVQ  DI, R10
+	JLE   LBB24_27
+	LONG  $0x840d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44164(%rip), %r9  /* _first(%rip) */
+	LONG  $0x7d058d4c; WORD $0x00ad; BYTE $0x00 // leaq         $44413(%rip), %r8  /* _ranges(%rip) */
+	LONG  $0x19158d4c; WORD $0x0001; BYTE $0x00 // leaq         $281(%rip), %r10  /* LJTI24_0(%rip) */
+	MOVQ  DI, R14
 
 LBB24_2:
-	CMPB 0(R10), $0
+	CMPB 0(R14), $0
 	JS   LBB24_3
-	MOVQ SI, BX
-	MOVQ R10, CX
-	MOVQ DX, R8
-	CMPQ DX, $16
+	MOVQ SI, DX
+	MOVQ R14, CX
+	CMPQ SI, $16
 	JL   LBB24_5
 
-LBB24_8:
+LBB24_10:
 	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
-	LONG  $0xc8d779c5 // vpmovmskb    %xmm0, %r9d
-	TESTW R9, R9
-	JNE   LBB24_9
+	LONG  $0xd8d7f9c5 // vpmovmskb    %xmm0, %ebx
+	TESTW BX, BX
+	JNE   LBB24_11
 	ADDQ  $16, CX
-	CMPQ  BX, $17
-	LEAQ  -16(BX), BX
-	JL    LBB24_4
-	CMPQ  R8, $31
-	LEAQ  -16(R8), R8
-	JG    LBB24_8
-	JMP   LBB24_4
-
-LBB24_3:
-	XORL R8, R8
-	JMP  LBB24_13
-
-LBB24_9:
-	MOVWLZX R9, BX
-	SUBQ    R10, CX
-	BSFQ    BX, R8
-	ADDQ    CX, R8
-	JMP     LBB24_13
-
-LBB24_4:
-	TESTQ BX, BX
-	JE    LBB24_30
+	CMPQ  DX, $31
+	LEAQ  -16(DX), DX
+	JG    LBB24_10
 
 LBB24_5:
+	TESTQ DX, DX
+	JLE   LBB24_27
+	INCQ  DX
+
+LBB24_7:
 	CMPB 0(CX), $0
 	JS   LBB24_12
-	DECQ BX
 	INCQ CX
-	JMP  LBB24_4
+	DECQ DX
+	CMPQ DX, $1
+	JG   LBB24_7
+	JMP  LBB24_27
+
+LBB24_3:
+	XORL DX, DX
+	CMPQ DX, $-1
+	JNE  LBB24_14
+	JMP  LBB24_27
 
 LBB24_12:
-	SUBQ R10, CX
-	MOVQ CX, R8
+	SUBQ R14, CX
+	MOVQ CX, DX
+	CMPQ DX, $-1
+	JE   LBB24_27
 
-LBB24_13:
-	CMPQ    R8, $-1
-	JE      LBB24_30
-	SUBQ    R8, SI
-	JLE     LBB24_30
-	LEAQ    0(R10)(R8*1), R9
-	CMPQ    SI, $2
-	JB      LBB24_29
-	MOVBLZX 1(R10)(R8*1), R11
-	MOVL    R11, CX
-	ANDL    $-64, CX
-	CMPL    CX, $128
-	JNE     LBB24_29
-	MOVBLZX 0(R9), R14
-	MOVL    R14, CX
-	ANDL    $-32, CX
-	CMPL    CX, $192
-	JE      LBB24_18
-	CMPQ    SI, $3
-	JB      LBB24_29
-	MOVBLZX 2(R10)(R8*1), CX
-	MOVL    CX, BX
-	ANDL    $-64, BX
-	CMPL    BX, $128
-	JNE     LBB24_29
-	CMPB    R14, $-17
+LBB24_14:
+	SUBQ    DX, SI
+	JLE     LBB24_27
+	LEAQ    0(R14)(DX*1), R11
+	MOVBLZX 0(R14)(DX*1), R14
+	MOVBLZX 0(R14)(R9*1), R15
+	MOVL    R15, DX
+	ANDL    $7, DX
+	CMPQ    SI, DX
+	JB      LBB24_25
+	CMPB    DX, $4
 	JA      LBB24_25
-	SHLL    $12, R14
-	MOVWLZX R14, R10
-	ANDL    $63, R11
-	SHLL    $6, R11
-	ANDL    $63, CX
-	ORL     R11, CX
-	LEAL    0(CX)(R10*1), BX
-	MOVL    $3, R11
-	CMPL    BX, $57343
-	JA      LBB24_24
-	LEAL    -2048(R10)(CX*1), CX
-	CMPL    CX, $53248
-	JAE     LBB24_29
-
-LBB24_24:
-	SUBQ R8, DX
-	SUBQ R11, DX
-	ADDQ R11, R9
-	MOVQ R9, R10
-	SUBQ R11, SI
-	JG   LBB24_2
-	JMP  LBB24_30
+	MOVL    $1, BX
+	MOVBLZX DX, CX
+	MOVLQSX 0(R10)(CX*4), CX
+	ADDQ    R10, CX
+	JMP     CX
 
 LBB24_18:
-	MOVL  $2, R11
-	TESTB $30, R14
-	JNE   LBB24_24
-	JMP   LBB24_29
+	MOVB  3(R11), BX
+	TESTB BX, BX
+	JNS   LBB24_25
+	CMPB  BX, $-65
+	JA    LBB24_25
+
+LBB24_20:
+	MOVB  2(R11), BX
+	TESTB BX, BX
+	JNS   LBB24_25
+	CMPB  BX, $-65
+	JA    LBB24_25
+
+LBB24_22:
+	TESTB R14, R14
+	JNS   LBB24_25
+	SHRQ  $4, R15
+	MOVB  1(R11), R14
+	CMPB  R14, 0(R8)(R15*2)
+	JB    LBB24_25
+	MOVQ  DX, BX
+	CMPB  1(R8)(R15*2), R14
+	JB    LBB24_25
+
+LBB24_26:
+	ADDQ BX, R11
+	MOVQ R11, R14
+	SUBQ BX, SI
+	JG   LBB24_2
+	JMP  LBB24_27
+
+LBB24_11:
+	MOVWLZX BX, DX
+	SUBQ    R14, CX
+	BSFQ    DX, DX
+	ADDQ    CX, DX
+	CMPQ    DX, $-1
+	JNE     LBB24_14
+	JMP     LBB24_27
 
 LBB24_25:
-	CMPQ    SI, $4
-	JB      LBB24_29
-	MOVBLZX 3(R10)(R8*1), R10
-	MOVL    R10, BX
-	ANDL    $-64, BX
-	CMPL    BX, $128
-	JNE     LBB24_29
-	CMPB    R14, $-9
-	JA      LBB24_29
-	ANDL    $7, R14
-	SHLL    $18, R14
-	ANDL    $63, R11
-	SHLL    $12, R11
-	ANDL    $63, CX
-	SHLL    $6, CX
-	ORL     R11, CX
-	ANDL    $63, R10
-	ORL     CX, R10
-	LEAL    -65536(R14)(R10*1), CX
-	MOVL    $4, R11
-	CMPL    CX, $1048576
-	JB      LBB24_24
+	SUBQ DI, R11
+	MOVQ R11, AX
 
-LBB24_29:
-	SUBQ DI, R9
-	MOVQ R9, AX
-
-LBB24_30:
+LBB24_27:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
+	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	RET
+
+// .set L24_0_set_26, LBB24_26-LJTI24_0
+// .set L24_0_set_25, LBB24_25-LJTI24_0
+// .set L24_0_set_22, LBB24_22-LJTI24_0
+// .set L24_0_set_20, LBB24_20-LJTI24_0
+// .set L24_0_set_18, LBB24_18-LJTI24_0
+LJTI24_0:
+	LONG $0xffffffc9 // .long L24_0_set_26
+	LONG $0xfffffff3 // .long L24_0_set_25
+	LONG $0xffffffac // .long L24_0_set_22
+	LONG $0xffffff9f // .long L24_0_set_20
+	LONG $0xffffff92 // .long L24_0_set_18
 
 _skip_negative:
 	BYTE  $0x55                   // pushq        %rbp
@@ -6731,57 +6735,47 @@ _validate_one:
 	JMP  _fsm_exec
 
 _find_non_ascii:
-	BYTE  $0x55               // pushq        %rbp
-	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
-	CMPQ  DX, $16
-	JL    LBB29_1
-	TESTQ SI, SI
-	JLE   LBB29_1
-	MOVQ  DI, CX
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	MOVQ DI, CX
+	CMPQ SI, $16
+	JL   LBB29_1
 
-LBB29_8:
+LBB29_6:
 	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
 	LONG  $0xc0d7f9c5 // vpmovmskb    %xmm0, %eax
 	TESTW AX, AX
-	JNE   LBB29_9
-	LEAQ  -16(SI), R8
+	JNE   LBB29_7
 	ADDQ  $16, CX
-	CMPQ  DX, $32
-	JL    LBB29_2
-	ADDQ  $-16, DX
-	CMPQ  SI, $16
-	MOVQ  R8, SI
-	JG    LBB29_8
-	JMP   LBB29_2
+	CMPQ  SI, $31
+	LEAQ  -16(SI), SI
+	JG    LBB29_6
 
 LBB29_1:
-	MOVQ SI, R8
-	MOVQ DI, CX
-
-LBB29_2:
 	MOVQ  $-1, AX
-	TESTQ R8, R8
-	JE    LBB29_13
+	TESTQ SI, SI
+	JLE   LBB29_9
+	INCQ  SI
 
-LBB29_4:
-	CMPB  0(CX), $0
-	JS    LBB29_12
-	DECQ  R8
-	INCQ  CX
-	TESTQ R8, R8
-	JNE   LBB29_4
+LBB29_3:
+	CMPB 0(CX), $0
+	JS   LBB29_8
+	INCQ CX
+	DECQ SI
+	CMPQ SI, $1
+	JG   LBB29_3
 
-LBB29_13:
+LBB29_9:
 	BYTE $0x5d // popq         %rbp
 	RET
 
-LBB29_12:
+LBB29_8:
 	SUBQ DI, CX
 	MOVQ CX, AX
 	BYTE $0x5d  // popq         %rbp
 	RET
 
-LBB29_9:
+LBB29_7:
 	MOVWLZX AX, AX
 	SUBQ    DI, CX
 	BSFQ    AX, AX
@@ -11352,6 +11346,36 @@ _P10_TAB:
 	QUAD $0x444b1ae4d6e2ef50 // .quad 4921056587992461136
 	QUAD $0x4480f0cf064dd592 // .quad 4936209963552724370
 
+_first:
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0x020202020202f1f1; QUAD $0x0202020202020202 // .ascii 16, '\xf1\xf1\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02'
+	QUAD $0x0202020202020202; QUAD $0x0202020202020202 // .ascii 16, '\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02'
+	QUAD $0x0303030303030313; QUAD $0x0303230303030303 // .ascii 16, '\x13\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03#\x03\x03'
+	QUAD $0xf1f1f14404040434; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '4\x04\x04\x04D\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+
+_ranges:
+	BYTE $0x80 // .byte 128
+	BYTE $0xbf // .byte 191
+	BYTE $0xa0 // .byte 160
+	BYTE $0xbf // .byte 191
+	BYTE $0x80 // .byte 128
+	BYTE $0x9f // .byte 159
+	BYTE $0x90 // .byte 144
+	BYTE $0xbf // .byte 191
+	BYTE $0x80 // .byte 128
+	BYTE $0x8f // .byte 143
+
 TEXT ·__f64toa(SB), NOSPLIT | NOFRAME, $0 - 24
 	NO_LOCAL_POINTERS
 
@@ -11597,7 +11621,7 @@ _validate_one:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+20498(SB) // _validate_one
+	CALL ·__native_entry__+20414(SB) // _validate_one
 	MOVQ AX, ret+24(FP)
 	RET
 

--- a/internal/native/avx/native_amd64_test.go
+++ b/internal/native/avx/native_amd64_test.go
@@ -260,6 +260,13 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
 func TestNative_ValidateOne(t *testing.T) {
     {
         p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n\\r\\b\\f😁ſ景\xef\xbf\xbf\xf4\x8f\xbf\xbf\xc2\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\""
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, len(s), p)
+        assert.Equal(t, 0, r)
+    }
+    {
+        p := 0
         s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
         r := __validate_one(&s, &p, &types.StateMachine{})
         assert.Equal(t, 64, p)

--- a/internal/native/avx/native_amd64_test.go
+++ b/internal/native/avx/native_amd64_test.go
@@ -257,6 +257,44 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
     assert.Equal(t, int64(0), v.Iv)
 }
 
+func TestNative_ValidateOne(t *testing.T) {
+    {
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\x00\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\x80\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\xed\xbf\xbf\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+}
+
 func TestNative_VstringHangUpOnRandomData(t *testing.T) {
     v, e := hex.DecodeString(
         "228dc61efd54ef80a908fb6026b7f2d5f92a257ba8b347c995f259eb8685376a" +

--- a/internal/native/avx/native_subr_amd64.go
+++ b/internal/native/avx/native_subr_amd64.go
@@ -20,7 +20,7 @@ var (
     _subr__skip_one     = __native_entry__() + 15444
     _subr__u64toa       = __native_entry__() + 3735
     _subr__unquote      = __native_entry__() + 6005
-    _subr__validate_one = __native_entry__() + 20498
+    _subr__validate_one = __native_entry__() + 20414
     _subr__value        = __native_entry__() + 10806
     _subr__vnumber      = __native_entry__() + 13602
     _subr__vsigned      = __native_entry__() + 14916

--- a/internal/native/avx/native_subr_amd64.go
+++ b/internal/native/avx/native_subr_amd64.go
@@ -9,22 +9,23 @@ package avx
 func __native_entry__() uintptr
 
 var (
-    _subr__f64toa      = __native_entry__() + 630
-    _subr__html_escape = __native_entry__() + 8160
-    _subr__i64toa      = __native_entry__() + 3642
-    _subr__lspace      = __native_entry__() + 301
-    _subr__lzero       = __native_entry__() + 13
-    _subr__quote       = __native_entry__() + 4955
-    _subr__skip_array  = __native_entry__() + 17223
-    _subr__skip_object = __native_entry__() + 17258
-    _subr__skip_one    = __native_entry__() + 15444
-    _subr__u64toa      = __native_entry__() + 3735
-    _subr__unquote     = __native_entry__() + 6005
-    _subr__value       = __native_entry__() + 10806
-    _subr__vnumber     = __native_entry__() + 13602
-    _subr__vsigned     = __native_entry__() + 14916
-    _subr__vstring     = __native_entry__() + 12567
-    _subr__vunsigned   = __native_entry__() + 15175
+    _subr__f64toa       = __native_entry__() + 630
+    _subr__html_escape  = __native_entry__() + 8160
+    _subr__i64toa       = __native_entry__() + 3642
+    _subr__lspace       = __native_entry__() + 301
+    _subr__lzero        = __native_entry__() + 13
+    _subr__quote        = __native_entry__() + 4955
+    _subr__skip_array   = __native_entry__() + 17296
+    _subr__skip_object  = __native_entry__() + 17333
+    _subr__skip_one     = __native_entry__() + 15444
+    _subr__u64toa       = __native_entry__() + 3735
+    _subr__unquote      = __native_entry__() + 6005
+    _subr__validate_one = __native_entry__() + 20498
+    _subr__value        = __native_entry__() + 10806
+    _subr__vnumber      = __native_entry__() + 13602
+    _subr__vsigned      = __native_entry__() + 14916
+    _subr__vstring      = __native_entry__() + 12567
+    _subr__vunsigned    = __native_entry__() + 15175
 )
 
 const (
@@ -34,11 +35,12 @@ const (
     _stack__lspace = 8
     _stack__lzero = 8
     _stack__quote = 80
-    _stack__skip_array = 144
-    _stack__skip_object = 144
-    _stack__skip_one = 144
+    _stack__skip_array = 160
+    _stack__skip_object = 160
+    _stack__skip_one = 160
     _stack__u64toa = 8
     _stack__unquote = 88
+    _stack__validate_one = 160
     _stack__value = 400
     _stack__vnumber = 312
     _stack__vsigned = 16
@@ -58,6 +60,7 @@ var (
     _ = _subr__skip_one
     _ = _subr__u64toa
     _ = _subr__unquote
+    _ = _subr__validate_one
     _ = _subr__value
     _ = _subr__vnumber
     _ = _subr__vsigned
@@ -77,6 +80,7 @@ const (
     _ = _stack__skip_one
     _ = _stack__u64toa
     _ = _stack__unquote
+    _ = _stack__validate_one
     _ = _stack__value
     _ = _stack__vnumber
     _ = _stack__vsigned

--- a/internal/native/avx2/native_amd64.go
+++ b/internal/native/avx2/native_amd64.go
@@ -103,3 +103,8 @@ func __skip_array(s *string, p *int, m *types.StateMachine) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __skip_object(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -350,7 +350,7 @@ LBB2_5:
 	LONG    $0x4fdc6941; WORD $0x1293; BYTE $0x00 // imull        $1217359, %r12d, %ebx
 	MOVQ    R12, AX
 	SHLQ    $4, AX
-	LONG    $0xf00d8d48; WORD $0x0085; BYTE $0x00 // leaq         $34288(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
+	LONG    $0x7a0d8d48; WORD $0x008e; BYTE $0x00 // leaq         $36474(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(AX)(CX*1), R10
@@ -437,7 +437,7 @@ LBB2_12:
 	SHRL    $19, BX
 	MOVLQSX AX, SI
 	SHLQ    $4, SI
-	LONG    $0x1b158d4c; WORD $0x009a; BYTE $0x00 // leaq         $39451(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
+	LONG    $0xa5158d4c; WORD $0x00a2; BYTE $0x00 // leaq         $41637(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(SI)(R10*1), R14
@@ -850,7 +850,7 @@ LBB2_61:
 	LEAQ 1(R13), BX
 	MOVQ BX, SI
 	MOVL R15, DX
-	LONG $0x004f8ee8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x005818e8; BYTE $0x00 // callq        _print_mantissa
 	MOVB 1(R13), AX
 	MOVB AX, 0(R13)
 	MOVL $1, AX
@@ -879,7 +879,7 @@ LBB2_66:
 	LEAL    0(CX)(CX*1), AX
 	LEAL    0(AX)(AX*4), AX
 	SUBL    AX, R14
-	LONG    $0xed058d48; WORD $0x00a8; BYTE $0x00 // leaq         $43245(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0x77058d48; WORD $0x00b1; BYTE $0x00 // leaq         $45431(%rip), %rax  /* _Digits(%rip) */
 	MOVWLZX 0(AX)(CX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -915,7 +915,7 @@ LBB2_70:
 	CMPL    R14, $10
 	JL      LBB2_85
 	MOVLQSX R14, AX
-	LONG    $0x7f0d8d48; WORD $0x00a8; BYTE $0x00 // leaq         $43135(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x090d8d48; WORD $0x00b1; BYTE $0x00 // leaq         $45321(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -934,7 +934,7 @@ LBB2_74:
 	MOVL  BX, SI
 	ADDQ  -64(BP), SI
 	MOVL  R15, DX
-	LONG  $0x004e8ae8; BYTE $0x00 // callq        _print_mantissa
+	LONG  $0x005714e8; BYTE $0x00 // callq        _print_mantissa
 	TESTL R13, R13
 	JE    LBB2_78
 	LEAL  0(R13)(BX*1), AX
@@ -1138,7 +1138,7 @@ LBB2_105:
 	MOVQ R13, SI
 	MOVL R15, DX
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x004b78e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x005402e8; BYTE $0x00 // callq        _print_mantissa
 	ADDL BX, R15
 	MOVL R15, BX
 
@@ -1231,7 +1231,7 @@ _u64toa:
 	ADDQ    AX, AX
 	CMPL    SI, $1000
 	JB      LBB4_3
-	LONG    $0x410d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42049(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0xcb0d8d48; WORD $0x00ac; BYTE $0x00 // leaq         $44235(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(DX)(CX*1), CX
 	MOVB    CX, 0(DI)
 	MOVL    $1, CX
@@ -1245,14 +1245,14 @@ LBB4_3:
 LBB4_4:
 	MOVWLZX DX, DX
 	ORQ     $1, DX
-	LONG    $0x20358d48; WORD $0x00a4; BYTE $0x00 // leaq         $42016(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0xaa358d48; WORD $0x00ac; BYTE $0x00 // leaq         $44202(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(DX)(SI*1), DX
 	MOVL    CX, SI
 	INCL    CX
 	MOVB    DX, 0(DI)(SI*1)
 
 LBB4_6:
-	LONG $0x0f158d48; WORD $0x00a4; BYTE $0x00 // leaq         $41999(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x99158d48; WORD $0x00ac; BYTE $0x00 // leaq         $44185(%rip), %rdx  /* _Digits(%rip) */
 	MOVB 0(AX)(DX*1), DX
 	MOVL CX, SI
 	INCL CX
@@ -1261,7 +1261,7 @@ LBB4_6:
 LBB4_7:
 	MOVWLZX AX, AX
 	ORQ     $1, AX
-	LONG    $0xf7158d48; WORD $0x00a3; BYTE $0x00 // leaq         $41975(%rip), %rdx  /* _Digits(%rip) */
+	LONG    $0x81158d48; WORD $0x00ac; BYTE $0x00 // leaq         $44161(%rip), %rdx  /* _Digits(%rip) */
 	MOVB    0(AX)(DX*1), AX
 	MOVL    CX, DX
 	INCL    CX
@@ -1308,7 +1308,7 @@ LBB4_8:
 	ADDQ    R11, R11
 	CMPL    SI, $10000000
 	JB      LBB4_11
-	LONG    $0x60058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41824(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0xea058d48; WORD $0x00ab; BYTE $0x00 // leaq         $44010(%rip), %rax  /* _Digits(%rip) */
 	MOVB    0(R10)(AX*1), AX
 	MOVB    AX, 0(DI)
 	MOVL    $1, CX
@@ -1322,14 +1322,14 @@ LBB4_11:
 LBB4_12:
 	MOVL R10, AX
 	ORQ  $1, AX
-	LONG $0x3b358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41787(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xc5358d48; WORD $0x00ab; BYTE $0x00 // leaq         $43973(%rip), %rsi  /* _Digits(%rip) */
 	MOVB 0(AX)(SI*1), AX
 	MOVL CX, SI
 	INCL CX
 	MOVB AX, 0(DI)(SI*1)
 
 LBB4_14:
-	LONG $0x2a058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41770(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xb4058d48; WORD $0x00ab; BYTE $0x00 // leaq         $43956(%rip), %rax  /* _Digits(%rip) */
 	MOVB 0(R9)(AX*1), AX
 	MOVL CX, SI
 	INCL CX
@@ -1338,7 +1338,7 @@ LBB4_14:
 LBB4_15:
 	MOVWLZX R9, AX
 	ORQ     $1, AX
-	LONG    $0x10358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41744(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0x9a358d48; WORD $0x00ab; BYTE $0x00 // leaq         $43930(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(AX)(SI*1), AX
 	MOVL    CX, DX
 	MOVB    AX, 0(DX)(DI*1)
@@ -1420,7 +1420,7 @@ LBB4_16:
 	MOVL $16, CX
 	SUBL AX, CX
 	SHLQ $4, AX
-	LONG $0x83158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41603(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x0d158d48; WORD $0x00ab; BYTE $0x00 // leaq         $43789(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	MOVL CX, AX
@@ -1446,7 +1446,7 @@ LBB4_20:
 	CMPL DX, $99
 	JA   LBB4_22
 	MOVL DX, AX
-	LONG $0x660d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41318(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xf00d8d48; WORD $0x00a9; BYTE $0x00 // leaq         $43504(%rip), %rcx  /* _Digits(%rip) */
 	MOVB 0(CX)(AX*2), DX
 	MOVB 1(CX)(AX*2), AX
 	MOVB DX, 0(DI)
@@ -1471,7 +1471,7 @@ LBB4_22:
 	WORD    $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	SUBL    CX, AX
 	MOVWLZX AX, AX
-	LONG    $0x150d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41237(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x9f0d8d48; WORD $0x00a9; BYTE $0x00 // leaq         $43423(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(CX)(AX*2), DX
 	MOVB    1(CX)(AX*2), AX
 	MOVB    DX, 1(DI)
@@ -1483,7 +1483,7 @@ LBB4_24:
 	WORD    $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	SUBL    CX, DX
 	MOVWLZX AX, AX
-	LONG    $0xf2058d4c; WORD $0x00a0; BYTE $0x00 // leaq         $41202(%rip), %r8  /* _Digits(%rip) */
+	LONG    $0x7c058d4c; WORD $0x00a9; BYTE $0x00 // leaq         $43388(%rip), %r8  /* _Digits(%rip) */
 	MOVB    0(R8)(AX*2), CX
 	MOVB    1(R8)(AX*2), AX
 	MOVB    CX, 0(DI)
@@ -1580,8 +1580,8 @@ _quote:
 	SUBQ  $16, SP
 	MOVQ  CX, R15
 	TESTB $1, R8
-	LONG  $0x92058d48; WORD $0x00a0; BYTE $0x00 // leaq         $41106(%rip), %rax  /* __SingleQuoteTab(%rip) */
-	LONG  $0x8b158d4c; WORD $0x00b0; BYTE $0x00 // leaq         $45195(%rip), %r10  /* __DoubleQuoteTab(%rip) */
+	LONG  $0x1c058d48; WORD $0x00a9; BYTE $0x00 // leaq         $43292(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG  $0x15158d4c; WORD $0x00b9; BYTE $0x00 // leaq         $47381(%rip), %r10  /* __DoubleQuoteTab(%rip) */
 	LONG  $0xd0440f4c                           // cmoveq       %rax, %r10
 	MOVQ  DX, R8
 	MOVQ  DI, AX
@@ -1790,7 +1790,7 @@ LBB5_25:
 LBB5_26:
 	TESTQ BX, BX
 	MOVQ  -48(BP), R15
-	LONG  $0x560d8d4c; WORD $0x009d; BYTE $0x00 // leaq         $40278(%rip), %r9  /* __SingleQuoteTab(%rip) */
+	LONG  $0xe00d8d4c; WORD $0x00a5; BYTE $0x00 // leaq         $42464(%rip), %r9  /* __SingleQuoteTab(%rip) */
 	JLE   LBB5_31
 	TESTQ SI, SI
 	JLE   LBB5_31
@@ -2289,7 +2289,7 @@ LBB6_24:
 LBB6_26:
 	ADDQ    BX, AX
 	MOVBLZX -1(R9), CX
-	LONG    $0x221d8d48; WORD $0x00b8; BYTE $0x00 // leaq         $47138(%rip), %rbx  /* __UnquoteTab(%rip) */
+	LONG    $0xac1d8d48; WORD $0x00c0; BYTE $0x00 // leaq         $49324(%rip), %rbx  /* __UnquoteTab(%rip) */
 	MOVB    0(CX)(BX*1), BX
 	CMPB    BX, $-1
 	JE      LBB6_29
@@ -2877,7 +2877,7 @@ _html_escape:
 	QUAD  $0xffffff260d6f7ec5                   // vmovdqu      $-218(%rip), %ymm9  /* LCPI7_1(%rip) */
 	QUAD  $0xffffff3e156f7ec5                   // vmovdqu      $-194(%rip), %ymm10  /* LCPI7_2(%rip) */
 	QUAD  $0xffffff56356ffec5                   // vmovdqu      $-170(%rip), %ymm6  /* LCPI7_3(%rip) */
-	LONG  $0xf11d8d4c; WORD $0x00b0; BYTE $0x00 // leaq         $45297(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x7b1d8d4c; WORD $0x00b9; BYTE $0x00 // leaq         $47483(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	MOVQ  DI, AX
 	MOVQ  -48(BP), R12
 	JMP   LBB7_2
@@ -3094,7 +3094,7 @@ LBB7_50:
 	NEGQ  SI
 	SBBQ  R9, R9
 	XORQ  R13, R9
-	LONG  $0xc71d8d4c; WORD $0x00ad; BYTE $0x00 // leaq         $44487(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x511d8d4c; WORD $0x00b6; BYTE $0x00 // leaq         $46673(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3130,7 +3130,7 @@ LBB7_34:
 	SUBQ  AX, R9
 	ADDQ  R13, R9
 	NOTQ  R9
-	LONG  $0x6c1d8d4c; WORD $0x00ad; BYTE $0x00 // leaq         $44396(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0xf61d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46582(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3140,7 +3140,7 @@ LBB7_40:
 	SUBQ    AX, R13
 	BSFL    CX, R9
 	ADDQ    R13, R9
-	LONG    $0x4a1d8d4c; WORD $0x00ad; BYTE $0x00 // leaq         $44362(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG    $0xd41d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46548(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ   R9, R9
 	JNS     LBB7_78
 	JMP     LBB7_77
@@ -3178,7 +3178,7 @@ LBB7_22:
 
 LBB7_74:
 	MOVQ  R13, R9
-	LONG  $0xf71d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44279(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x811d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46465(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3228,7 +3228,7 @@ LBB7_52:
 	LEAQ 8(R13), R9
 	ADDQ $8, R8
 	LEAQ -8(R15), SI
-	LONG $0x551d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44117(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0xdf1d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46303(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	CMPQ SI, $4
 	JAE  LBB7_56
 	JMP  LBB7_57
@@ -3262,7 +3262,7 @@ LBB7_71:
 	ADDQ  R13, R11
 	NOTQ  R11
 	MOVQ  R11, R9
-	LONG  $0x061d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44038(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x901d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46224(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3274,7 +3274,7 @@ LBB7_73:
 LBB7_53:
 	MOVQ R13, R9
 	MOVQ R15, SI
-	LONG $0xe71d8d4c; WORD $0x00ab; BYTE $0x00 // leaq         $44007(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x711d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46193(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	CMPQ SI, $4
 	JB   LBB7_57
 
@@ -3438,7 +3438,7 @@ LBB8_5:
 	SHLQ CX, DI
 	MOVL AX, CX
 	SHLQ $4, CX
-	LONG $0x5a3d8d4c; WORD $0x0032; BYTE $0x00 // leaq         $12890(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0xe43d8d4c; WORD $0x003a; BYTE $0x00 // leaq         $15076(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	MOVQ DI, AX
 	MULQ 8(CX)(R15*1)
 	MOVQ AX, R11
@@ -3570,14 +3570,14 @@ LBB9_5:
 	MOVQ  R13, -48(BP)
 	JLE   LBB9_20
 	XORL  R15, R15
-	LONG  $0x492d8d4c; WORD $0x005c; BYTE $0x00 // leaq         $23625(%rip), %r13  /* _POW_TAB(%rip) */
+	LONG  $0xd32d8d4c; WORD $0x0064; BYTE $0x00 // leaq         $25811(%rip), %r13  /* _POW_TAB(%rip) */
 	JMP   LBB9_9
 
 LBB9_7:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x002f66e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0037f0e8; BYTE $0x00 // callq        _right_shift
 
 LBB9_8:
 	ADDL  R14, R15
@@ -3607,7 +3607,7 @@ LBB9_11:
 LBB9_15:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002f1ee8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0037a8e8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3621,7 +3621,7 @@ LBB9_16:
 LBB9_17:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002d90e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x00361ae8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3633,16 +3633,16 @@ LBB9_18:
 
 LBB9_19:
 	MOVQ R12, DI
-	LONG $0x002d7ae8; BYTE $0x00 // callq        _left_shift
+	LONG $0x003604e8; BYTE $0x00 // callq        _left_shift
 	JMP  LBB9_8
 
 LBB9_20:
-	LONG $0xb5358d4c; WORD $0x005b; BYTE $0x00 // leaq         $23477(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x3f358d4c; WORD $0x0064; BYTE $0x00 // leaq         $25663(%rip), %r14  /* _POW_TAB(%rip) */
 	JMP  LBB9_23
 
 LBB9_21:
 	MOVQ R12, DI
-	LONG $0x002d67e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x0035f1e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_22:
 	SUBL R13, R15
@@ -3682,7 +3682,7 @@ LBB9_28:
 LBB9_33:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002d0ce8; BYTE $0x00 // callq        _left_shift
+	LONG $0x003596e8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3697,7 +3697,7 @@ LBB9_34:
 LBB9_35:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002e59e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0036e3e8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3707,7 +3707,7 @@ LBB9_36:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x002e43e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0036cde8; BYTE $0x00 // callq        _right_shift
 	JMP  LBB9_22
 
 LBB9_37:
@@ -3724,7 +3724,7 @@ LBB9_37:
 LBB9_41:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x002e02e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x00368ce8; BYTE $0x00 // callq        _right_shift
 	ADDL $60, R15
 	CMPL R15, $-120
 	JL   LBB9_41
@@ -3751,7 +3751,7 @@ LBB9_47:
 	NEGL R15
 	MOVQ R12, DI
 	MOVL R15, SI
-	LONG $0x002db2e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x00363ce8; BYTE $0x00 // callq        _right_shift
 	MOVL $-1022, R14
 
 LBB9_48:
@@ -3759,7 +3759,7 @@ LBB9_48:
 	JE   LBB9_50
 	MOVQ R12, DI
 	MOVL $53, SI
-	LONG $0x002c28e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x0034b2e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_50:
 	MOVLQSX 20(R12), R10
@@ -5467,7 +5467,7 @@ LBB14_71:
 	CMPL    DI, $23
 	JL      LBB14_81
 	MOVLQSX DI, AX
-	LONG    $0x710d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $47985(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0xfb0d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50171(%rip), %rcx  /* _P10_TAB(%rip) */
 	QUAD    $0xffff50c18459fbc5; BYTE $0xff       // vmulsd       $-176(%rcx,%rax,8), %xmm0, %xmm0
 	LONG    $0x4511fbc5; BYTE $0xd0               // vmovsd       %xmm0, $-48(%rbp)
 	MOVL    $22, AX
@@ -5485,7 +5485,7 @@ LBB14_77:
 	JB      LBB14_60
 	NEGL    DI
 	MOVLQSX DI, AX
-	LONG    $0x2f0d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $47919(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0xb90d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50105(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG    $0x045efbc5; BYTE $0xc1               // vdivsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP     LBB14_65
 
@@ -5517,7 +5517,7 @@ LBB14_82:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	JA   LBB14_60
 	MOVL AX, AX
-	LONG $0xb60d8d48; WORD $0x00ba; BYTE $0x00 // leaq         $47798(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x400d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $49984(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP  LBB14_65
 
@@ -5790,6 +5790,7 @@ _skip_one:
 	MOVQ DI, SI
 	MOVQ $1, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -5832,41 +5833,42 @@ _fsm_exec:
 	SUBQ $24, SP
 	CMPL 0(DI), $0
 	JE   LBB18_2
-	MOVQ DX, R15
-	MOVQ SI, R10
-	MOVQ DI, R13
+	MOVQ DX, R11
+	MOVQ SI, BX
+	MOVQ DI, R12
+	MOVL CX, -52(BP)
 	MOVQ $-1, R14
-	MOVQ $4294977024, R11
-	QUAD $0xffffff081d6ffec5 // vmovdqu      $-248(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD $0xffffff20256ffec5 // vmovdqu      $-224(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD $0xffffff382d6ffec5 // vmovdqu      $-200(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD $0xffffff50356ffec5 // vmovdqu      $-176(%rip), %ymm6  /* LCPI18_3(%rip) */
+	MOVQ $4294977024, R8
+	QUAD $0xffffff051d6ffec5 // vmovdqu      $-251(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD $0xffffff1d256ffec5 // vmovdqu      $-227(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD $0xffffff352d6ffec5 // vmovdqu      $-203(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD $0xffffff4d356ffec5 // vmovdqu      $-179(%rip), %ymm6  /* LCPI18_3(%rip) */
 	MOVQ SI, -48(BP)
 	JMP  LBB18_4
 
 LBB18_2:
-	MOVQ $-1, BX
-	JMP  LBB18_111
+	MOVQ $-1, R13
+	JMP  LBB18_122
 
 LBB18_3:
 	LEAQ  3(AX), CX
-	MOVQ  CX, 0(R15)
+	MOVQ  CX, 0(R11)
 	TESTQ AX, AX
-	JLE   LBB18_115
+	JLE   LBB18_118
 
-LBB18_89:
-	MOVL  0(R13), AX
-	MOVQ  R14, BX
+LBB18_94:
+	MOVL  0(R12), AX
+	MOVQ  R14, R13
 	TESTL AX, AX
-	JE    LBB18_111
+	JE    LBB18_122
 
 LBB18_4:
-	MOVQ 0(R15), SI
-	MOVQ 0(R10), R8
-	MOVQ 8(R10), R9
-	CMPQ SI, R9
+	MOVQ 0(R11), SI
+	MOVQ 0(BX), R9
+	MOVQ 8(BX), R10
+	CMPQ SI, R10
 	JAE  LBB18_8
-	MOVB 0(R8)(SI*1), CX
+	MOVB 0(R9)(SI*1), CX
 	CMPB CX, $13
 	JE   LBB18_8
 	CMPB CX, $32
@@ -5877,9 +5879,9 @@ LBB18_4:
 
 LBB18_8:
 	LEAQ 1(SI), DX
-	CMPQ DX, R9
+	CMPQ DX, R10
 	JAE  LBB18_13
-	MOVB 0(R8)(DX*1), CX
+	MOVB 0(R9)(DX*1), CX
 	CMPB CX, $13
 	JE   LBB18_13
 	CMPB CX, $32
@@ -5890,9 +5892,9 @@ LBB18_8:
 
 LBB18_13:
 	LEAQ 2(SI), DX
-	CMPQ DX, R9
+	CMPQ DX, R10
 	JAE  LBB18_18
-	MOVB 0(R8)(DX*1), CX
+	MOVB 0(R9)(DX*1), CX
 	CMPB CX, $13
 	JE   LBB18_18
 	CMPB CX, $32
@@ -5903,9 +5905,9 @@ LBB18_13:
 
 LBB18_18:
 	LEAQ 3(SI), DX
-	CMPQ DX, R9
+	CMPQ DX, R10
 	JAE  LBB18_23
-	MOVB 0(R8)(DX*1), CX
+	MOVB 0(R9)(DX*1), CX
 	CMPB CX, $13
 	JE   LBB18_23
 	CMPB CX, $32
@@ -5920,18 +5922,18 @@ LBB18_12:
 
 LBB18_23:
 	LEAQ  4(SI), CX
-	CMPQ  R9, CX
+	CMPQ  R10, CX
 	JBE   LBB18_48
-	LEAQ  0(R8)(CX*1), DI
-	MOVQ  R9, DX
+	LEAQ  0(R9)(CX*1), DI
+	MOVQ  R10, DX
 	SUBQ  CX, DX
 	JE    LBB18_32
 	MOVL  DI, CX
 	ANDL  $31, CX
 	TESTQ CX, CX
 	JE    LBB18_32
-	LEAQ  0(R8)(SI*1), DI
-	MOVQ  R9, DX
+	LEAQ  0(R9)(SI*1), DI
+	MOVQ  R10, DX
 	SUBQ  SI, DX
 	LEAQ  -5(DX), SI
 	XORL  BX, BX
@@ -5939,9 +5941,9 @@ LBB18_23:
 LBB18_27:
 	MOVBLSX 4(DI)(BX*1), CX
 	CMPL    CX, $32
-	JA      LBB18_50
-	BTQ     CX, R11
-	JAE     LBB18_50
+	JA      LBB18_51
+	BTQ     CX, R8
+	JAE     LBB18_51
 	LEAQ    1(BX), CX
 	CMPQ    SI, BX
 	JE      LBB18_31
@@ -5955,6 +5957,7 @@ LBB18_31:
 	LEAQ 4(CX)(DI*1), DI
 	SUBQ CX, DX
 	ADDQ $-4, DX
+	MOVQ -48(BP), BX
 
 LBB18_32:
 	CMPQ DX, $32
@@ -5962,7 +5965,7 @@ LBB18_32:
 	LEAQ -32(DX), SI
 	MOVQ SI, CX
 	ANDQ $-32, CX
-	LEAQ 32(CX)(DI*1), BX
+	LEAQ 32(CX)(DI*1), R8
 	ANDL $31, SI
 
 LBB18_34:
@@ -5982,413 +5985,474 @@ LBB18_34:
 	CMPQ DX, $31
 	JA   LBB18_34
 	MOVQ SI, DX
-	MOVQ BX, DI
+	MOVQ R8, DI
 
 LBB18_37:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	CMPQ DX, $16
-	JB   LBB18_105
+	JB   LBB18_111
 	LEAQ -16(DX), SI
 	MOVQ SI, AX
 	ANDQ $-16, AX
-	LEAQ 16(AX)(DI*1), BX
+	LEAQ 16(AX)(DI*1), R8
 	ANDL $15, SI
-	QUAD $0xfffffd3f1d6ffec5 // vmovdqu      $-705(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD $0xfffffd57256ffec5 // vmovdqu      $-681(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD $0xfffffd6f2d6ffec5 // vmovdqu      $-657(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD $0xfffffd87356ffec5 // vmovdqu      $-633(%rip), %ymm6  /* LCPI18_3(%rip) */
+	QUAD $0xfffffd381d6ffec5 // vmovdqu      $-712(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD $0xfffffd50256ffec5 // vmovdqu      $-688(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD $0xfffffd682d6ffec5 // vmovdqu      $-664(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD $0xfffffd80356ffec5 // vmovdqu      $-640(%rip), %ymm6  /* LCPI18_3(%rip) */
 
 LBB18_39:
 	LONG  $0x076ff9c5         // vmovdqa      (%rdi), %xmm0
-	QUAD  $0xfffffd9b0d74f9c5 // vpcmpeqb     $-613(%rip), %xmm0, %xmm1  /* LCPI18_4(%rip) */
-	QUAD  $0xfffffda31574f9c5 // vpcmpeqb     $-605(%rip), %xmm0, %xmm2  /* LCPI18_5(%rip) */
+	QUAD  $0xfffffd940d74f9c5 // vpcmpeqb     $-620(%rip), %xmm0, %xmm1  /* LCPI18_4(%rip) */
+	QUAD  $0xfffffd9c1574f9c5 // vpcmpeqb     $-612(%rip), %xmm0, %xmm2  /* LCPI18_5(%rip) */
 	LONG  $0xcaebf1c5         // vpor         %xmm2, %xmm1, %xmm1
-	QUAD  $0xfffffda71574f9c5 // vpcmpeqb     $-601(%rip), %xmm0, %xmm2  /* LCPI18_6(%rip) */
-	QUAD  $0xfffffdaf0574f9c5 // vpcmpeqb     $-593(%rip), %xmm0, %xmm0  /* LCPI18_7(%rip) */
+	QUAD  $0xfffffda01574f9c5 // vpcmpeqb     $-608(%rip), %xmm0, %xmm2  /* LCPI18_6(%rip) */
+	QUAD  $0xfffffda80574f9c5 // vpcmpeqb     $-600(%rip), %xmm0, %xmm0  /* LCPI18_7(%rip) */
 	LONG  $0xc2ebf9c5         // vpor         %xmm2, %xmm0, %xmm0
 	LONG  $0xc1ebf9c5         // vpor         %xmm1, %xmm0, %xmm0
 	LONG  $0xc8d7f9c5         // vpmovmskb    %xmm0, %ecx
 	CMPW  CX, $-1
-	JNE   LBB18_103
+	JNE   LBB18_54
 	ADDQ  $16, DI
 	ADDQ  $-16, DX
 	CMPQ  DX, $15
 	JA    LBB18_39
 	MOVQ  SI, DX
-	MOVQ  BX, DI
+	MOVQ  R8, DI
 	TESTQ DX, DX
 	JE    LBB18_47
 
 LBB18_42:
-	LEAQ 0(DI)(DX*1), BX
+	LEAQ 0(DI)(DX*1), R8
 	INCQ DI
 	MOVQ DI, SI
 
 LBB18_43:
 	MOVBLSX -1(SI), CX
 	CMPL    CX, $32
-	JA      LBB18_104
-	BTQ     CX, R11
-	JAE     LBB18_104
+	JA      LBB18_55
+	MOVQ    $4294977024, AX
+	BTQ     CX, AX
+	JAE     LBB18_55
 	DECQ    DX
 	INCQ    SI
 	TESTQ   DX, DX
 	JNE     LBB18_43
-	MOVQ    BX, DI
+	MOVQ    R8, DI
 
 LBB18_47:
-	SUBQ R8, DI
+	MOVQ $4294977024, R8
+	SUBQ R9, DI
 	MOVQ DI, SI
-	JMP  LBB18_51
+	CMPQ SI, R10
+	JB   LBB18_52
+	JMP  LBB18_56
 
 LBB18_48:
-	MOVQ CX, 0(R15)
-	JMP  LBB18_54
+	MOVQ CX, 0(R11)
+	JMP  LBB18_56
 
 LBB18_49:
 	WORD    $0xf8c5; BYTE $0x77 // vzeroupper
-	QUAD    $0xfffffce9356ffec5 // vmovdqu      $-791(%rip), %ymm6  /* LCPI18_3(%rip) */
-	QUAD    $0xfffffcc12d6ffec5 // vmovdqu      $-831(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD    $0xfffffc99256ffec5 // vmovdqu      $-871(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD    $0xfffffc711d6ffec5 // vmovdqu      $-911(%rip), %ymm3  /* LCPI18_0(%rip) */
-	SUBQ    R8, DI
+	QUAD    $0xfffffcc9356ffec5 // vmovdqu      $-823(%rip), %ymm6  /* LCPI18_3(%rip) */
+	QUAD    $0xfffffca12d6ffec5 // vmovdqu      $-863(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD    $0xfffffc79256ffec5 // vmovdqu      $-903(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD    $0xfffffc511d6ffec5 // vmovdqu      $-943(%rip), %ymm3  /* LCPI18_0(%rip) */
+	SUBQ    R9, DI
 	NOTL    CX
 	MOVLQSX CX, AX
 	BSFQ    AX, SI
-	ADDQ    DI, SI
-	JMP     LBB18_51
 
 LBB18_50:
-	ADDQ BX, DI
-	NOTQ R8
-	LEAQ 5(R8)(DI*1), SI
+	ADDQ DI, SI
+	MOVQ $4294977024, R8
+	CMPQ SI, R10
+	JAE  LBB18_56
 
-LBB18_51:
-	CMPQ SI, R9
-	JAE  LBB18_54
-	MOVQ 0(R10), R8
+LBB18_52:
+	MOVQ 0(BX), R9
 
 LBB18_53:
 	LEAQ 1(SI), AX
-	MOVQ AX, 0(R15)
-	MOVB 0(R8)(SI*1), DX
-	JMP  LBB18_55
+	MOVQ AX, 0(R11)
+	MOVB 0(R9)(SI*1), DX
+	JMP  LBB18_57
 
-LBB18_54:
+LBB18_51:
+	ADDQ BX, DI
+	NOTQ R9
+	LEAQ 5(R9)(DI*1), SI
+	MOVQ -48(BP), BX
+	CMPQ SI, R10
+	JB   LBB18_52
+
+LBB18_56:
 	XORL DX, DX
 
-LBB18_55:
-	MOVLQSX 0(R13), CX
+LBB18_57:
+	MOVLQSX 0(R12), CX
 	LEAQ    -1(CX), AX
-	MOVL    0(R13)(CX*4), SI
+	MOVL    0(R12)(CX*4), SI
 	CMPQ    R14, $-1
-	JNE     LBB18_57
-	MOVQ    0(R15), R14
+	JNE     LBB18_59
+	MOVQ    0(R11), R14
 	DECQ    R14
 
-LBB18_57:
+LBB18_59:
 	DECL    SI
 	CMPL    SI, $5
-	JA      LBB18_62
-	LONG    $0x1b3d8d48; WORD $0x0005; BYTE $0x00 // leaq         $1307(%rip), %rdi  /* LJTI18_0(%rip) */
+	JA      LBB18_64
+	LONG    $0xdc3d8d48; WORD $0x0005; BYTE $0x00 // leaq         $1500(%rip), %rdi  /* LJTI18_0(%rip) */
 	MOVLQSX 0(DI)(SI*4), SI
 	ADDQ    DI, SI
 	JMP     SI
 
-LBB18_59:
-	MOVBLSX DX, DX
-	CMPL    DX, $44
-	JE      LBB18_81
-	CMPL    DX, $93
-	JNE     LBB18_110
-	MOVL    AX, 0(R13)
-	MOVQ    R14, BX
-	TESTL   AX, AX
-	JNE     LBB18_4
-	JMP     LBB18_111
-
-LBB18_62:
-	MOVL    AX, 0(R13)
-	MOVBLSX DX, AX
-	CMPL    AX, $123
-	JBE     LBB18_78
-	JMP     LBB18_110
-
-LBB18_63:
+LBB18_61:
 	MOVBLSX DX, DX
 	CMPL    DX, $44
 	JE      LBB18_83
-	CMPL    DX, $125
-	JNE     LBB18_110
-	MOVL    AX, 0(R13)
-	MOVQ    R14, BX
+	CMPL    DX, $93
+	JNE     LBB18_121
+	MOVL    AX, 0(R12)
+	MOVQ    R14, R13
 	TESTL   AX, AX
 	JNE     LBB18_4
-	JMP     LBB18_111
+	JMP     LBB18_122
 
-LBB18_66:
-	CMPB DX, $34
-	JNE  LBB18_110
-	MOVL $4, 0(R13)(CX*4)
-
-LBB18_68:
-	MOVQ  0(R15), R12
-	MOVQ  R10, DI
-	MOVQ  R12, SI
-	LEAQ  -56(BP), DX
-	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG  $0xfff173e8; BYTE $0xff // callq        _advance_string
-	MOVQ  AX, BX
-	TESTQ AX, AX
-	JS    LBB18_106
-	MOVQ  BX, 0(R15)
-	TESTQ R12, R12
-	MOVQ  -48(BP), R10
-	MOVQ  $4294977024, R11
-	QUAD  $0xfffffb581d6ffec5     // vmovdqu      $-1192(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD  $0xfffffb70256ffec5     // vmovdqu      $-1168(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD  $0xfffffb882d6ffec5     // vmovdqu      $-1144(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD  $0xfffffba0356ffec5     // vmovdqu      $-1120(%rip), %ymm6  /* LCPI18_3(%rip) */
-	JG    LBB18_89
-	JMP   LBB18_107
-
-LBB18_70:
-	CMPB DX, $58
-	JNE  LBB18_110
-	MOVL $0, 0(R13)(CX*4)
-	JMP  LBB18_89
-
-LBB18_72:
-	CMPB  DX, $93
-	JNE   LBB18_77
-	MOVL  AX, 0(R13)
-	MOVQ  R14, BX
-	TESTL AX, AX
-	JNE   LBB18_4
-	JMP   LBB18_111
-
-LBB18_74:
-	MOVBLSX DX, DX
-	CMPL    DX, $34
-	JE      LBB18_85
-	CMPL    DX, $125
-	JNE     LBB18_110
-	MOVL    AX, 0(R13)
-	MOVQ    R14, BX
-	TESTL   AX, AX
-	JNE     LBB18_4
-	JMP     LBB18_111
-
-LBB18_77:
-	MOVL    $1, 0(R13)(CX*4)
+LBB18_64:
+	MOVL    AX, 0(R12)
 	MOVBLSX DX, AX
 	CMPL    AX, $123
-	JA      LBB18_110
+	JBE     LBB18_80
+	JMP     LBB18_121
 
-LBB18_78:
-	MOVQ    $-1, BX
-	LONG    $0xd50d8d48; WORD $0x0003; BYTE $0x00 // leaq         $981(%rip), %rcx  /* LJTI18_1(%rip) */
+LBB18_65:
+	MOVBLSX DX, DX
+	CMPL    DX, $44
+	JE      LBB18_85
+	CMPL    DX, $125
+	JNE     LBB18_121
+	MOVL    AX, 0(R12)
+	MOVQ    R14, R13
+	TESTL   AX, AX
+	JNE     LBB18_4
+	JMP     LBB18_122
+
+LBB18_68:
+	CMPB DX, $34
+	JNE  LBB18_121
+	MOVL $4, 0(R12)(CX*4)
+
+LBB18_70:
+	MOVQ  0(R11), R15
+	MOVQ  BX, DI
+	MOVQ  R15, SI
+	LEAQ  -64(BP), DX
+	MOVQ  R11, BX
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0xfff13fe8; BYTE $0xff // callq        _advance_string
+	MOVQ  AX, R13
+	TESTQ AX, AX
+	JS    LBB18_112
+	MOVQ  R13, 0(BX)
+	TESTQ R15, R15
+	MOVQ  BX, R11
+	MOVQ  -48(BP), BX
+	MOVQ  $4294977024, R8
+	QUAD  $0xfffffb231d6ffec5     // vmovdqu      $-1245(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD  $0xfffffb3b256ffec5     // vmovdqu      $-1221(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD  $0xfffffb532d6ffec5     // vmovdqu      $-1197(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD  $0xfffffb6b356ffec5     // vmovdqu      $-1173(%rip), %ymm6  /* LCPI18_3(%rip) */
+	JG    LBB18_94
+	JMP   LBB18_113
+
+LBB18_72:
+	CMPB DX, $58
+	JNE  LBB18_121
+	MOVL $0, 0(R12)(CX*4)
+	JMP  LBB18_94
+
+LBB18_74:
+	CMPB  DX, $93
+	JNE   LBB18_79
+	MOVL  AX, 0(R12)
+	MOVQ  R14, R13
+	TESTL AX, AX
+	JNE   LBB18_4
+	JMP   LBB18_122
+
+LBB18_76:
+	MOVBLSX DX, DX
+	CMPL    DX, $34
+	JE      LBB18_87
+	CMPL    DX, $125
+	JNE     LBB18_121
+	MOVL    AX, 0(R12)
+	MOVQ    R14, R13
+	TESTL   AX, AX
+	JNE     LBB18_4
+	JMP     LBB18_122
+
+LBB18_79:
+	MOVL    $1, 0(R12)(CX*4)
+	MOVBLSX DX, AX
+	CMPL    AX, $123
+	JA      LBB18_121
+
+LBB18_80:
+	MOVQ    $-1, R13
+	LONG    $0x930d8d48; WORD $0x0004; BYTE $0x00 // leaq         $1171(%rip), %rcx  /* LJTI18_1(%rip) */
 	MOVLQSX 0(CX)(AX*4), AX
 	ADDQ    CX, AX
 	JMP     AX
 
-LBB18_79:
-	MOVQ  0(R15), R12
-	LEAQ  -1(R12), BX
-	MOVQ  0(R10), DI
-	ADDQ  BX, DI
-	MOVQ  8(R10), SI
-	SUBQ  BX, SI
-	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG  $0x0007c3e8; BYTE $0x00 // callq        _skip_number
-	TESTQ AX, AX
-	JS    LBB18_108
-	MOVQ  0(R15), CX
-	LEAQ  -1(AX)(CX*1), AX
-	MOVQ  AX, 0(R15)
-	TESTQ R12, R12
-	MOVQ  -48(BP), R10
-	MOVQ  $4294977024, R11
-	QUAD  $0xfffffa661d6ffec5     // vmovdqu      $-1434(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD  $0xfffffa7e256ffec5     // vmovdqu      $-1410(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD  $0xfffffa962d6ffec5     // vmovdqu      $-1386(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD  $0xfffffaae356ffec5     // vmovdqu      $-1362(%rip), %ymm6  /* LCPI18_3(%rip) */
-	JG    LBB18_89
-	JMP   LBB18_111
-
 LBB18_81:
-	CMPL CX, $65535
-	JG   LBB18_112
-	LEAL 1(CX), AX
-	MOVL AX, 0(R13)
-	MOVL $0, 4(R13)(CX*4)
-	JMP  LBB18_89
+	MOVQ  0(R11), R15
+	LEAQ  -1(R15), R13
+	MOVQ  0(BX), DI
+	ADDQ  R13, DI
+	MOVQ  8(BX), SI
+	SUBQ  R13, SI
+	MOVQ  R11, BX
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0x000f38e8; BYTE $0x00 // callq        _skip_number
+	TESTQ AX, AX
+	JS    LBB18_114
+	MOVQ  0(BX), CX
+	LEAQ  -1(AX)(CX*1), AX
+	MOVQ  AX, 0(BX)
+	TESTQ R15, R15
+	MOVQ  BX, R11
+	MOVQ  -48(BP), BX
+	MOVQ  $4294977024, R8
+	QUAD  $0xfffffa2e1d6ffec5     // vmovdqu      $-1490(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD  $0xfffffa46256ffec5     // vmovdqu      $-1466(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD  $0xfffffa5e2d6ffec5     // vmovdqu      $-1442(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD  $0xfffffa76356ffec5     // vmovdqu      $-1418(%rip), %ymm6  /* LCPI18_3(%rip) */
+	JG    LBB18_94
+	JMP   LBB18_122
 
 LBB18_83:
 	CMPL CX, $65535
-	JG   LBB18_112
+	JG   LBB18_115
 	LEAL 1(CX), AX
-	MOVL AX, 0(R13)
-	MOVL $3, 4(R13)(CX*4)
-	JMP  LBB18_89
+	MOVL AX, 0(R12)
+	MOVL $0, 4(R12)(CX*4)
+	JMP  LBB18_94
 
 LBB18_85:
-	MOVL    $2, 0(R13)(CX*4)
-	MOVQ    0(R15), R12
-	MOVQ    R10, DI
-	MOVQ    R12, SI
-	LEAQ    -56(BP), DX
-	WORD    $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG    $0xffefd6e8; BYTE $0xff // callq        _advance_string
-	MOVQ    AX, BX
-	TESTQ   AX, AX
-	JS      LBB18_106
-	MOVQ    BX, 0(R15)
-	TESTQ   R12, R12
-	JLE     LBB18_107
-	MOVLQSX 0(R13), AX
-	CMPQ    AX, $65535
-	JG      LBB18_112
-	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $4, 4(R13)(AX*4)
-	MOVQ    -48(BP), R10
-	MOVQ    $4294977024, R11
-	QUAD    $0xfffff9951d6ffec5     // vmovdqu      $-1643(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD    $0xfffff9ad256ffec5     // vmovdqu      $-1619(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD    $0xfffff9c52d6ffec5     // vmovdqu      $-1595(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD    $0xfffff9dd356ffec5     // vmovdqu      $-1571(%rip), %ymm6  /* LCPI18_3(%rip) */
-	JMP     LBB18_89
+	CMPL CX, $65535
+	JG   LBB18_115
+	LEAL 1(CX), AX
+	MOVL AX, 0(R12)
+	MOVL $3, 4(R12)(CX*4)
+	JMP  LBB18_94
 
-LBB18_90:
-	MOVQ  0(R15), BX
-	MOVQ  0(R10), DI
-	ADDQ  BX, DI
-	MOVQ  8(R10), SI
-	SUBQ  BX, SI
+LBB18_87:
+	MOVL  $2, 0(R12)(CX*4)
+	MOVL  -52(BP), AX
+	CMPL  AX, $1
+	JE    LBB18_91
+	TESTL AX, AX
+	JNE   LBB18_92
+	MOVQ  0(R11), R15
+	MOVQ  BX, DI
+	MOVQ  R15, SI
+	LEAQ  -64(BP), DX
+	MOVQ  R11, BX
 	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG  $0x000690e8; BYTE $0x00 // callq        _skip_number
-	MOVQ  0(R15), CX
+	LONG  $0xffef8ee8; BYTE $0xff // callq        _advance_string
+	MOVQ  AX, R13
 	TESTQ AX, AX
-	JS    LBB18_116
-	ADDQ  AX, CX
-	MOVQ  CX, 0(R15)
-	TESTQ BX, BX
-	MOVQ  -48(BP), R10
-	MOVQ  $4294977024, R11
-	QUAD  $0xfffff9351d6ffec5     // vmovdqu      $-1739(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD  $0xfffff94d256ffec5     // vmovdqu      $-1715(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD  $0xfffff9652d6ffec5     // vmovdqu      $-1691(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD  $0xfffff97d356ffec5     // vmovdqu      $-1667(%rip), %ymm6  /* LCPI18_3(%rip) */
-	JG    LBB18_89
-	JMP   LBB18_122
+	JS    LBB18_112
+	MOVQ  R13, 0(BX)
+	TESTQ R15, R15
+	MOVQ  BX, R11
+	MOVQ  -48(BP), BX
+	JG    LBB18_92
+	JMP   LBB18_113
+
+LBB18_91:
+	MOVQ  BX, DI
+	MOVQ  R11, SI
+	MOVQ  R11, BX
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0x000654e8; BYTE $0x00 // callq        _validate_string
+	MOVQ  BX, R11
+	MOVQ  -48(BP), BX
+	TESTQ AX, AX
+	JS    LBB18_119
 
 LBB18_92:
-	MOVLQSX 0(R13), AX
+	MOVLQSX 0(R12), AX
 	CMPQ    AX, $65535
-	JG      LBB18_112
+	JG      LBB18_115
 	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $5, 4(R13)(AX*4)
-	JMP     LBB18_89
+	MOVL    CX, 0(R12)
+	MOVL    $4, 4(R12)(AX*4)
+	MOVQ    $4294977024, R8
+	QUAD    $0xfffff92a1d6ffec5 // vmovdqu      $-1750(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD    $0xfffff942256ffec5 // vmovdqu      $-1726(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD    $0xfffff95a2d6ffec5 // vmovdqu      $-1702(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD    $0xfffff972356ffec5 // vmovdqu      $-1678(%rip), %ymm6  /* LCPI18_3(%rip) */
+	JMP     LBB18_94
 
-LBB18_94:
-	MOVQ  0(R15), AX
-	MOVQ  8(R10), CX
-	LEAQ  -4(CX), DX
-	CMPQ  AX, DX
-	JA    LBB18_119
-	MOVQ  0(R10), CX
-	MOVL  0(CX)(AX*1), DX
-	CMPL  DX, $1702063201
-	JNE   LBB18_123
-	LEAQ  4(AX), CX
-	MOVQ  CX, 0(R15)
-	TESTQ AX, AX
-	JG    LBB18_89
-	JMP   LBB18_115
+LBB18_95:
+	MOVL  -52(BP), AX
+	CMPL  AX, $1
+	JE    LBB18_110
+	TESTL AX, AX
+	JE    LBB18_70
+	JMP   LBB18_94
 
 LBB18_97:
-	MOVQ 0(R15), AX
-	MOVQ 8(R10), CX
-	LEAQ -3(CX), DX
-	CMPQ AX, DX
-	JA   LBB18_119
-	MOVQ 0(R10), CX
-	CMPL -1(CX)(AX*1), $1819047278
-	JE   LBB18_3
-	JMP  LBB18_126
+	MOVQ  0(R11), R13
+	MOVQ  0(BX), DI
+	ADDQ  R13, DI
+	MOVQ  8(BX), SI
+	SUBQ  R13, SI
+	MOVQ  R11, BX
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0x000db3e8; BYTE $0x00 // callq        _skip_number
+	MOVQ  BX, R11
+	MOVQ  0(BX), CX
+	TESTQ AX, AX
+	JS    LBB18_120
+	ADDQ  AX, CX
+	MOVQ  CX, 0(R11)
+	TESTQ R13, R13
+	MOVQ  -48(BP), BX
+	MOVQ  $4294977024, R8
+	QUAD  $0xfffff8ab1d6ffec5     // vmovdqu      $-1877(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD  $0xfffff8c3256ffec5     // vmovdqu      $-1853(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD  $0xfffff8db2d6ffec5     // vmovdqu      $-1829(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD  $0xfffff8f3356ffec5     // vmovdqu      $-1805(%rip), %ymm6  /* LCPI18_3(%rip) */
+	JG    LBB18_94
+	JMP   LBB18_128
 
 LBB18_99:
-	MOVQ 0(R15), AX
-	MOVQ 8(R10), CX
-	LEAQ -3(CX), DX
-	CMPQ AX, DX
-	JA   LBB18_119
-	MOVQ 0(R10), CX
-	CMPL -1(CX)(AX*1), $1702195828
-	JE   LBB18_3
-	JMP  LBB18_129
+	MOVLQSX 0(R12), AX
+	CMPQ    AX, $65535
+	JG      LBB18_115
+	LEAL    1(AX), CX
+	MOVL    CX, 0(R12)
+	MOVL    $5, 4(R12)(AX*4)
+	JMP     LBB18_94
 
 LBB18_101:
-	MOVLQSX 0(R13), AX
-	CMPQ    AX, $65535
-	JG      LBB18_112
-	LEAL    1(AX), CX
-	MOVL    CX, 0(R13)
-	MOVL    $6, 4(R13)(AX*4)
-	JMP     LBB18_89
-
-LBB18_103:
-	MOVWLZX CX, AX
-	SUBQ    R8, DI
-	NOTL    AX
-	BSFL    AX, SI
-	ADDQ    DI, SI
-	JMP     LBB18_51
+	MOVQ  0(R11), AX
+	MOVQ  8(BX), CX
+	LEAQ  -4(CX), DX
+	CMPQ  AX, DX
+	JA    LBB18_125
+	MOVQ  0(BX), CX
+	MOVL  0(CX)(AX*1), DX
+	CMPL  DX, $1702063201
+	JNE   LBB18_129
+	LEAQ  4(AX), CX
+	MOVQ  CX, 0(R11)
+	TESTQ AX, AX
+	JG    LBB18_94
+	JMP   LBB18_118
 
 LBB18_104:
-	NOTQ R8
-	ADDQ R8, SI
-	JMP  LBB18_51
+	MOVQ 0(R11), AX
+	MOVQ 8(BX), CX
+	LEAQ -3(CX), DX
+	CMPQ AX, DX
+	JA   LBB18_125
+	MOVQ 0(BX), CX
+	CMPL -1(CX)(AX*1), $1819047278
+	JE   LBB18_3
+	JMP  LBB18_132
 
-LBB18_105:
-	QUAD  $0xfffff8171d6ffec5 // vmovdqu      $-2025(%rip), %ymm3  /* LCPI18_0(%rip) */
-	QUAD  $0xfffff82f256ffec5 // vmovdqu      $-2001(%rip), %ymm4  /* LCPI18_1(%rip) */
-	QUAD  $0xfffff8472d6ffec5 // vmovdqu      $-1977(%rip), %ymm5  /* LCPI18_2(%rip) */
-	QUAD  $0xfffff85f356ffec5 // vmovdqu      $-1953(%rip), %ymm6  /* LCPI18_3(%rip) */
+LBB18_106:
+	MOVQ 0(R11), AX
+	MOVQ 8(BX), CX
+	LEAQ -3(CX), DX
+	CMPQ AX, DX
+	JA   LBB18_125
+	MOVQ 0(BX), CX
+	CMPL -1(CX)(AX*1), $1702195828
+	JE   LBB18_3
+	JMP  LBB18_135
+
+LBB18_108:
+	MOVLQSX 0(R12), AX
+	CMPQ    AX, $65535
+	JG      LBB18_115
+	LEAL    1(AX), CX
+	MOVL    CX, 0(R12)
+	MOVL    $6, 4(R12)(AX*4)
+	JMP     LBB18_94
+
+LBB18_54:
+	MOVWLZX CX, AX
+	SUBQ    R9, DI
+	NOTL    AX
+	BSFL    AX, SI
+	JMP     LBB18_50
+
+LBB18_110:
+	MOVQ  BX, DI
+	MOVQ  R11, SI
+	MOVQ  R11, BX
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0x000476e8; BYTE $0x00 // callq        _validate_string
+	QUAD  $0xfffff7e6356ffec5     // vmovdqu      $-2074(%rip), %ymm6  /* LCPI18_3(%rip) */
+	QUAD  $0xfffff7be2d6ffec5     // vmovdqu      $-2114(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD  $0xfffff796256ffec5     // vmovdqu      $-2154(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD  $0xfffff76e1d6ffec5     // vmovdqu      $-2194(%rip), %ymm3  /* LCPI18_0(%rip) */
+	MOVQ  $4294977024, R8
+	MOVQ  BX, R11
+	MOVQ  -48(BP), BX
+	TESTQ AX, AX
+	JNS   LBB18_94
+	JMP   LBB18_119
+
+LBB18_55:
+	NOTQ R9
+	ADDQ R9, SI
+	MOVQ $4294977024, R8
+	CMPQ SI, R10
+	JB   LBB18_52
+	JMP  LBB18_56
+
+LBB18_111:
+	QUAD  $0xfffff7291d6ffec5 // vmovdqu      $-2263(%rip), %ymm3  /* LCPI18_0(%rip) */
+	QUAD  $0xfffff741256ffec5 // vmovdqu      $-2239(%rip), %ymm4  /* LCPI18_1(%rip) */
+	QUAD  $0xfffff7592d6ffec5 // vmovdqu      $-2215(%rip), %ymm5  /* LCPI18_2(%rip) */
+	QUAD  $0xfffff771356ffec5 // vmovdqu      $-2191(%rip), %ymm6  /* LCPI18_3(%rip) */
 	TESTQ DX, DX
 	JNE   LBB18_42
 	JMP   LBB18_47
 
-LBB18_112:
-	MOVQ $-7, BX
-	JMP  LBB18_111
+LBB18_115:
+	MOVQ $-7, R13
+	JMP  LBB18_122
 
-LBB18_106:
+LBB18_112:
 	MOVQ -48(BP), AX
 	MOVQ 8(AX), AX
-	MOVQ AX, 0(R15)
-	JMP  LBB18_111
+	MOVQ AX, 0(BX)
+	JMP  LBB18_122
 
-LBB18_107:
-	DECQ R12
-	MOVQ R12, BX
-	JMP  LBB18_111
+LBB18_113:
+	DECQ R15
+	MOVQ R15, R13
+	JMP  LBB18_122
 
-LBB18_108:
-	MOVQ 0(R15), CX
+LBB18_114:
+	MOVQ 0(BX), CX
 	SUBQ AX, CX
 	ADDQ $-2, CX
+	MOVQ CX, 0(BX)
 
-LBB18_109:
-	MOVQ CX, 0(R15)
+LBB18_121:
+	MOVQ $-2, R13
 
-LBB18_110:
-	MOVQ $-2, BX
-
-LBB18_111:
-	MOVQ BX, AX
+LBB18_122:
+	MOVQ R13, AX
 	ADDQ $24, SP
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
@@ -6399,226 +6463,229 @@ LBB18_111:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	RET
 
-LBB18_119:
-	MOVQ CX, 0(R15)
-	JMP  LBB18_111
+LBB18_125:
+	MOVQ CX, 0(R11)
+	JMP  LBB18_122
 
-LBB18_115:
+LBB18_118:
 	DECQ AX
-	MOVQ AX, BX
-	JMP  LBB18_111
 
-LBB18_116:
+LBB18_119:
+	MOVQ AX, R13
+	JMP  LBB18_122
+
+LBB18_120:
 	NOTQ AX
 	ADDQ AX, CX
-	JMP  LBB18_109
+	MOVQ CX, 0(R11)
+	JMP  LBB18_121
 
-LBB18_122:
-	DECQ BX
-	JMP  LBB18_111
+LBB18_128:
+	DECQ R13
+	JMP  LBB18_122
 
-LBB18_123:
-	MOVQ $-2, BX
+LBB18_129:
+	MOVQ $-2, R13
 	CMPB DX, $97
-	JNE  LBB18_111
+	JNE  LBB18_122
 	INCQ AX
 	MOVL $1702063201, DX
 
-LBB18_125:
-	SHRL    $8, DX
-	MOVQ    AX, 0(R15)
-	MOVBLSX 0(CX)(AX*1), SI
-	MOVBLZX DX, DI
-	INCQ    AX
-	CMPL    DI, SI
-	JE      LBB18_125
-	JMP     LBB18_111
-
-LBB18_126:
-	LEAQ -1(AX), DX
-	MOVQ DX, 0(R15)
-	MOVQ $-2, BX
-	CMPB -1(CX)(AX*1), $110
-	JNE  LBB18_111
-	MOVL $1819047278, DX
-
-LBB18_128:
-	SHRL    $8, DX
-	MOVQ    AX, 0(R15)
-	MOVBLSX 0(CX)(AX*1), SI
-	MOVBLZX DX, DI
-	INCQ    AX
-	CMPL    DI, SI
-	JE      LBB18_128
-	JMP     LBB18_111
-
-LBB18_129:
-	LEAQ -1(AX), DX
-	MOVQ DX, 0(R15)
-	MOVQ $-2, BX
-	CMPB -1(CX)(AX*1), $116
-	JNE  LBB18_111
-	MOVL $1702195828, DX
-
 LBB18_131:
 	SHRL    $8, DX
-	MOVQ    AX, 0(R15)
+	MOVQ    AX, 0(R11)
 	MOVBLSX 0(CX)(AX*1), SI
 	MOVBLZX DX, DI
 	INCQ    AX
 	CMPL    DI, SI
 	JE      LBB18_131
-	JMP     LBB18_111
+	JMP     LBB18_122
 
-// .set L18_0_set_59, LBB18_59-LJTI18_0
-// .set L18_0_set_63, LBB18_63-LJTI18_0
-// .set L18_0_set_66, LBB18_66-LJTI18_0
-// .set L18_0_set_70, LBB18_70-LJTI18_0
+LBB18_132:
+	LEAQ -1(AX), DX
+	MOVQ DX, 0(R11)
+	MOVQ $-2, R13
+	CMPB -1(CX)(AX*1), $110
+	JNE  LBB18_122
+	MOVL $1819047278, DX
+
+LBB18_134:
+	SHRL    $8, DX
+	MOVQ    AX, 0(R11)
+	MOVBLSX 0(CX)(AX*1), SI
+	MOVBLZX DX, DI
+	INCQ    AX
+	CMPL    DI, SI
+	JE      LBB18_134
+	JMP     LBB18_122
+
+LBB18_135:
+	LEAQ -1(AX), DX
+	MOVQ DX, 0(R11)
+	MOVQ $-2, R13
+	CMPB -1(CX)(AX*1), $116
+	JNE  LBB18_122
+	MOVL $1702195828, DX
+
+LBB18_137:
+	SHRL    $8, DX
+	MOVQ    AX, 0(R11)
+	MOVBLSX 0(CX)(AX*1), SI
+	MOVBLZX DX, DI
+	INCQ    AX
+	CMPL    DI, SI
+	JE      LBB18_137
+	JMP     LBB18_122
+
+// .set L18_0_set_61, LBB18_61-LJTI18_0
+// .set L18_0_set_65, LBB18_65-LJTI18_0
+// .set L18_0_set_68, LBB18_68-LJTI18_0
 // .set L18_0_set_72, LBB18_72-LJTI18_0
 // .set L18_0_set_74, LBB18_74-LJTI18_0
+// .set L18_0_set_76, LBB18_76-LJTI18_0
 LJTI18_0:
-	LONG $0xfffffaee // .long L18_0_set_59
-	LONG $0xfffffb2c // .long L18_0_set_63
-	LONG $0xfffffb55 // .long L18_0_set_66
-	LONG $0xfffffbc7 // .long L18_0_set_70
-	LONG $0xfffffbde // .long L18_0_set_72
-	LONG $0xfffffbf7 // .long L18_0_set_74
+	LONG $0xfffffa2d // .long L18_0_set_61
+	LONG $0xfffffa6b // .long L18_0_set_65
+	LONG $0xfffffa94 // .long L18_0_set_68
+	LONG $0xfffffb0b // .long L18_0_set_72
+	LONG $0xfffffb21 // .long L18_0_set_74
+	LONG $0xfffffb3a // .long L18_0_set_76
 
-	// .set L18_1_set_111, LBB18_111-LJTI18_1
-	// .set L18_1_set_110, LBB18_110-LJTI18_1
-	// .set L18_1_set_68, LBB18_68-LJTI18_1
-	// .set L18_1_set_90, LBB18_90-LJTI18_1
-	// .set L18_1_set_79, LBB18_79-LJTI18_1
-	// .set L18_1_set_92, LBB18_92-LJTI18_1
-	// .set L18_1_set_94, LBB18_94-LJTI18_1
+	// .set L18_1_set_122, LBB18_122-LJTI18_1
+	// .set L18_1_set_121, LBB18_121-LJTI18_1
+	// .set L18_1_set_95, LBB18_95-LJTI18_1
 	// .set L18_1_set_97, LBB18_97-LJTI18_1
+	// .set L18_1_set_81, LBB18_81-LJTI18_1
 	// .set L18_1_set_99, LBB18_99-LJTI18_1
 	// .set L18_1_set_101, LBB18_101-LJTI18_1
+	// .set L18_1_set_104, LBB18_104-LJTI18_1
+	// .set L18_1_set_106, LBB18_106-LJTI18_1
+	// .set L18_1_set_108, LBB18_108-LJTI18_1
 LJTI18_1:
-	LONG $0xffffff25 // .long L18_1_set_111
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffb4f // .long L18_1_set_68
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffd6c // .long L18_1_set_90
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xfffffc34 // .long L18_1_set_79
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffdd2 // .long L18_1_set_92
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffdf7 // .long L18_1_set_94
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffe32 // .long L18_1_set_97
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffe5c // .long L18_1_set_99
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xffffff1e // .long L18_1_set_110
-	LONG $0xfffffe86 // .long L18_1_set_101
+	LONG $0xffffff22 // .long L18_1_set_122
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffce6 // .long L18_1_set_95
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffcff // .long L18_1_set_97
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xfffffb76 // .long L18_1_set_81
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffd6b // .long L18_1_set_99
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffd90 // .long L18_1_set_101
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffdcb // .long L18_1_set_104
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffdf5 // .long L18_1_set_106
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xffffff1b // .long L18_1_set_121
+	LONG $0xfffffe1f // .long L18_1_set_108
 
 _skip_array:
 	BYTE $0x55               // pushq        %rbp
@@ -6629,6 +6696,7 @@ _skip_array:
 	MOVQ $21474836481, CX
 	MOVQ CX, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -6641,6 +6709,7 @@ _skip_object:
 	MOVQ $25769803777, CX
 	MOVQ CX, 0(AX)
 	MOVQ AX, DI
+	XORL CX, CX
 	BYTE $0x5d               // popq         %rbp
 	JMP  _fsm_exec
 
@@ -6656,7 +6725,7 @@ _skip_string:
 	MOVQ  0(SI), BX
 	LEAQ  -32(BP), DX
 	MOVQ  BX, SI
-	LONG  $0xffea82e8; BYTE $0xff // callq        _advance_string
+	LONG  $0xffe98be8; BYTE $0xff // callq        _advance_string
 	TESTQ AX, AX
 	JS    LBB21_2
 	DECQ  BX
@@ -6676,6 +6745,553 @@ LBB21_3:
 	BYTE $0x5d      // popq         %rbp
 	RET
 
+LCPI22_0:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI22_1:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+LCPI22_2:
+	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
+	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
+
+_validate_string:
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	WORD $0x5741             // pushq        %r15
+	WORD $0x5641             // pushq        %r14
+	WORD $0x5541             // pushq        %r13
+	WORD $0x5441             // pushq        %r12
+	BYTE $0x53               // pushq        %rbx
+	SUBQ $40, SP
+	MOVQ SI, R14
+	MOVQ 0(SI), R15
+	MOVQ 8(DI), DX
+	MOVQ DX, -72(BP)
+	SUBQ R15, DX
+	JE   LBB22_18
+	MOVQ R14, -48(BP)
+	MOVQ 0(DI), AX
+	MOVQ AX, -56(BP)
+	LEAQ 0(AX)(R15*1), BX
+	CMPQ DX, $64
+	MOVQ BX, -80(BP)
+	JB   LBB22_25
+	MOVL DX, R12
+	ANDL $63, R12
+	MOVQ $-1, AX
+	XORL R13, R13
+	QUAD $0xffffff42056ffec5 // vmovdqu      $-190(%rip), %ymm0  /* LCPI22_0(%rip) */
+	QUAD $0xffffff5a0d6ffec5 // vmovdqu      $-166(%rip), %ymm1  /* LCPI22_1(%rip) */
+	QUAD $0xffffff72156ffec5 // vmovdqu      $-142(%rip), %ymm2  /* LCPI22_2(%rip) */
+	LONG $0xdb76e5c5         // vpcmpeqd     %ymm3, %ymm3, %ymm3
+	MOVQ DX, CX
+
+LBB22_3:
+	LONG  $0x236ffec5             // vmovdqu      (%rbx), %ymm4
+	LONG  $0x6b6ffec5; BYTE $0x20 // vmovdqu      $32(%rbx), %ymm5
+	LONG  $0xf074ddc5             // vpcmpeqb     %ymm0, %ymm4, %ymm6
+	LONG  $0xf6d77dc5             // vpmovmskb    %ymm6, %r14d
+	LONG  $0xf074d5c5             // vpcmpeqb     %ymm0, %ymm5, %ymm6
+	LONG  $0xd6d77dc5             // vpmovmskb    %ymm6, %r10d
+	LONG  $0xf174ddc5             // vpcmpeqb     %ymm1, %ymm4, %ymm6
+	LONG  $0xc6d77dc5             // vpmovmskb    %ymm6, %r8d
+	LONG  $0xf174d5c5             // vpcmpeqb     %ymm1, %ymm5, %ymm6
+	LONG  $0xced77dc5             // vpmovmskb    %ymm6, %r9d
+	LONG  $0xf464edc5             // vpcmpgtb     %ymm4, %ymm2, %ymm6
+	LONG  $0xe364ddc5             // vpcmpgtb     %ymm3, %ymm4, %ymm4
+	LONG  $0xe6dbddc5             // vpand        %ymm6, %ymm4, %ymm4
+	LONG  $0xdcd77dc5             // vpmovmskb    %ymm4, %r11d
+	LONG  $0xe564edc5             // vpcmpgtb     %ymm5, %ymm2, %ymm4
+	LONG  $0xeb64d5c5             // vpcmpgtb     %ymm3, %ymm5, %ymm5
+	LONG  $0xe4dbd5c5             // vpand        %ymm4, %ymm5, %ymm4
+	LONG  $0xf4d7fdc5             // vpmovmskb    %ymm4, %esi
+	SHLQ  $32, R10
+	SHLQ  $32, R9
+	ORQ   R9, R8
+	CMPQ  AX, $-1
+	JNE   LBB22_5
+	TESTQ R8, R8
+	JNE   LBB22_10
+
+LBB22_5:
+	SHLQ  $32, SI
+	ORQ   R14, R10
+	MOVQ  R8, DI
+	ORQ   R13, DI
+	JNE   LBB22_9
+	ORQ   R11, SI
+	TESTQ R10, R10
+	JNE   LBB22_11
+
+LBB22_7:
+	TESTQ SI, SI
+	JNE   LBB22_21
+	ADDQ  $64, BX
+	ADDQ  $-64, CX
+	CMPQ  CX, $63
+	JA    LBB22_3
+	JMP   LBB22_26
+
+LBB22_9:
+	MOVQ  R13, R14
+	NOTQ  R14
+	ANDQ  R8, R14
+	LEAQ  0(R14)(R14*1), R9
+	ORQ   R13, R9
+	MOVQ  R9, -64(BP)
+	NOTQ  R9
+	ANDQ  R8, R9
+	MOVQ  $-6148914691236517206, DI
+	ANDQ  DI, R9
+	XORL  R13, R13
+	ADDQ  R14, R9
+	SETCS R13
+	ADDQ  R9, R9
+	MOVQ  $6148914691236517205, DI
+	XORQ  DI, R9
+	ANDQ  -64(BP), R9
+	NOTQ  R9
+	ANDQ  R9, R10
+	ORQ   R11, SI
+	TESTQ R10, R10
+	JE    LBB22_7
+	JMP   LBB22_11
+
+LBB22_10:
+	MOVQ BX, R9
+	SUBQ -56(BP), R9
+	BSFQ R8, AX
+	ADDQ R9, AX
+	JMP  LBB22_5
+
+LBB22_11:
+	SUBQ  -56(BP), BX
+	BSFQ  R10, CX
+	LEAQ  1(BX)(CX*1), R12
+	TESTQ SI, SI
+	MOVQ  -48(BP), R14
+	JE    LBB22_13
+	BSFQ  SI, SI
+	CMPQ  SI, CX
+	JBE   LBB22_34
+
+LBB22_13:
+	TESTQ R12, R12
+	JS    LBB22_17
+	MOVQ  R15, SI
+	NOTQ  SI
+	ADDQ  R12, SI
+	MOVQ  -80(BP), DI
+	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
+	LONG  $0x00026ee8; BYTE $0x00 // callq        _utf8_validate
+	TESTQ AX, AX
+	JS    LBB22_19
+	ADDQ  0(R14), AX
+
+LBB22_16:
+	MOVQ $-2, R12
+	JMP  LBB22_20
+
+LBB22_17:
+	CMPQ R12, $-1
+	JNE  LBB22_20
+
+LBB22_18:
+	MOVQ $-1, R12
+	MOVQ -72(BP), AX
+	JMP  LBB22_20
+
+LBB22_19:
+	DECQ R15
+	MOVQ R12, AX
+	MOVQ R15, R12
+
+LBB22_20:
+	MOVQ AX, 0(R14)
+	MOVQ R12, AX
+	ADDQ $40, SP
+	BYTE $0x5b               // popq         %rbx
+	WORD $0x5c41             // popq         %r12
+	WORD $0x5d41             // popq         %r13
+	WORD $0x5e41             // popq         %r14
+	WORD $0x5f41             // popq         %r15
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	RET
+
+LBB22_21:
+	MOVQ $-2, R12
+	CMPQ AX, $-1
+	JE   LBB22_23
+
+LBB22_22:
+	MOVQ -48(BP), R14
+	JMP  LBB22_20
+
+LBB22_23:
+	SUBQ -56(BP), BX
+	BSFQ SI, AX
+
+LBB22_24:
+	ADDQ BX, AX
+	MOVQ -48(BP), R14
+	JMP  LBB22_20
+
+LBB22_25:
+	MOVQ $-1, AX
+	XORL R13, R13
+	MOVQ DX, R12
+
+LBB22_26:
+	CMPQ  R12, $32
+	JB    LBB22_40
+	LONG  $0x036ffec5         // vmovdqu      (%rbx), %ymm0
+	QUAD  $0xfffffd5c0d74fdc5 // vpcmpeqb     $-676(%rip), %ymm0, %ymm1  /* LCPI22_0(%rip) */
+	LONG  $0xf1d7fdc5         // vpmovmskb    %ymm1, %esi
+	QUAD  $0xfffffd700d74fdc5 // vpcmpeqb     $-656(%rip), %ymm0, %ymm1  /* LCPI22_1(%rip) */
+	LONG  $0xc9d7fdc5         // vpmovmskb    %ymm1, %ecx
+	QUAD  $0xfffffd840d6ffec5 // vmovdqu      $-636(%rip), %ymm1  /* LCPI22_2(%rip) */
+	LONG  $0xc864f5c5         // vpcmpgtb     %ymm0, %ymm1, %ymm1
+	LONG  $0xd276edc5         // vpcmpeqd     %ymm2, %ymm2, %ymm2
+	LONG  $0xc264fdc5         // vpcmpgtb     %ymm2, %ymm0, %ymm0
+	LONG  $0xc1dbfdc5         // vpand        %ymm1, %ymm0, %ymm0
+	LONG  $0xc0d77dc5         // vpmovmskb    %ymm0, %r8d
+	TESTL CX, CX
+	JNE   LBB22_35
+	TESTQ R13, R13
+	JNE   LBB22_37
+	XORL  R13, R13
+	TESTQ SI, SI
+	JE    LBB22_38
+
+LBB22_30:
+	SUBQ  -56(BP), BX
+	BSFQ  SI, SI
+	LEAQ  1(BX)(SI*1), R12
+	TESTL R8, R8
+	JE    LBB22_33
+	BSFQ  R8, CX
+	CMPQ  CX, SI
+	MOVQ  -48(BP), R14
+	JA    LBB22_13
+	ADDQ  BX, CX
+	CMPQ  AX, $-1
+	LONG  $0xc1440f48      // cmoveq       %rcx, %rax
+	JMP   LBB22_16
+
+LBB22_33:
+	MOVQ -48(BP), R14
+	JMP  LBB22_13
+
+LBB22_34:
+	ADDQ BX, SI
+	CMPQ AX, $-1
+	LONG $0xc6440f48 // cmoveq       %rsi, %rax
+	JMP  LBB22_16
+
+LBB22_35:
+	CMPQ AX, $-1
+	JNE  LBB22_37
+	MOVQ BX, DI
+	SUBQ -56(BP), DI
+	BSFQ CX, AX
+	ADDQ DI, AX
+
+LBB22_37:
+	MOVL  R13, R10
+	NOTL  R10
+	ANDL  CX, R10
+	LEAL  0(R10)(R10*1), R9
+	ORL   R13, R9
+	MOVL  R9, DI
+	NOTL  DI
+	ANDL  CX, DI
+	ANDL  $-1431655766, DI
+	XORL  R13, R13
+	ADDL  R10, DI
+	SETCS R13
+	ADDL  DI, DI
+	XORL  $1431655765, DI
+	ANDL  R9, DI
+	NOTL  DI
+	ANDL  DI, SI
+	TESTQ SI, SI
+	JNE   LBB22_30
+
+LBB22_38:
+	TESTL R8, R8
+	JNE   LBB22_52
+	ADDQ  $32, BX
+	ADDQ  $-32, R12
+
+LBB22_40:
+	TESTQ R13, R13
+	JNE   LBB22_54
+	MOVQ  -48(BP), R14
+	TESTQ R12, R12
+	JE    LBB22_51
+
+LBB22_42:
+	MOVQ -56(BP), R8
+	NOTQ R8
+
+LBB22_43:
+	LEAQ    1(BX), SI
+	MOVBLZX 0(BX), CX
+	CMPB    CX, $34
+	JE      LBB22_50
+	LEAQ    -1(R12), R10
+	CMPB    CX, $92
+	JE      LBB22_47
+	CMPB    CX, $31
+	JBE     LBB22_56
+	MOVQ    SI, BX
+	MOVQ    R10, R12
+	TESTQ   R10, R10
+	JNE     LBB22_43
+	JMP     LBB22_49
+
+LBB22_47:
+	TESTQ R10, R10
+	JE    LBB22_18
+	ADDQ  R8, SI
+	CMPQ  AX, $-1
+	LONG  $0xc6440f48 // cmoveq       %rsi, %rax
+	ADDQ  $2, BX
+	ADDQ  $-2, R12
+	MOVQ  R12, R10
+	TESTQ R10, R10
+	JNE   LBB22_43
+
+LBB22_49:
+	CMPB CX, $34
+	JNE  LBB22_18
+	JMP  LBB22_51
+
+LBB22_50:
+	MOVQ SI, BX
+
+LBB22_51:
+	SUBQ -56(BP), BX
+	MOVQ BX, R12
+	JMP  LBB22_13
+
+LBB22_52:
+	MOVQ $-2, R12
+	CMPQ AX, $-1
+	JNE  LBB22_22
+	SUBQ -56(BP), BX
+	BSFQ R8, AX
+	JMP  LBB22_24
+
+LBB22_54:
+	TESTQ R12, R12
+	MOVQ  -48(BP), R14
+	JE    LBB22_18
+	MOVQ  -56(BP), CX
+	NOTQ  CX
+	ADDQ  BX, CX
+	CMPQ  AX, $-1
+	LONG  $0xc1440f48  // cmoveq       %rcx, %rax
+	INCQ  BX
+	DECQ  R12
+	TESTQ R12, R12
+	JNE   LBB22_42
+	JMP   LBB22_51
+
+LBB22_56:
+	MOVQ $-2, R12
+	CMPQ AX, $-1
+	JNE  LBB22_22
+	ADDQ R8, SI
+	MOVQ SI, AX
+	MOVQ -48(BP), R14
+	JMP  LBB22_20
+
+_utf8_validate:
+	BYTE  $0x55               // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	WORD  $0x5641             // pushq        %r14
+	BYTE  $0x53               // pushq        %rbx
+	MOVQ  $-1, AX
+	TESTQ SI, SI
+	JLE   LBB23_38
+	MOVQ  DI, R9
+
+LBB23_2:
+	CMPB 0(R9), $0
+	JS   LBB23_3
+	MOVQ DX, R8
+	MOVQ SI, CX
+	MOVQ R9, R10
+	CMPQ DX, $32
+	JL   LBB23_11
+	MOVQ R9, R10
+	MOVQ SI, CX
+	MOVQ DX, R11
+
+LBB23_6:
+	LONG  $0x6f7ec1c4; BYTE $0x02 // vmovdqu      (%r10), %ymm0
+	LONG  $0xd8d7fdc5             // vpmovmskb    %ymm0, %ebx
+	TESTL BX, BX
+	JNE   LBB23_7
+	LEAQ  -32(R11), R8
+	ADDQ  $32, R10
+	CMPQ  CX, $33
+	LEAQ  -32(CX), CX
+	JL    LBB23_11
+	CMPQ  R11, $63
+	MOVQ  R8, R11
+	JG    LBB23_6
+
+LBB23_11:
+	WORD  $0xf8c5; BYTE $0x77 // vzeroupper
+	CMPQ  R8, $16
+	JL    LBB23_13
+	TESTQ CX, CX
+	JLE   LBB23_13
+
+LBB23_16:
+	LONG  $0x6f7ac1c4; BYTE $0x02 // vmovdqu      (%r10), %xmm0
+	LONG  $0xd8d7f9c5             // vpmovmskb    %xmm0, %ebx
+	TESTW BX, BX
+	JNE   LBB23_17
+	ADDQ  $16, R10
+	CMPQ  CX, $17
+	LEAQ  -16(CX), CX
+	JL    LBB23_13
+	CMPQ  R8, $31
+	LEAQ  -16(R8), R8
+	JG    LBB23_16
+	JMP   LBB23_13
+
+LBB23_15:
+	DECQ CX
+	INCQ R10
+
+LBB23_13:
+	TESTQ CX, CX
+	JE    LBB23_38
+	CMPB  0(R10), $0
+	JNS   LBB23_15
+	SUBQ  R9, R10
+	MOVQ  R10, R8
+	CMPQ  R8, $-1
+	JNE   LBB23_22
+	JMP   LBB23_38
+
+LBB23_3:
+	XORL R8, R8
+	CMPQ R8, $-1
+	JE   LBB23_38
+
+LBB23_22:
+	SUBQ    R8, SI
+	JLE     LBB23_38
+	LEAQ    0(R9)(R8*1), R10
+	CMPQ    SI, $2
+	JB      LBB23_37
+	MOVBLZX 1(R9)(R8*1), R11
+	MOVL    R11, CX
+	ANDL    $-64, CX
+	CMPL    CX, $128
+	JNE     LBB23_37
+	MOVBLZX 0(R10), R14
+	MOVL    R14, CX
+	ANDL    $-32, CX
+	CMPL    CX, $192
+	JE      LBB23_26
+	CMPQ    SI, $3
+	JB      LBB23_37
+	MOVBLZX 2(R9)(R8*1), CX
+	MOVL    CX, BX
+	ANDL    $-64, BX
+	CMPL    BX, $128
+	JNE     LBB23_37
+	CMPB    R14, $-17
+	JA      LBB23_33
+	SHLL    $12, R14
+	MOVWLZX R14, R9
+	ANDL    $63, R11
+	SHLL    $6, R11
+	ANDL    $63, CX
+	ORL     R11, CX
+	LEAL    0(CX)(R9*1), BX
+	MOVL    $3, R11
+	CMPL    BX, $57343
+	JA      LBB23_32
+	LEAL    -2048(R9)(CX*1), CX
+	CMPL    CX, $53248
+	JAE     LBB23_37
+
+LBB23_32:
+	SUBQ R8, DX
+	SUBQ R11, DX
+	ADDQ R11, R10
+	MOVQ R10, R9
+	SUBQ R11, SI
+	JG   LBB23_2
+	JMP  LBB23_38
+
+LBB23_7:
+	MOVLQSX BX, CX
+	JMP     LBB23_8
+
+LBB23_17:
+	MOVWLZX BX, CX
+
+LBB23_8:
+	SUBQ R9, R10
+	BSFQ CX, R8
+	ADDQ R10, R8
+	CMPQ R8, $-1
+	JNE  LBB23_22
+	JMP  LBB23_38
+
+LBB23_26:
+	MOVL  $2, R11
+	TESTB $30, R14
+	JNE   LBB23_32
+	JMP   LBB23_37
+
+LBB23_33:
+	CMPQ    SI, $4
+	JB      LBB23_37
+	MOVBLZX 3(R9)(R8*1), R9
+	MOVL    R9, BX
+	ANDL    $-64, BX
+	CMPL    BX, $128
+	JNE     LBB23_37
+	CMPB    R14, $-9
+	JA      LBB23_37
+	ANDL    $7, R14
+	SHLL    $18, R14
+	ANDL    $63, R11
+	SHLL    $12, R11
+	ANDL    $63, CX
+	SHLL    $6, CX
+	ORL     R11, CX
+	ANDL    $63, R9
+	ORL     CX, R9
+	LEAL    -65536(R14)(R9*1), CX
+	MOVL    $4, R11
+	CMPL    CX, $1048576
+	JB      LBB23_32
+
+LBB23_37:
+	SUBQ DI, R10
+	MOVQ R10, AX
+
+LBB23_38:
+	BYTE $0x5b               // popq         %rbx
+	WORD $0x5e41             // popq         %r14
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	RET
+
 _skip_negative:
 	BYTE  $0x55                   // pushq        %rbp
 	WORD  $0x8948; BYTE $0xe5     // movq         %rsp, %rbp
@@ -6691,72 +7307,72 @@ _skip_negative:
 	LONG  $0x00017be8; BYTE $0x00 // callq        _skip_number
 	MOVQ  0(R14), CX
 	TESTQ AX, AX
-	JS    LBB22_1
+	JS    LBB24_1
 	ADDQ  AX, CX
 	MOVQ  CX, 0(R14)
 	DECQ  BX
-	JMP   LBB22_3
+	JMP   LBB24_3
 
-LBB22_1:
+LBB24_1:
 	NOTQ AX
 	ADDQ AX, CX
 	MOVQ CX, 0(R14)
 	MOVQ $-2, BX
 
-LBB22_3:
+LBB24_3:
 	MOVQ BX, AX
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LCPI23_0:
+LCPI25_0:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI23_1:
+LCPI25_1:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI23_2:
+LCPI25_2:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI23_3:
+LCPI25_3:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI23_4:
+LCPI25_4:
 	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
 	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
 
-LCPI23_5:
+LCPI25_5:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI23_6:
+LCPI25_6:
 	QUAD $0x6565656565656565; QUAD $0x6565656565656565 // .space 16, 'eeeeeeeeeeeeeeee'
 	QUAD $0x6565656565656565; QUAD $0x6565656565656565 // .space 16, 'eeeeeeeeeeeeeeee'
 
-LCPI23_7:
+LCPI25_7:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI23_8:
+LCPI25_8:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI23_9:
+LCPI25_9:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI23_10:
+LCPI25_10:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI23_11:
+LCPI25_11:
 	QUAD $0x2020202020202020; QUAD $0x2020202020202020 // .space 16, '                '
 
-LCPI23_12:
+LCPI25_12:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI23_13:
+LCPI25_13:
 	QUAD $0x6565656565656565; QUAD $0x6565656565656565 // .space 16, 'eeeeeeeeeeeeeeee'
 
 _skip_number:
@@ -6768,42 +7384,42 @@ _skip_number:
 	WORD    $0x5441                // pushq        %r12
 	BYTE    $0x53                  // pushq        %rbx
 	TESTQ   SI, SI
-	JE      LBB23_53
+	JE      LBB25_53
 	CMPB    0(DI), $48
-	JNE     LBB23_5
+	JNE     LBB25_5
 	MOVL    $1, DX
 	CMPQ    SI, $1
-	JE      LBB23_73
+	JE      LBB25_73
 	MOVB    1(DI), AX
 	ADDB    $-46, AX
 	CMPB    AX, $55
-	JA      LBB23_73
+	JA      LBB25_73
 	MOVBLZX AX, AX
 	MOVQ    $36028797027352577, CX
 	BTQ     AX, CX
-	JAE     LBB23_73
+	JAE     LBB25_73
 
-LBB23_5:
+LBB25_5:
 	CMPQ SI, $32
-	JB   LBB23_76
+	JB   LBB25_76
 	LEAQ -32(SI), R11
 	MOVQ R11, AX
 	ANDQ $-32, AX
 	LEAQ 32(AX)(DI*1), R10
 	ANDL $31, R11
 	MOVQ $-1, R9
-	QUAD $0xfffffe35056ffec5 // vmovdqu      $-459(%rip), %ymm0  /* LCPI23_0(%rip) */
-	QUAD $0xfffffe4d0d6ffec5 // vmovdqu      $-435(%rip), %ymm1  /* LCPI23_1(%rip) */
-	QUAD $0xfffffe65156ffec5 // vmovdqu      $-411(%rip), %ymm2  /* LCPI23_2(%rip) */
-	QUAD $0xfffffe7d1d6ffec5 // vmovdqu      $-387(%rip), %ymm3  /* LCPI23_3(%rip) */
-	QUAD $0xfffffe95256ffec5 // vmovdqu      $-363(%rip), %ymm4  /* LCPI23_4(%rip) */
-	QUAD $0xfffffead2d6ffec5 // vmovdqu      $-339(%rip), %ymm5  /* LCPI23_5(%rip) */
-	QUAD $0xfffffec5356ffec5 // vmovdqu      $-315(%rip), %ymm6  /* LCPI23_6(%rip) */
+	QUAD $0xfffffe35056ffec5 // vmovdqu      $-459(%rip), %ymm0  /* LCPI25_0(%rip) */
+	QUAD $0xfffffe4d0d6ffec5 // vmovdqu      $-435(%rip), %ymm1  /* LCPI25_1(%rip) */
+	QUAD $0xfffffe65156ffec5 // vmovdqu      $-411(%rip), %ymm2  /* LCPI25_2(%rip) */
+	QUAD $0xfffffe7d1d6ffec5 // vmovdqu      $-387(%rip), %ymm3  /* LCPI25_3(%rip) */
+	QUAD $0xfffffe95256ffec5 // vmovdqu      $-363(%rip), %ymm4  /* LCPI25_4(%rip) */
+	QUAD $0xfffffead2d6ffec5 // vmovdqu      $-339(%rip), %ymm5  /* LCPI25_5(%rip) */
+	QUAD $0xfffffec5356ffec5 // vmovdqu      $-315(%rip), %ymm6  /* LCPI25_6(%rip) */
 	MOVQ $-1, AX
 	MOVQ $-1, R8
 	MOVQ DI, R14
 
-LBB23_7:
+LBB25_7:
 	LONG $0x6f7ec1c4; BYTE $0x3e // vmovdqu      (%r14), %ymm7
 	LONG $0xc06445c5             // vpcmpgtb     %ymm0, %ymm7, %ymm8
 	LONG $0xcf6475c5             // vpcmpgtb     %ymm7, %ymm1, %ymm9
@@ -6824,7 +7440,7 @@ LBB23_7:
 	NOTQ CX
 	BSFQ CX, CX
 	CMPL CX, $32
-	JE   LBB23_9
+	JE   LBB25_9
 	MOVL $-1, BX
 	SHLL CX, BX
 	NOTL BX
@@ -6833,76 +7449,76 @@ LBB23_7:
 	ANDL R15, BX
 	MOVL BX, R15
 
-LBB23_9:
+LBB25_9:
 	LEAL  -1(DX), BX
 	ANDL  DX, BX
-	JNE   LBB23_70
+	JNE   LBB25_70
 	LEAL  -1(R12), BX
 	ANDL  R12, BX
-	JNE   LBB23_70
+	JNE   LBB25_70
 	LEAL  -1(R15), BX
 	ANDL  R15, BX
-	JNE   LBB23_70
+	JNE   LBB25_70
 	TESTL DX, DX
-	JE    LBB23_15
+	JE    LBB25_15
 	MOVQ  R14, BX
 	SUBQ  DI, BX
 	BSFL  DX, DX
 	ADDQ  BX, DX
 	CMPQ  R8, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, R8
 
-LBB23_15:
+LBB25_15:
 	TESTL R12, R12
-	JE    LBB23_18
+	JE    LBB25_18
 	MOVQ  R14, BX
 	SUBQ  DI, BX
 	BSFL  R12, DX
 	ADDQ  BX, DX
 	CMPQ  AX, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, AX
 
-LBB23_18:
+LBB25_18:
 	TESTL R15, R15
-	JE    LBB23_21
+	JE    LBB25_21
 	MOVQ  R14, BX
 	SUBQ  DI, BX
 	BSFL  R15, DX
 	ADDQ  BX, DX
 	CMPQ  R9, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, R9
 
-LBB23_21:
+LBB25_21:
 	CMPL CX, $32
-	JNE  LBB23_54
+	JNE  LBB25_54
 	ADDQ $32, R14
 	ADDQ $-32, SI
 	CMPQ SI, $31
-	JA   LBB23_7
+	JA   LBB25_7
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	MOVQ R11, SI
 	CMPQ SI, $16
-	JB   LBB23_42
+	JB   LBB25_42
 
-LBB23_24:
+LBB25_24:
 	LEAQ -16(SI), R14
 	MOVQ R14, CX
 	ANDQ $-16, CX
 	LEAQ 16(CX)(R10*1), R11
 	ANDL $15, R14
-	QUAD $0xfffffda2056f7ac5 // vmovdqu      $-606(%rip), %xmm8  /* LCPI23_7(%rip) */
-	QUAD $0xfffffdaa0d6f7ac5 // vmovdqu      $-598(%rip), %xmm9  /* LCPI23_8(%rip) */
-	QUAD $0xfffffdb2156f7ac5 // vmovdqu      $-590(%rip), %xmm10  /* LCPI23_9(%rip) */
-	QUAD $0xfffffdba1d6f7ac5 // vmovdqu      $-582(%rip), %xmm11  /* LCPI23_10(%rip) */
-	QUAD $0xfffffdc2256ffac5 // vmovdqu      $-574(%rip), %xmm4  /* LCPI23_11(%rip) */
-	QUAD $0xfffffdca2d6ffac5 // vmovdqu      $-566(%rip), %xmm5  /* LCPI23_12(%rip) */
-	QUAD $0xfffffdd2356ffac5 // vmovdqu      $-558(%rip), %xmm6  /* LCPI23_13(%rip) */
+	QUAD $0xfffffda2056f7ac5 // vmovdqu      $-606(%rip), %xmm8  /* LCPI25_7(%rip) */
+	QUAD $0xfffffdaa0d6f7ac5 // vmovdqu      $-598(%rip), %xmm9  /* LCPI25_8(%rip) */
+	QUAD $0xfffffdb2156f7ac5 // vmovdqu      $-590(%rip), %xmm10  /* LCPI25_9(%rip) */
+	QUAD $0xfffffdba1d6f7ac5 // vmovdqu      $-582(%rip), %xmm11  /* LCPI25_10(%rip) */
+	QUAD $0xfffffdc2256ffac5 // vmovdqu      $-574(%rip), %xmm4  /* LCPI25_11(%rip) */
+	QUAD $0xfffffdca2d6ffac5 // vmovdqu      $-566(%rip), %xmm5  /* LCPI25_12(%rip) */
+	QUAD $0xfffffdd2356ffac5 // vmovdqu      $-558(%rip), %xmm6  /* LCPI25_13(%rip) */
 	MOVL $4294967295, R15
 
-LBB23_25:
+LBB25_25:
 	LONG $0x6f7ac1c4; BYTE $0x3a // vmovdqu      (%r10), %xmm7
 	LONG $0x6441c1c4; BYTE $0xc0 // vpcmpgtb     %xmm8, %xmm7, %xmm0
 	LONG $0xcf64b1c5             // vpcmpgtb     %xmm7, %xmm9, %xmm1
@@ -6923,7 +7539,7 @@ LBB23_25:
 	XORQ R15, CX
 	BSFQ CX, CX
 	CMPL CX, $16
-	JE   LBB23_27
+	JE   LBB25_27
 	MOVL $-1, BX
 	SHLL CX, BX
 	NOTL BX
@@ -6932,196 +7548,196 @@ LBB23_25:
 	ANDL R12, BX
 	MOVL BX, R12
 
-LBB23_27:
+LBB25_27:
 	LEAL  -1(DX), BX
 	ANDL  DX, BX
-	JNE   LBB23_71
+	JNE   LBB25_71
 	LEAL  -1(R13), BX
 	ANDL  R13, BX
-	JNE   LBB23_71
+	JNE   LBB25_71
 	LEAL  -1(R12), BX
 	ANDL  R12, BX
-	JNE   LBB23_71
+	JNE   LBB25_71
 	TESTL DX, DX
-	JE    LBB23_33
+	JE    LBB25_33
 	MOVQ  R10, BX
 	SUBQ  DI, BX
 	BSFL  DX, DX
 	ADDQ  BX, DX
 	CMPQ  R8, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, R8
 
-LBB23_33:
+LBB25_33:
 	TESTL R13, R13
-	JE    LBB23_36
+	JE    LBB25_36
 	MOVQ  R10, BX
 	SUBQ  DI, BX
 	BSFL  R13, DX
 	ADDQ  BX, DX
 	CMPQ  AX, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, AX
 
-LBB23_36:
+LBB25_36:
 	TESTL R12, R12
-	JE    LBB23_39
+	JE    LBB25_39
 	MOVQ  R10, BX
 	SUBQ  DI, BX
 	BSFL  R12, DX
 	ADDQ  BX, DX
 	CMPQ  R9, $-1
-	JNE   LBB23_72
+	JNE   LBB25_72
 	MOVQ  DX, R9
 
-LBB23_39:
+LBB25_39:
 	CMPL CX, $16
-	JNE  LBB23_55
+	JNE  LBB25_55
 	ADDQ $16, R10
 	ADDQ $-16, SI
 	CMPQ SI, $15
-	JA   LBB23_25
+	JA   LBB25_25
 	MOVQ R14, SI
 	MOVQ R11, R10
 
-LBB23_42:
+LBB25_42:
 	TESTQ SI, SI
-	JE    LBB23_56
+	JE    LBB25_56
 	LEAQ  0(R10)(SI*1), R11
-	LONG  $0x8f1d8d48; WORD $0x0001; BYTE $0x00 // leaq         $399(%rip), %rbx  /* LJTI23_0(%rip) */
-	JMP   LBB23_45
+	LONG  $0x8f1d8d48; WORD $0x0001; BYTE $0x00 // leaq         $399(%rip), %rbx  /* LJTI25_0(%rip) */
+	JMP   LBB25_45
 
-LBB23_44:
+LBB25_44:
 	MOVQ CX, R10
 	DECQ SI
-	JE   LBB23_75
+	JE   LBB25_75
 
-LBB23_45:
+LBB25_45:
 	MOVBLSX 0(R10), DX
 	ADDL    $-43, DX
 	CMPL    DX, $58
-	JA      LBB23_56
+	JA      LBB25_56
 	LEAQ    1(R10), CX
 	MOVLQSX 0(BX)(DX*4), DX
 	ADDQ    BX, DX
 	JMP     DX
 
-LBB23_47:
+LBB25_47:
 	MOVQ CX, DX
 	SUBQ DI, DX
 	CMPQ R9, $-1
-	JNE  LBB23_79
+	JNE  LBB25_79
 	DECQ DX
 	MOVQ DX, R9
-	JMP  LBB23_44
+	JMP  LBB25_44
 
-LBB23_49:
+LBB25_49:
 	MOVQ CX, DX
 	SUBQ DI, DX
 	CMPQ AX, $-1
-	JNE  LBB23_79
+	JNE  LBB25_79
 	DECQ DX
 	MOVQ DX, AX
-	JMP  LBB23_44
+	JMP  LBB25_44
 
-LBB23_51:
+LBB25_51:
 	MOVQ CX, DX
 	SUBQ DI, DX
 	CMPQ R8, $-1
-	JNE  LBB23_79
+	JNE  LBB25_79
 	DECQ DX
 	MOVQ DX, R8
-	JMP  LBB23_44
+	JMP  LBB25_44
 
-LBB23_53:
+LBB25_53:
 	MOVQ $-1, AX
-	JMP  LBB23_74
+	JMP  LBB25_74
 
-LBB23_54:
+LBB25_54:
 	ADDQ  CX, R14
 	WORD  $0xf8c5; BYTE $0x77 // vzeroupper
 	MOVQ  R14, R10
 	MOVQ  $-1, DX
 	TESTQ AX, AX
-	JNE   LBB23_57
-	JMP   LBB23_73
+	JNE   LBB25_57
+	JMP   LBB25_73
 
-LBB23_55:
+LBB25_55:
 	ADDQ CX, R10
 
-LBB23_56:
+LBB25_56:
 	MOVQ  $-1, DX
 	TESTQ AX, AX
-	JE    LBB23_73
+	JE    LBB25_73
 
-LBB23_57:
+LBB25_57:
 	TESTQ R9, R9
-	JE    LBB23_73
+	JE    LBB25_73
 	TESTQ R8, R8
-	JE    LBB23_73
+	JE    LBB25_73
 	SUBQ  DI, R10
 	LEAQ  -1(R10), CX
 	CMPQ  AX, CX
-	JE    LBB23_65
+	JE    LBB25_65
 	CMPQ  R8, CX
-	JE    LBB23_65
+	JE    LBB25_65
 	CMPQ  R9, CX
-	JE    LBB23_65
+	JE    LBB25_65
 	TESTQ R9, R9
-	JLE   LBB23_66
+	JLE   LBB25_66
 	LEAQ  -1(R9), CX
 	CMPQ  AX, CX
-	JE    LBB23_66
+	JE    LBB25_66
 	NOTQ  R9
 	MOVQ  R9, DX
 	MOVQ  R9, AX
-	JMP   LBB23_74
+	JMP   LBB25_74
 
-LBB23_65:
+LBB25_65:
 	NEGQ R10
 	MOVQ R10, DX
 	MOVQ R10, AX
-	JMP  LBB23_74
+	JMP  LBB25_74
 
-LBB23_66:
+LBB25_66:
 	MOVQ  R8, CX
 	ORQ   AX, CX
 	CMPQ  R8, AX
-	JL    LBB23_69
+	JL    LBB25_69
 	TESTQ CX, CX
-	JS    LBB23_69
+	JS    LBB25_69
 	NOTQ  R8
 	MOVQ  R8, DX
 	MOVQ  R8, AX
-	JMP   LBB23_74
+	JMP   LBB25_74
 
-LBB23_69:
+LBB25_69:
 	TESTQ CX, CX
 	LEAQ  -1(AX), CX
 	NOTQ  AX
 	LONG  $0xc2480f49 // cmovsq       %r10, %rax
 	CMPQ  R8, CX
 	LONG  $0xc2450f49 // cmovneq      %r10, %rax
-	JMP   LBB23_74
+	JMP   LBB25_74
 
-LBB23_70:
+LBB25_70:
 	SUBQ DI, R14
 	BSFL BX, DX
 	ADDQ R14, DX
-	JMP  LBB23_72
+	JMP  LBB25_72
 
-LBB23_71:
+LBB25_71:
 	SUBQ DI, R10
 	BSFL BX, DX
 	ADDQ R10, DX
 
-LBB23_72:
+LBB25_72:
 	NOTQ DX
 
-LBB23_73:
+LBB25_73:
 	MOVQ DX, AX
 
-LBB23_74:
+LBB25_74:
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
 	WORD $0x5d41             // popq         %r13
@@ -7131,91 +7747,91 @@ LBB23_74:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	RET
 
-LBB23_75:
+LBB25_75:
 	MOVQ  R11, R10
 	MOVQ  $-1, DX
 	TESTQ AX, AX
-	JNE   LBB23_57
-	JMP   LBB23_73
+	JNE   LBB25_57
+	JMP   LBB25_73
 
-LBB23_79:
+LBB25_79:
 	NEGQ DX
-	JMP  LBB23_73
+	JMP  LBB25_73
 
-LBB23_76:
+LBB25_76:
 	MOVQ $-1, R9
 	MOVQ $-1, AX
 	MOVQ $-1, R8
 	MOVQ DI, R10
 	CMPQ SI, $16
-	JAE  LBB23_24
-	JMP  LBB23_42
+	JAE  LBB25_24
+	JMP  LBB25_42
 
-// .set L23_0_set_47, LBB23_47-LJTI23_0
-// .set L23_0_set_56, LBB23_56-LJTI23_0
-// .set L23_0_set_51, LBB23_51-LJTI23_0
-// .set L23_0_set_44, LBB23_44-LJTI23_0
-// .set L23_0_set_49, LBB23_49-LJTI23_0
-LJTI23_0:
-	LONG $0xfffffe98 // .long L23_0_set_47
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xfffffe98 // .long L23_0_set_47
-	LONG $0xfffffec8 // .long L23_0_set_51
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xfffffe73 // .long L23_0_set_44
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xfffffeb0 // .long L23_0_set_49
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xffffff09 // .long L23_0_set_56
-	LONG $0xfffffeb0 // .long L23_0_set_49
+// .set L25_0_set_47, LBB25_47-LJTI25_0
+// .set L25_0_set_56, LBB25_56-LJTI25_0
+// .set L25_0_set_51, LBB25_51-LJTI25_0
+// .set L25_0_set_44, LBB25_44-LJTI25_0
+// .set L25_0_set_49, LBB25_49-LJTI25_0
+LJTI25_0:
+	LONG $0xfffffe98 // .long L25_0_set_47
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xfffffe98 // .long L25_0_set_47
+	LONG $0xfffffec8 // .long L25_0_set_51
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xfffffe73 // .long L25_0_set_44
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xfffffeb0 // .long L25_0_set_49
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xffffff09 // .long L25_0_set_56
+	LONG $0xfffffeb0 // .long L25_0_set_49
 
 _skip_positive:
 	BYTE  $0x55                   // pushq        %rbp
@@ -7232,23 +7848,126 @@ _skip_positive:
 	MOVQ  AX, DI
 	LONG  $0xfffa20e8; BYTE $0xff // callq        _skip_number
 	TESTQ AX, AX
-	JS    LBB24_1
+	JS    LBB26_1
 	MOVQ  0(R14), CX
 	LEAQ  -1(AX)(CX*1), CX
-	JMP   LBB24_3
+	JMP   LBB26_3
 
-LBB24_1:
+LBB26_1:
 	MOVQ 0(R14), CX
 	SUBQ AX, CX
 	ADDQ $-2, CX
 	MOVQ $-2, BX
 
-LBB24_3:
+LBB26_3:
 	MOVQ CX, 0(R14)
 	MOVQ BX, AX
 	BYTE $0x5b      // popq         %rbx
 	WORD $0x5e41    // popq         %r14
 	BYTE $0x5d      // popq         %rbp
+	RET
+
+_validate_one:
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	MOVQ DX, AX
+	MOVQ SI, DX
+	MOVQ DI, SI
+	MOVQ $1, 0(AX)
+	MOVQ AX, DI
+	MOVL $1, CX
+	BYTE $0x5d               // popq         %rbp
+	JMP  _fsm_exec
+
+_find_non_ascii:
+	BYTE  $0x55               // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	CMPQ  DX, $32
+	JL    LBB28_1
+	TESTQ SI, SI
+	JLE   LBB28_1
+	MOVQ  DI, CX
+
+LBB28_4:
+	LONG  $0x016ffec5 // vmovdqu      (%rcx), %ymm0
+	LONG  $0xc0d7fdc5 // vpmovmskb    %ymm0, %eax
+	TESTL AX, AX
+	JNE   LBB28_5
+	LEAQ  -32(SI), AX
+	ADDQ  $32, CX
+	CMPQ  DX, $64
+	LEAQ  -32(DX), DX
+	JL    LBB28_9
+	CMPQ  SI, $32
+	MOVQ  AX, SI
+	JG    LBB28_4
+	JMP   LBB28_9
+
+LBB28_1:
+	MOVQ SI, AX
+	MOVQ DI, CX
+
+LBB28_9:
+	WORD  $0xf8c5; BYTE $0x77 // vzeroupper
+	CMPQ  DX, $16
+	JL    LBB28_11
+	TESTQ AX, AX
+	JLE   LBB28_11
+
+LBB28_16:
+	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
+	LONG  $0xf0d7f9c5 // vpmovmskb    %xmm0, %esi
+	TESTW SI, SI
+	JNE   LBB28_17
+	LEAQ  -16(AX), SI
+	ADDQ  $16, CX
+	CMPQ  DX, $32
+	JL    LBB28_12
+	ADDQ  $-16, DX
+	CMPQ  AX, $16
+	MOVQ  SI, AX
+	JG    LBB28_16
+	JMP   LBB28_12
+
+LBB28_11:
+	MOVQ AX, SI
+
+LBB28_12:
+	MOVQ  $-1, AX
+	TESTQ SI, SI
+	JE    LBB28_21
+
+LBB28_14:
+	CMPB  0(CX), $0
+	JS    LBB28_20
+	DECQ  SI
+	INCQ  CX
+	TESTQ SI, SI
+	JNE   LBB28_14
+
+LBB28_21:
+	BYTE $0x5d // popq         %rbp
+	RET
+
+LBB28_20:
+	SUBQ DI, CX
+	MOVQ CX, AX
+	BYTE $0x5d  // popq         %rbp
+	RET
+
+LBB28_5:
+	WORD $0x9848 // cltq
+	JMP  LBB28_6
+
+LBB28_17:
+	MOVWLZX SI, AX
+
+LBB28_6:
+	SUBQ DI, CX
+	BSFQ AX, AX
+	ADDQ CX, AX
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	RET
 
 _print_mantissa:
@@ -7260,7 +7979,7 @@ _print_mantissa:
 	ADDQ    SI, R14
 	MOVQ    DI, AX
 	SHRQ    $32, AX
-	JE      LBB25_2
+	JE      LBB29_2
 	MOVQ    $-6067343680855748867, DX
 	MOVQ    DI, AX
 	MULQ    DX
@@ -7304,13 +8023,13 @@ _print_mantissa:
 	ADDQ    $-8, R14
 	MOVQ    DX, DI
 
-LBB25_2:
+LBB29_2:
 	CMPL DI, $10000
-	JB   LBB25_3
+	JB   LBB29_3
 	MOVL $3518437209, R8
 	LONG $0xcc0d8d4c; WORD $0x0058; BYTE $0x00 // leaq         $22732(%rip), %r9  /* _Digits(%rip) */
 
-LBB25_5:
+LBB29_5:
 	MOVL    DI, AX
 	IMULQ   R8, AX
 	SHRQ    $45, AX
@@ -7327,11 +8046,11 @@ LBB25_5:
 	ADDQ    $-4, R14
 	CMPL    DI, $99999999
 	MOVL    AX, DI
-	JA      LBB25_5
+	JA      LBB29_5
 	CMPL    AX, $100
-	JB      LBB25_8
+	JB      LBB29_8
 
-LBB25_7:
+LBB29_7:
 	MOVWLZX AX, CX
 	SHRL    $2, CX
 	LONG    $0x147bc969; WORD $0x0000             // imull        $5243, %ecx, %ecx
@@ -7345,9 +8064,9 @@ LBB25_7:
 	ADDQ    $-2, R14
 	MOVL    CX, AX
 
-LBB25_8:
+LBB29_8:
 	CMPL    AX, $10
-	JB      LBB25_10
+	JB      LBB29_10
 	MOVL    AX, AX
 	LONG    $0x480d8d48; WORD $0x0058; BYTE $0x00 // leaq         $22600(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
@@ -7357,13 +8076,13 @@ LBB25_8:
 	BYTE    $0x5d                                 // popq         %rbp
 	RET
 
-LBB25_3:
+LBB29_3:
 	MOVL DI, AX
 	CMPL AX, $100
-	JAE  LBB25_7
-	JMP  LBB25_8
+	JAE  LBB29_7
+	JMP  LBB29_8
 
-LBB25_10:
+LBB29_10:
 	ADDB $48, AX
 	MOVB AX, 0(SI)
 	BYTE $0x5b     // popq         %rbx
@@ -7384,37 +8103,37 @@ _left_shift:
 	MOVLQSX 16(DI), R9
 	MOVB    4(DX)(SI*1), AX
 	TESTQ   R9, R9
-	JE      LBB26_6
+	JE      LBB30_6
 	LEAQ    5(DX)(SI*1), DX
 	XORL    SI, SI
 
-LBB26_3:
+LBB30_3:
 	TESTB   AX, AX
-	JE      LBB26_8
+	JE      LBB30_8
 	CMPB    0(R10)(SI*1), AX
-	JNE     LBB26_5
+	JNE     LBB30_5
 	MOVBLZX 0(DX)(SI*1), AX
 	INCQ    SI
 	CMPQ    R9, SI
-	JNE     LBB26_3
+	JNE     LBB30_3
 
-LBB26_6:
+LBB30_6:
 	TESTB AX, AX
-	JE    LBB26_8
+	JE    LBB30_8
 
-LBB26_7:
+LBB30_7:
 	DECL R8
 
-LBB26_8:
+LBB30_8:
 	TESTL   R9, R9
-	JLE     LBB26_23
+	JLE     LBB30_23
 	LEAL    0(R8)(R9*1), AX
 	MOVLQSX AX, R14
 	DECQ    R14
 	XORL    DX, DX
 	MOVQ    $-3689348814741910323, R11
 
-LBB26_10:
+LBB30_10:
 	MOVBQSX -1(R10)(R9*1), SI
 	ADDQ    $-48, SI
 	SHLQ    CX, SI
@@ -7427,83 +8146,83 @@ LBB26_10:
 	MOVQ    SI, AX
 	SUBQ    BX, AX
 	CMPQ    8(DI), R14
-	JBE     LBB26_16
+	JBE     LBB30_16
 	ADDB    $48, AX
 	MOVB    AX, 0(R10)(R14*1)
-	JMP     LBB26_18
+	JMP     LBB30_18
 
-LBB26_16:
+LBB30_16:
 	TESTQ AX, AX
-	JE    LBB26_18
+	JE    LBB30_18
 	MOVL  $1, 28(DI)
 
-LBB26_18:
+LBB30_18:
 	CMPQ R9, $2
-	JL   LBB26_12
+	JL   LBB30_12
 	DECQ R9
 	MOVQ 0(DI), R10
 	DECQ R14
-	JMP  LBB26_10
+	JMP  LBB30_10
 
-LBB26_12:
+LBB30_12:
 	CMPQ SI, $10
-	JAE  LBB26_13
+	JAE  LBB30_13
 
-LBB26_23:
+LBB30_23:
 	MOVLQSX 16(DI), CX
 	MOVLQSX R8, AX
 	ADDQ    CX, AX
 	MOVL    AX, 16(DI)
 	MOVQ    8(DI), CX
 	CMPQ    CX, AX
-	JA      LBB26_25
+	JA      LBB30_25
 	MOVL    CX, 16(DI)
 	MOVL    CX, AX
 
-LBB26_25:
+LBB30_25:
 	ADDL  R8, 20(DI)
 	TESTL AX, AX
-	JLE   LBB26_29
+	JLE   LBB30_29
 	MOVQ  0(DI), CX
 	MOVL  AX, AX
 
-LBB26_27:
+LBB30_27:
 	CMPB -1(CX)(AX*1), $48
-	JNE  LBB26_31
+	JNE  LBB30_31
 	MOVL AX, DX
 	DECQ AX
 	DECL DX
 	MOVL DX, 16(DI)
 	LEAQ 1(AX), DX
 	CMPQ DX, $1
-	JG   LBB26_27
+	JG   LBB30_27
 
-LBB26_29:
+LBB30_29:
 	TESTL AX, AX
-	JE    LBB26_30
+	JE    LBB30_30
 
-LBB26_31:
+LBB30_31:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	BYTE $0x5d   // popq         %rbp
 	RET
 
-LBB26_13:
+LBB30_13:
 	MOVLQSX R14, SI
 	DECQ    SI
-	JMP     LBB26_14
+	JMP     LBB30_14
 
-LBB26_15:
+LBB30_15:
 	ADDB $48, AX
 	MOVQ 0(DI), BX
 	MOVB AX, 0(BX)(SI*1)
 
-LBB26_22:
+LBB30_22:
 	DECQ SI
 	CMPQ CX, $9
-	JBE  LBB26_23
+	JBE  LBB30_23
 
-LBB26_14:
+LBB30_14:
 	MOVQ  DX, CX
 	MOVQ  DX, AX
 	MULQ  R11
@@ -7513,22 +8232,22 @@ LBB26_14:
 	MOVQ  CX, AX
 	SUBQ  BX, AX
 	CMPQ  8(DI), SI
-	JA    LBB26_15
+	JA    LBB30_15
 	TESTQ AX, AX
-	JE    LBB26_22
+	JE    LBB30_22
 	MOVL  $1, 28(DI)
-	JMP   LBB26_22
+	JMP   LBB30_22
 
-LBB26_30:
+LBB30_30:
 	MOVL $0, 20(DI)
 	BYTE $0x5b      // popq         %rbx
 	WORD $0x5e41    // popq         %r14
 	BYTE $0x5d      // popq         %rbp
 	RET
 
-LBB26_5:
-	JL  LBB26_7
-	JMP LBB26_8
+LBB30_5:
+	JL  LBB30_7
+	JMP LBB30_8
 
 _right_shift:
 	BYTE    $0x55               // pushq        %rbp
@@ -7538,9 +8257,9 @@ _right_shift:
 	XORL    SI, SI
 	XORL    AX, AX
 
-LBB27_1:
+LBB31_1:
 	CMPQ    SI, R9
-	JGE     LBB27_2
+	JGE     LBB31_2
 	LEAQ    0(AX)(AX*4), AX
 	MOVQ    0(DI), DX
 	MOVBQSX 0(DX)(SI*1), DX
@@ -7549,9 +8268,9 @@ LBB27_1:
 	MOVQ    AX, DX
 	SHRQ    CX, DX
 	TESTQ   DX, DX
-	JE      LBB27_1
+	JE      LBB31_1
 
-LBB27_6:
+LBB31_6:
 	MOVL    20(DI), DX
 	SUBL    SI, DX
 	INCL    DX
@@ -7561,12 +8280,12 @@ LBB27_6:
 	NOTQ    R8
 	XORL    R10, R10
 	CMPL    SI, R9
-	JGE     LBB27_9
+	JGE     LBB31_9
 	MOVLQSX SI, R9
 	MOVQ    0(DI), SI
 	XORL    R10, R10
 
-LBB27_8:
+LBB31_8:
 	MOVQ    AX, DX
 	SHRQ    CX, DX
 	ANDQ    R8, AX
@@ -7581,84 +8300,84 @@ LBB27_8:
 	LEAQ    1(R9)(R10*1), DX
 	INCQ    R10
 	CMPQ    DX, R11
-	JL      LBB27_8
-	JMP     LBB27_9
+	JL      LBB31_8
+	JMP     LBB31_9
 
-LBB27_11:
+LBB31_11:
 	ADDB $48, SI
 	MOVQ 0(DI), DX
 	MOVB SI, 0(DX)(R9*1)
 	INCL R9
 	MOVL R9, R10
 
-LBB27_14:
+LBB31_14:
 	ADDQ AX, AX
 	LEAQ 0(AX)(AX*4), AX
 
-LBB27_9:
+LBB31_9:
 	TESTQ   AX, AX
-	JE      LBB27_15
+	JE      LBB31_15
 	MOVQ    AX, SI
 	SHRQ    CX, SI
 	ANDQ    R8, AX
 	MOVLQSX R10, R9
 	CMPQ    8(DI), R9
-	JA      LBB27_11
+	JA      LBB31_11
 	TESTQ   SI, SI
-	JE      LBB27_14
+	JE      LBB31_14
 	MOVL    $1, 28(DI)
-	JMP     LBB27_14
+	JMP     LBB31_14
 
-LBB27_15:
+LBB31_15:
 	MOVL  R10, 16(DI)
 	TESTL R10, R10
-	JLE   LBB27_19
+	JLE   LBB31_19
 	MOVQ  0(DI), AX
 	MOVL  R10, R10
 
-LBB27_17:
+LBB31_17:
 	CMPB -1(AX)(R10*1), $48
-	JNE  LBB27_21
+	JNE  LBB31_21
 	MOVL R10, CX
 	DECQ R10
 	DECL CX
 	MOVL CX, 16(DI)
 	LEAQ 1(R10), CX
 	CMPQ CX, $1
-	JG   LBB27_17
+	JG   LBB31_17
 
-LBB27_19:
+LBB31_19:
 	TESTL R10, R10
-	JE    LBB27_20
+	JE    LBB31_20
 
-LBB27_21:
+LBB31_21:
 	BYTE $0x5d // popq         %rbp
 	RET
 
-LBB27_2:
+LBB31_2:
 	TESTQ AX, AX
-	JE    LBB27_22
+	JE    LBB31_22
 	MOVQ  AX, DX
 	SHRQ  CX, DX
 	TESTQ DX, DX
-	JNE   LBB27_6
+	JNE   LBB31_6
 
-LBB27_4:
+LBB31_4:
 	ADDQ  AX, AX
 	LEAQ  0(AX)(AX*4), AX
 	INCL  SI
 	MOVQ  AX, DX
 	SHRQ  CX, DX
 	TESTQ DX, DX
-	JE    LBB27_4
-	JMP   LBB27_6
+	JE    LBB31_4
+	JMP   LBB31_6
 
-LBB27_20:
+LBB31_20:
 	MOVL $0, 20(DI)
 	BYTE $0x5d      // popq         %rbp
 	RET
 
-LBB27_22:
+LBB31_22:
 	MOVL $0, 16(DI)
 	BYTE $0x5d      // popq         %rbp
 	RET
@@ -11953,7 +12672,7 @@ _skip_array:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+21058(SB) // _skip_array
+	CALL ·__native_entry__+21301(SB) // _skip_array
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -11974,7 +12693,7 @@ _skip_object:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+21093(SB) // _skip_object
+	CALL ·__native_entry__+21338(SB) // _skip_object
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -12040,6 +12759,27 @@ _unquote:
 	MOVQ flags+32(FP), R8
 	CALL ·__native_entry__+7080(SB) // _unquote
 	MOVQ AX, ret+40(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__validate_one(SB), NOSPLIT | NOFRAME, $0 - 32
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -136(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_validate_one:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	MOVQ m+16(FP), DX
+	CALL ·__native_entry__+25117(SB) // _validate_one
+	MOVQ AX, ret+24(FP)
 	RET
 
 _stack_grow:

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -350,7 +350,7 @@ LBB2_5:
 	LONG    $0x4fdc6941; WORD $0x1293; BYTE $0x00 // imull        $1217359, %r12d, %ebx
 	MOVQ    R12, AX
 	SHLQ    $4, AX
-	LONG    $0x7a0d8d48; WORD $0x008e; BYTE $0x00 // leaq         $36474(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
+	LONG    $0xa10d8d48; WORD $0x008d; BYTE $0x00 // leaq         $36257(%rip), %rcx  /* _DOUBLE_POW5_INV_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(AX)(CX*1), R10
@@ -437,7 +437,7 @@ LBB2_12:
 	SHRL    $19, BX
 	MOVLQSX AX, SI
 	SHLQ    $4, SI
-	LONG    $0xa5158d4c; WORD $0x00a2; BYTE $0x00 // leaq         $41637(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
+	LONG    $0xcc158d4c; WORD $0x00a1; BYTE $0x00 // leaq         $41420(%rip), %r10  /* _DOUBLE_POW5_SPLIT(%rip) */
 	MOVQ    R8, DI
 	ORQ     $2, DI
 	MOVQ    0(SI)(R10*1), R14
@@ -850,7 +850,7 @@ LBB2_61:
 	LEAQ 1(R13), BX
 	MOVQ BX, SI
 	MOVL R15, DX
-	LONG $0x005818e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x00573fe8; BYTE $0x00 // callq        _print_mantissa
 	MOVB 1(R13), AX
 	MOVB AX, 0(R13)
 	MOVL $1, AX
@@ -879,7 +879,7 @@ LBB2_66:
 	LEAL    0(CX)(CX*1), AX
 	LEAL    0(AX)(AX*4), AX
 	SUBL    AX, R14
-	LONG    $0x77058d48; WORD $0x00b1; BYTE $0x00 // leaq         $45431(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0x9e058d48; WORD $0x00b0; BYTE $0x00 // leaq         $45214(%rip), %rax  /* _Digits(%rip) */
 	MOVWLZX 0(AX)(CX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -915,7 +915,7 @@ LBB2_70:
 	CMPL    R14, $10
 	JL      LBB2_85
 	MOVLQSX R14, AX
-	LONG    $0x090d8d48; WORD $0x00b1; BYTE $0x00 // leaq         $45321(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0x300d8d48; WORD $0x00b0; BYTE $0x00 // leaq         $45104(%rip), %rcx  /* _Digits(%rip) */
 	MOVWLZX 0(CX)(AX*2), AX
 	MOVL    BX, CX
 	MOVW    AX, 0(R13)(CX*1)
@@ -934,7 +934,7 @@ LBB2_74:
 	MOVL  BX, SI
 	ADDQ  -64(BP), SI
 	MOVL  R15, DX
-	LONG  $0x005714e8; BYTE $0x00 // callq        _print_mantissa
+	LONG  $0x00563be8; BYTE $0x00 // callq        _print_mantissa
 	TESTL R13, R13
 	JE    LBB2_78
 	LEAL  0(R13)(BX*1), AX
@@ -1138,7 +1138,7 @@ LBB2_105:
 	MOVQ R13, SI
 	MOVL R15, DX
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x005402e8; BYTE $0x00 // callq        _print_mantissa
+	LONG $0x005329e8; BYTE $0x00 // callq        _print_mantissa
 	ADDL BX, R15
 	MOVL R15, BX
 
@@ -1231,7 +1231,7 @@ _u64toa:
 	ADDQ    AX, AX
 	CMPL    SI, $1000
 	JB      LBB4_3
-	LONG    $0xcb0d8d48; WORD $0x00ac; BYTE $0x00 // leaq         $44235(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0xf20d8d48; WORD $0x00ab; BYTE $0x00 // leaq         $44018(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(DX)(CX*1), CX
 	MOVB    CX, 0(DI)
 	MOVL    $1, CX
@@ -1245,14 +1245,14 @@ LBB4_3:
 LBB4_4:
 	MOVWLZX DX, DX
 	ORQ     $1, DX
-	LONG    $0xaa358d48; WORD $0x00ac; BYTE $0x00 // leaq         $44202(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0xd1358d48; WORD $0x00ab; BYTE $0x00 // leaq         $43985(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(DX)(SI*1), DX
 	MOVL    CX, SI
 	INCL    CX
 	MOVB    DX, 0(DI)(SI*1)
 
 LBB4_6:
-	LONG $0x99158d48; WORD $0x00ac; BYTE $0x00 // leaq         $44185(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xc0158d48; WORD $0x00ab; BYTE $0x00 // leaq         $43968(%rip), %rdx  /* _Digits(%rip) */
 	MOVB 0(AX)(DX*1), DX
 	MOVL CX, SI
 	INCL CX
@@ -1261,7 +1261,7 @@ LBB4_6:
 LBB4_7:
 	MOVWLZX AX, AX
 	ORQ     $1, AX
-	LONG    $0x81158d48; WORD $0x00ac; BYTE $0x00 // leaq         $44161(%rip), %rdx  /* _Digits(%rip) */
+	LONG    $0xa8158d48; WORD $0x00ab; BYTE $0x00 // leaq         $43944(%rip), %rdx  /* _Digits(%rip) */
 	MOVB    0(AX)(DX*1), AX
 	MOVL    CX, DX
 	INCL    CX
@@ -1308,7 +1308,7 @@ LBB4_8:
 	ADDQ    R11, R11
 	CMPL    SI, $10000000
 	JB      LBB4_11
-	LONG    $0xea058d48; WORD $0x00ab; BYTE $0x00 // leaq         $44010(%rip), %rax  /* _Digits(%rip) */
+	LONG    $0x11058d48; WORD $0x00ab; BYTE $0x00 // leaq         $43793(%rip), %rax  /* _Digits(%rip) */
 	MOVB    0(R10)(AX*1), AX
 	MOVB    AX, 0(DI)
 	MOVL    $1, CX
@@ -1322,14 +1322,14 @@ LBB4_11:
 LBB4_12:
 	MOVL R10, AX
 	ORQ  $1, AX
-	LONG $0xc5358d48; WORD $0x00ab; BYTE $0x00 // leaq         $43973(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xec358d48; WORD $0x00aa; BYTE $0x00 // leaq         $43756(%rip), %rsi  /* _Digits(%rip) */
 	MOVB 0(AX)(SI*1), AX
 	MOVL CX, SI
 	INCL CX
 	MOVB AX, 0(DI)(SI*1)
 
 LBB4_14:
-	LONG $0xb4058d48; WORD $0x00ab; BYTE $0x00 // leaq         $43956(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xdb058d48; WORD $0x00aa; BYTE $0x00 // leaq         $43739(%rip), %rax  /* _Digits(%rip) */
 	MOVB 0(R9)(AX*1), AX
 	MOVL CX, SI
 	INCL CX
@@ -1338,7 +1338,7 @@ LBB4_14:
 LBB4_15:
 	MOVWLZX R9, AX
 	ORQ     $1, AX
-	LONG    $0x9a358d48; WORD $0x00ab; BYTE $0x00 // leaq         $43930(%rip), %rsi  /* _Digits(%rip) */
+	LONG    $0xc1358d48; WORD $0x00aa; BYTE $0x00 // leaq         $43713(%rip), %rsi  /* _Digits(%rip) */
 	MOVB    0(AX)(SI*1), AX
 	MOVL    CX, DX
 	MOVB    AX, 0(DX)(DI*1)
@@ -1420,7 +1420,7 @@ LBB4_16:
 	MOVL $16, CX
 	SUBL AX, CX
 	SHLQ $4, AX
-	LONG $0x0d158d48; WORD $0x00ab; BYTE $0x00 // leaq         $43789(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x34158d48; WORD $0x00aa; BYTE $0x00 // leaq         $43572(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	MOVL CX, AX
@@ -1446,7 +1446,7 @@ LBB4_20:
 	CMPL DX, $99
 	JA   LBB4_22
 	MOVL DX, AX
-	LONG $0xf00d8d48; WORD $0x00a9; BYTE $0x00 // leaq         $43504(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x170d8d48; WORD $0x00a9; BYTE $0x00 // leaq         $43287(%rip), %rcx  /* _Digits(%rip) */
 	MOVB 0(CX)(AX*2), DX
 	MOVB 1(CX)(AX*2), AX
 	MOVB DX, 0(DI)
@@ -1471,7 +1471,7 @@ LBB4_22:
 	WORD    $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	SUBL    CX, AX
 	MOVWLZX AX, AX
-	LONG    $0x9f0d8d48; WORD $0x00a9; BYTE $0x00 // leaq         $43423(%rip), %rcx  /* _Digits(%rip) */
+	LONG    $0xc60d8d48; WORD $0x00a8; BYTE $0x00 // leaq         $43206(%rip), %rcx  /* _Digits(%rip) */
 	MOVB    0(CX)(AX*2), DX
 	MOVB    1(CX)(AX*2), AX
 	MOVB    DX, 1(DI)
@@ -1483,7 +1483,7 @@ LBB4_24:
 	WORD    $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	SUBL    CX, DX
 	MOVWLZX AX, AX
-	LONG    $0x7c058d4c; WORD $0x00a9; BYTE $0x00 // leaq         $43388(%rip), %r8  /* _Digits(%rip) */
+	LONG    $0xa3058d4c; WORD $0x00a8; BYTE $0x00 // leaq         $43171(%rip), %r8  /* _Digits(%rip) */
 	MOVB    0(R8)(AX*2), CX
 	MOVB    1(R8)(AX*2), AX
 	MOVB    CX, 0(DI)
@@ -1580,8 +1580,8 @@ _quote:
 	SUBQ  $16, SP
 	MOVQ  CX, R15
 	TESTB $1, R8
-	LONG  $0x1c058d48; WORD $0x00a9; BYTE $0x00 // leaq         $43292(%rip), %rax  /* __SingleQuoteTab(%rip) */
-	LONG  $0x15158d4c; WORD $0x00b9; BYTE $0x00 // leaq         $47381(%rip), %r10  /* __DoubleQuoteTab(%rip) */
+	LONG  $0x43058d48; WORD $0x00a8; BYTE $0x00 // leaq         $43075(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG  $0x3c158d4c; WORD $0x00b8; BYTE $0x00 // leaq         $47164(%rip), %r10  /* __DoubleQuoteTab(%rip) */
 	LONG  $0xd0440f4c                           // cmoveq       %rax, %r10
 	MOVQ  DX, R8
 	MOVQ  DI, AX
@@ -1790,7 +1790,7 @@ LBB5_25:
 LBB5_26:
 	TESTQ BX, BX
 	MOVQ  -48(BP), R15
-	LONG  $0xe00d8d4c; WORD $0x00a5; BYTE $0x00 // leaq         $42464(%rip), %r9  /* __SingleQuoteTab(%rip) */
+	LONG  $0x070d8d4c; WORD $0x00a5; BYTE $0x00 // leaq         $42247(%rip), %r9  /* __SingleQuoteTab(%rip) */
 	JLE   LBB5_31
 	TESTQ SI, SI
 	JLE   LBB5_31
@@ -2289,7 +2289,7 @@ LBB6_24:
 LBB6_26:
 	ADDQ    BX, AX
 	MOVBLZX -1(R9), CX
-	LONG    $0xac1d8d48; WORD $0x00c0; BYTE $0x00 // leaq         $49324(%rip), %rbx  /* __UnquoteTab(%rip) */
+	LONG    $0xd31d8d48; WORD $0x00bf; BYTE $0x00 // leaq         $49107(%rip), %rbx  /* __UnquoteTab(%rip) */
 	MOVB    0(CX)(BX*1), BX
 	CMPB    BX, $-1
 	JE      LBB6_29
@@ -2877,7 +2877,7 @@ _html_escape:
 	QUAD  $0xffffff260d6f7ec5                   // vmovdqu      $-218(%rip), %ymm9  /* LCPI7_1(%rip) */
 	QUAD  $0xffffff3e156f7ec5                   // vmovdqu      $-194(%rip), %ymm10  /* LCPI7_2(%rip) */
 	QUAD  $0xffffff56356ffec5                   // vmovdqu      $-170(%rip), %ymm6  /* LCPI7_3(%rip) */
-	LONG  $0x7b1d8d4c; WORD $0x00b9; BYTE $0x00 // leaq         $47483(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0xa21d8d4c; WORD $0x00b8; BYTE $0x00 // leaq         $47266(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	MOVQ  DI, AX
 	MOVQ  -48(BP), R12
 	JMP   LBB7_2
@@ -3094,7 +3094,7 @@ LBB7_50:
 	NEGQ  SI
 	SBBQ  R9, R9
 	XORQ  R13, R9
-	LONG  $0x511d8d4c; WORD $0x00b6; BYTE $0x00 // leaq         $46673(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x781d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46456(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3130,7 +3130,7 @@ LBB7_34:
 	SUBQ  AX, R9
 	ADDQ  R13, R9
 	NOTQ  R9
-	LONG  $0xf61d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46582(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0x1d1d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46365(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3140,7 +3140,7 @@ LBB7_40:
 	SUBQ    AX, R13
 	BSFL    CX, R9
 	ADDQ    R13, R9
-	LONG    $0xd41d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46548(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG    $0xfb1d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46331(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ   R9, R9
 	JNS     LBB7_78
 	JMP     LBB7_77
@@ -3178,7 +3178,7 @@ LBB7_22:
 
 LBB7_74:
 	MOVQ  R13, R9
-	LONG  $0x811d8d4c; WORD $0x00b5; BYTE $0x00 // leaq         $46465(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0xa81d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46248(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3228,7 +3228,7 @@ LBB7_52:
 	LEAQ 8(R13), R9
 	ADDQ $8, R8
 	LEAQ -8(R15), SI
-	LONG $0xdf1d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46303(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x061d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46086(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	CMPQ SI, $4
 	JAE  LBB7_56
 	JMP  LBB7_57
@@ -3262,7 +3262,7 @@ LBB7_71:
 	ADDQ  R13, R11
 	NOTQ  R11
 	MOVQ  R11, R9
-	LONG  $0x901d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46224(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG  $0xb71d8d4c; WORD $0x00b3; BYTE $0x00 // leaq         $46007(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	TESTQ R9, R9
 	JNS   LBB7_78
 	JMP   LBB7_77
@@ -3274,7 +3274,7 @@ LBB7_73:
 LBB7_53:
 	MOVQ R13, R9
 	MOVQ R15, SI
-	LONG $0x711d8d4c; WORD $0x00b4; BYTE $0x00 // leaq         $46193(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x981d8d4c; WORD $0x00b3; BYTE $0x00 // leaq         $45976(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	CMPQ SI, $4
 	JB   LBB7_57
 
@@ -3438,7 +3438,7 @@ LBB8_5:
 	SHLQ CX, DI
 	MOVL AX, CX
 	SHLQ $4, CX
-	LONG $0xe43d8d4c; WORD $0x003a; BYTE $0x00 // leaq         $15076(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0x0b3d8d4c; WORD $0x003a; BYTE $0x00 // leaq         $14859(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	MOVQ DI, AX
 	MULQ 8(CX)(R15*1)
 	MOVQ AX, R11
@@ -3570,14 +3570,14 @@ LBB9_5:
 	MOVQ  R13, -48(BP)
 	JLE   LBB9_20
 	XORL  R15, R15
-	LONG  $0xd32d8d4c; WORD $0x0064; BYTE $0x00 // leaq         $25811(%rip), %r13  /* _POW_TAB(%rip) */
+	LONG  $0xfa2d8d4c; WORD $0x0063; BYTE $0x00 // leaq         $25594(%rip), %r13  /* _POW_TAB(%rip) */
 	JMP   LBB9_9
 
 LBB9_7:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x0037f0e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x003717e8; BYTE $0x00 // callq        _right_shift
 
 LBB9_8:
 	ADDL  R14, R15
@@ -3607,7 +3607,7 @@ LBB9_11:
 LBB9_15:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x0037a8e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0036cfe8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3621,7 +3621,7 @@ LBB9_16:
 LBB9_17:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x00361ae8; BYTE $0x00 // callq        _left_shift
+	LONG $0x003541e8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3633,16 +3633,16 @@ LBB9_18:
 
 LBB9_19:
 	MOVQ R12, DI
-	LONG $0x003604e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x00352be8; BYTE $0x00 // callq        _left_shift
 	JMP  LBB9_8
 
 LBB9_20:
-	LONG $0x3f358d4c; WORD $0x0064; BYTE $0x00 // leaq         $25663(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x66358d4c; WORD $0x0063; BYTE $0x00 // leaq         $25446(%rip), %r14  /* _POW_TAB(%rip) */
 	JMP  LBB9_23
 
 LBB9_21:
 	MOVQ R12, DI
-	LONG $0x0035f1e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x003518e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_22:
 	SUBL R13, R15
@@ -3682,7 +3682,7 @@ LBB9_28:
 LBB9_33:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x003596e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x0034bde8; BYTE $0x00 // callq        _left_shift
 	LEAL -60(BX), SI
 	CMPL BX, $120
 	MOVL SI, BX
@@ -3697,7 +3697,7 @@ LBB9_34:
 LBB9_35:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x0036e3e8; BYTE $0x00 // callq        _right_shift
+	LONG $0x00360ae8; BYTE $0x00 // callq        _right_shift
 	LEAL 60(BX), AX
 	CMPL BX, $-120
 	MOVL AX, BX
@@ -3707,7 +3707,7 @@ LBB9_36:
 	NEGL BX
 	MOVQ R12, DI
 	MOVL BX, SI
-	LONG $0x0036cde8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0035f4e8; BYTE $0x00 // callq        _right_shift
 	JMP  LBB9_22
 
 LBB9_37:
@@ -3724,7 +3724,7 @@ LBB9_37:
 LBB9_41:
 	MOVQ R12, DI
 	MOVL $60, SI
-	LONG $0x00368ce8; BYTE $0x00 // callq        _right_shift
+	LONG $0x0035b3e8; BYTE $0x00 // callq        _right_shift
 	ADDL $60, R15
 	CMPL R15, $-120
 	JL   LBB9_41
@@ -3751,7 +3751,7 @@ LBB9_47:
 	NEGL R15
 	MOVQ R12, DI
 	MOVL R15, SI
-	LONG $0x00363ce8; BYTE $0x00 // callq        _right_shift
+	LONG $0x003563e8; BYTE $0x00 // callq        _right_shift
 	MOVL $-1022, R14
 
 LBB9_48:
@@ -3759,7 +3759,7 @@ LBB9_48:
 	JE   LBB9_50
 	MOVQ R12, DI
 	MOVL $53, SI
-	LONG $0x0034b2e8; BYTE $0x00 // callq        _left_shift
+	LONG $0x0033d9e8; BYTE $0x00 // callq        _left_shift
 
 LBB9_50:
 	MOVLQSX 20(R12), R10
@@ -5467,7 +5467,7 @@ LBB14_71:
 	CMPL    DI, $23
 	JL      LBB14_81
 	MOVLQSX DI, AX
-	LONG    $0xfb0d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50171(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0x220d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $49954(%rip), %rcx  /* _P10_TAB(%rip) */
 	QUAD    $0xffff50c18459fbc5; BYTE $0xff       // vmulsd       $-176(%rcx,%rax,8), %xmm0, %xmm0
 	LONG    $0x4511fbc5; BYTE $0xd0               // vmovsd       %xmm0, $-48(%rbp)
 	MOVL    $22, AX
@@ -5485,7 +5485,7 @@ LBB14_77:
 	JB      LBB14_60
 	NEGL    DI
 	MOVLQSX DI, AX
-	LONG    $0xb90d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50105(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG    $0xe00d8d48; WORD $0x00c2; BYTE $0x00 // leaq         $49888(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG    $0x045efbc5; BYTE $0xc1               // vdivsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP     LBB14_65
 
@@ -5517,7 +5517,7 @@ LBB14_82:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	JA   LBB14_60
 	MOVL AX, AX
-	LONG $0x400d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $49984(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x670d8d48; WORD $0x00c2; BYTE $0x00 // leaq         $49767(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	JMP  LBB14_65
 
@@ -6215,7 +6215,7 @@ LBB18_81:
 	SUBQ  R13, SI
 	MOVQ  R11, BX
 	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG  $0x000f38e8; BYTE $0x00 // callq        _skip_number
+	LONG  $0x000e90e8; BYTE $0x00 // callq        _skip_number
 	TESTQ AX, AX
 	JS    LBB18_114
 	MOVQ  0(BX), CX
@@ -6313,7 +6313,7 @@ LBB18_97:
 	SUBQ  R13, SI
 	MOVQ  R11, BX
 	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG  $0x000db3e8; BYTE $0x00 // callq        _skip_number
+	LONG  $0x000d0be8; BYTE $0x00 // callq        _skip_number
 	MOVQ  BX, R11
 	MOVQ  0(BX), CX
 	TESTQ AX, AX
@@ -6768,115 +6768,113 @@ _validate_string:
 	SUBQ $40, SP
 	MOVQ SI, R14
 	MOVQ 0(SI), R15
-	MOVQ 8(DI), DX
-	MOVQ DX, -72(BP)
-	SUBQ R15, DX
+	MOVQ 8(DI), R12
+	MOVQ R12, -64(BP)
+	SUBQ R15, R12
 	JE   LBB22_18
 	MOVQ R14, -48(BP)
-	MOVQ 0(DI), AX
-	MOVQ AX, -56(BP)
-	LEAQ 0(AX)(R15*1), BX
-	CMPQ DX, $64
-	MOVQ BX, -80(BP)
-	JB   LBB22_25
-	MOVL DX, R12
-	ANDL $63, R12
+	MOVQ 0(DI), DI
+	LEAQ 0(DI)(R15*1), SI
+	CMPQ R12, $64
+	MOVQ SI, -72(BP)
+	JB   LBB22_33
+	MOVL R12, R9
+	ANDL $63, R9
 	MOVQ $-1, AX
 	XORL R13, R13
-	QUAD $0xffffff42056ffec5 // vmovdqu      $-190(%rip), %ymm0  /* LCPI22_0(%rip) */
-	QUAD $0xffffff5a0d6ffec5 // vmovdqu      $-166(%rip), %ymm1  /* LCPI22_1(%rip) */
-	QUAD $0xffffff72156ffec5 // vmovdqu      $-142(%rip), %ymm2  /* LCPI22_2(%rip) */
+	QUAD $0xffffff46056ffec5 // vmovdqu      $-186(%rip), %ymm0  /* LCPI22_0(%rip) */
+	QUAD $0xffffff5e0d6ffec5 // vmovdqu      $-162(%rip), %ymm1  /* LCPI22_1(%rip) */
+	QUAD $0xffffff76156ffec5 // vmovdqu      $-138(%rip), %ymm2  /* LCPI22_2(%rip) */
 	LONG $0xdb76e5c5         // vpcmpeqd     %ymm3, %ymm3, %ymm3
-	MOVQ DX, CX
 
 LBB22_3:
-	LONG  $0x236ffec5             // vmovdqu      (%rbx), %ymm4
-	LONG  $0x6b6ffec5; BYTE $0x20 // vmovdqu      $32(%rbx), %ymm5
+	LONG  $0x266ffec5             // vmovdqu      (%rsi), %ymm4
+	LONG  $0x6e6ffec5; BYTE $0x20 // vmovdqu      $32(%rsi), %ymm5
 	LONG  $0xf074ddc5             // vpcmpeqb     %ymm0, %ymm4, %ymm6
-	LONG  $0xf6d77dc5             // vpmovmskb    %ymm6, %r14d
-	LONG  $0xf074d5c5             // vpcmpeqb     %ymm0, %ymm5, %ymm6
-	LONG  $0xd6d77dc5             // vpmovmskb    %ymm6, %r10d
-	LONG  $0xf174ddc5             // vpcmpeqb     %ymm1, %ymm4, %ymm6
 	LONG  $0xc6d77dc5             // vpmovmskb    %ymm6, %r8d
+	LONG  $0xf074d5c5             // vpcmpeqb     %ymm0, %ymm5, %ymm6
+	LONG  $0xded7fdc5             // vpmovmskb    %ymm6, %ebx
+	LONG  $0xf174ddc5             // vpcmpeqb     %ymm1, %ymm4, %ymm6
+	LONG  $0xded77dc5             // vpmovmskb    %ymm6, %r11d
 	LONG  $0xf174d5c5             // vpcmpeqb     %ymm1, %ymm5, %ymm6
-	LONG  $0xced77dc5             // vpmovmskb    %ymm6, %r9d
+	LONG  $0xf6d77dc5             // vpmovmskb    %ymm6, %r14d
 	LONG  $0xf464edc5             // vpcmpgtb     %ymm4, %ymm2, %ymm6
 	LONG  $0xe364ddc5             // vpcmpgtb     %ymm3, %ymm4, %ymm4
 	LONG  $0xe6dbddc5             // vpand        %ymm6, %ymm4, %ymm4
-	LONG  $0xdcd77dc5             // vpmovmskb    %ymm4, %r11d
+	LONG  $0xd4d77dc5             // vpmovmskb    %ymm4, %r10d
 	LONG  $0xe564edc5             // vpcmpgtb     %ymm5, %ymm2, %ymm4
 	LONG  $0xeb64d5c5             // vpcmpgtb     %ymm3, %ymm5, %ymm5
 	LONG  $0xe4dbd5c5             // vpand        %ymm4, %ymm5, %ymm4
-	LONG  $0xf4d7fdc5             // vpmovmskb    %ymm4, %esi
-	SHLQ  $32, R10
-	SHLQ  $32, R9
-	ORQ   R9, R8
+	LONG  $0xd4d7fdc5             // vpmovmskb    %ymm4, %edx
+	SHLQ  $32, BX
+	SHLQ  $32, R14
+	ORQ   R14, R11
 	CMPQ  AX, $-1
 	JNE   LBB22_5
-	TESTQ R8, R8
+	TESTQ R11, R11
 	JNE   LBB22_10
 
 LBB22_5:
-	SHLQ  $32, SI
-	ORQ   R14, R10
-	MOVQ  R8, DI
-	ORQ   R13, DI
+	SHLQ  $32, DX
+	ORQ   R8, BX
+	MOVQ  R11, CX
+	ORQ   R13, CX
 	JNE   LBB22_9
-	ORQ   R11, SI
-	TESTQ R10, R10
+	ORQ   R10, DX
+	TESTQ BX, BX
 	JNE   LBB22_11
 
 LBB22_7:
-	TESTQ SI, SI
+	TESTQ DX, DX
 	JNE   LBB22_21
-	ADDQ  $64, BX
-	ADDQ  $-64, CX
-	CMPQ  CX, $63
+	ADDQ  $64, SI
+	ADDQ  $-64, R12
+	CMPQ  R12, $63
 	JA    LBB22_3
-	JMP   LBB22_26
+	JMP   LBB22_23
 
 LBB22_9:
 	MOVQ  R13, R14
 	NOTQ  R14
-	ANDQ  R8, R14
-	LEAQ  0(R14)(R14*1), R9
-	ORQ   R13, R9
-	MOVQ  R9, -64(BP)
-	NOTQ  R9
-	ANDQ  R8, R9
-	MOVQ  $-6148914691236517206, DI
-	ANDQ  DI, R9
+	ANDQ  R11, R14
+	LEAQ  0(R14)(R14*1), R8
+	ORQ   R13, R8
+	MOVQ  R8, -56(BP)
+	NOTQ  R8
+	ANDQ  R11, R8
+	MOVQ  $-6148914691236517206, CX
+	ANDQ  CX, R8
 	XORL  R13, R13
-	ADDQ  R14, R9
+	ADDQ  R14, R8
 	SETCS R13
-	ADDQ  R9, R9
-	MOVQ  $6148914691236517205, DI
-	XORQ  DI, R9
-	ANDQ  -64(BP), R9
-	NOTQ  R9
-	ANDQ  R9, R10
-	ORQ   R11, SI
-	TESTQ R10, R10
+	ADDQ  R8, R8
+	MOVQ  $6148914691236517205, CX
+	XORQ  CX, R8
+	ANDQ  -56(BP), R8
+	NOTQ  R8
+	ANDQ  R8, BX
+	ORQ   R10, DX
+	TESTQ BX, BX
 	JE    LBB22_7
 	JMP   LBB22_11
 
 LBB22_10:
-	MOVQ BX, R9
-	SUBQ -56(BP), R9
-	BSFQ R8, AX
-	ADDQ R9, AX
+	MOVQ SI, R14
+	SUBQ DI, R14
+	BSFQ R11, AX
+	ADDQ R14, AX
 	JMP  LBB22_5
 
 LBB22_11:
-	SUBQ  -56(BP), BX
-	BSFQ  R10, CX
-	LEAQ  1(BX)(CX*1), R12
-	TESTQ SI, SI
+	SUBQ  DI, SI
+	BSFQ  BX, BX
+	LEAQ  1(SI)(BX*1), R12
+	TESTQ DX, DX
 	MOVQ  -48(BP), R14
 	JE    LBB22_13
-	BSFQ  SI, SI
-	CMPQ  SI, CX
-	JBE   LBB22_34
+	BSFQ  DX, CX
+	CMPQ  CX, BX
+	JBE   LBB22_29
 
 LBB22_13:
 	TESTQ R12, R12
@@ -6884,7 +6882,7 @@ LBB22_13:
 	MOVQ  R15, SI
 	NOTQ  SI
 	ADDQ  R12, SI
-	MOVQ  -80(BP), DI
+	MOVQ  -72(BP), DI
 	WORD  $0xf8c5; BYTE $0x77     // vzeroupper
 	LONG  $0x00026ee8; BYTE $0x00 // callq        _utf8_validate
 	TESTQ AX, AX
@@ -6901,7 +6899,7 @@ LBB22_17:
 
 LBB22_18:
 	MOVQ $-1, R12
-	MOVQ -72(BP), AX
+	MOVQ -64(BP), AX
 	JMP  LBB22_20
 
 LBB22_19:
@@ -6925,372 +6923,356 @@ LBB22_20:
 LBB22_21:
 	MOVQ $-2, R12
 	CMPQ AX, $-1
-	JE   LBB22_23
+	JE   LBB22_30
 
 LBB22_22:
 	MOVQ -48(BP), R14
 	JMP  LBB22_20
 
 LBB22_23:
-	SUBQ -56(BP), BX
-	BSFQ SI, AX
+	MOVQ R9, R12
+	CMPQ R12, $32
+	JB   LBB22_39
 
 LBB22_24:
-	ADDQ BX, AX
-	MOVQ -48(BP), R14
-	JMP  LBB22_20
-
-LBB22_25:
-	MOVQ $-1, AX
-	XORL R13, R13
-	MOVQ DX, R12
-
-LBB22_26:
-	CMPQ  R12, $32
-	JB    LBB22_40
-	LONG  $0x036ffec5         // vmovdqu      (%rbx), %ymm0
-	QUAD  $0xfffffd5c0d74fdc5 // vpcmpeqb     $-676(%rip), %ymm0, %ymm1  /* LCPI22_0(%rip) */
-	LONG  $0xf1d7fdc5         // vpmovmskb    %ymm1, %esi
-	QUAD  $0xfffffd700d74fdc5 // vpcmpeqb     $-656(%rip), %ymm0, %ymm1  /* LCPI22_1(%rip) */
-	LONG  $0xc9d7fdc5         // vpmovmskb    %ymm1, %ecx
-	QUAD  $0xfffffd840d6ffec5 // vmovdqu      $-636(%rip), %ymm1  /* LCPI22_2(%rip) */
+	LONG  $0x066ffec5         // vmovdqu      (%rsi), %ymm0
+	QUAD  $0xfffffd7c0d74fdc5 // vpcmpeqb     $-644(%rip), %ymm0, %ymm1  /* LCPI22_0(%rip) */
+	LONG  $0xd9d7fdc5         // vpmovmskb    %ymm1, %ebx
+	QUAD  $0xfffffd900d74fdc5 // vpcmpeqb     $-624(%rip), %ymm0, %ymm1  /* LCPI22_1(%rip) */
+	LONG  $0xd1d7fdc5         // vpmovmskb    %ymm1, %edx
+	QUAD  $0xfffffda40d6ffec5 // vmovdqu      $-604(%rip), %ymm1  /* LCPI22_2(%rip) */
 	LONG  $0xc864f5c5         // vpcmpgtb     %ymm0, %ymm1, %ymm1
 	LONG  $0xd276edc5         // vpcmpeqd     %ymm2, %ymm2, %ymm2
 	LONG  $0xc264fdc5         // vpcmpgtb     %ymm2, %ymm0, %ymm0
 	LONG  $0xc1dbfdc5         // vpand        %ymm1, %ymm0, %ymm0
 	LONG  $0xc0d77dc5         // vpmovmskb    %ymm0, %r8d
-	TESTL CX, CX
-	JNE   LBB22_35
+	TESTL DX, DX
+	JNE   LBB22_34
 	TESTQ R13, R13
-	JNE   LBB22_37
+	JNE   LBB22_36
 	XORL  R13, R13
-	TESTQ SI, SI
-	JE    LBB22_38
+	TESTQ BX, BX
+	JE    LBB22_37
 
-LBB22_30:
-	SUBQ  -56(BP), BX
-	BSFQ  SI, SI
-	LEAQ  1(BX)(SI*1), R12
+LBB22_27:
+	SUBQ  DI, SI
+	BSFQ  BX, DX
+	LEAQ  1(SI)(DX*1), R12
 	TESTL R8, R8
-	JE    LBB22_33
+	JE    LBB22_32
 	BSFQ  R8, CX
-	CMPQ  CX, SI
+	CMPQ  CX, DX
 	MOVQ  -48(BP), R14
 	JA    LBB22_13
-	ADDQ  BX, CX
-	CMPQ  AX, $-1
-	LONG  $0xc1440f48      // cmoveq       %rcx, %rax
-	JMP   LBB22_16
 
-LBB22_33:
+LBB22_29:
+	ADDQ SI, CX
+	CMPQ AX, $-1
+	LONG $0xc1440f48 // cmoveq       %rcx, %rax
+	JMP  LBB22_16
+
+LBB22_30:
+	SUBQ DI, SI
+	BSFQ DX, AX
+
+LBB22_31:
+	ADDQ SI, AX
+	MOVQ -48(BP), R14
+	JMP  LBB22_20
+
+LBB22_32:
 	MOVQ -48(BP), R14
 	JMP  LBB22_13
 
+LBB22_33:
+	MOVQ $-1, AX
+	XORL R13, R13
+	CMPQ R12, $32
+	JAE  LBB22_24
+	JMP  LBB22_39
+
 LBB22_34:
-	ADDQ BX, SI
 	CMPQ AX, $-1
-	LONG $0xc6440f48 // cmoveq       %rsi, %rax
-	JMP  LBB22_16
+	JNE  LBB22_36
+	MOVQ SI, CX
+	SUBQ DI, CX
+	BSFQ DX, AX
+	ADDQ CX, AX
 
-LBB22_35:
-	CMPQ AX, $-1
-	JNE  LBB22_37
-	MOVQ BX, DI
-	SUBQ -56(BP), DI
-	BSFQ CX, AX
-	ADDQ DI, AX
-
-LBB22_37:
+LBB22_36:
 	MOVL  R13, R10
 	NOTL  R10
-	ANDL  CX, R10
+	ANDL  DX, R10
 	LEAL  0(R10)(R10*1), R9
 	ORL   R13, R9
-	MOVL  R9, DI
-	NOTL  DI
-	ANDL  CX, DI
-	ANDL  $-1431655766, DI
+	MOVL  R9, CX
+	NOTL  CX
+	ANDL  DX, CX
+	ANDL  $-1431655766, CX
 	XORL  R13, R13
-	ADDL  R10, DI
+	ADDL  R10, CX
 	SETCS R13
-	ADDL  DI, DI
-	XORL  $1431655765, DI
-	ANDL  R9, DI
-	NOTL  DI
-	ANDL  DI, SI
-	TESTQ SI, SI
-	JNE   LBB22_30
+	ADDL  CX, CX
+	XORL  $1431655765, CX
+	ANDL  R9, CX
+	NOTL  CX
+	ANDL  CX, BX
+	TESTQ BX, BX
+	JNE   LBB22_27
 
-LBB22_38:
+LBB22_37:
 	TESTL R8, R8
-	JNE   LBB22_52
-	ADDQ  $32, BX
+	JNE   LBB22_51
+	ADDQ  $32, SI
 	ADDQ  $-32, R12
 
-LBB22_40:
+LBB22_39:
 	TESTQ R13, R13
-	JNE   LBB22_54
+	JNE   LBB22_53
 	MOVQ  -48(BP), R14
 	TESTQ R12, R12
-	JE    LBB22_51
+	JE    LBB22_50
 
-LBB22_42:
-	MOVQ -56(BP), R8
+LBB22_41:
+	MOVQ DI, R8
 	NOTQ R8
 
-LBB22_43:
-	LEAQ    1(BX), SI
-	MOVBLZX 0(BX), CX
-	CMPB    CX, $34
-	JE      LBB22_50
+LBB22_42:
+	LEAQ    1(SI), DX
+	MOVBLZX 0(SI), BX
+	CMPB    BX, $34
+	JE      LBB22_49
 	LEAQ    -1(R12), R10
-	CMPB    CX, $92
-	JE      LBB22_47
-	CMPB    CX, $31
-	JBE     LBB22_56
-	MOVQ    SI, BX
+	CMPB    BX, $92
+	JE      LBB22_46
+	CMPB    BX, $31
+	JBE     LBB22_55
+	MOVQ    DX, SI
 	MOVQ    R10, R12
 	TESTQ   R10, R10
-	JNE     LBB22_43
-	JMP     LBB22_49
+	JNE     LBB22_42
+	JMP     LBB22_48
 
-LBB22_47:
+LBB22_46:
 	TESTQ R10, R10
 	JE    LBB22_18
-	ADDQ  R8, SI
+	ADDQ  R8, DX
 	CMPQ  AX, $-1
-	LONG  $0xc6440f48 // cmoveq       %rsi, %rax
-	ADDQ  $2, BX
+	LONG  $0xc2440f48 // cmoveq       %rdx, %rax
+	ADDQ  $2, SI
 	ADDQ  $-2, R12
 	MOVQ  R12, R10
 	TESTQ R10, R10
-	JNE   LBB22_43
+	JNE   LBB22_42
+
+LBB22_48:
+	CMPB BX, $34
+	JNE  LBB22_18
+	JMP  LBB22_50
 
 LBB22_49:
-	CMPB CX, $34
-	JNE  LBB22_18
-	JMP  LBB22_51
+	MOVQ DX, SI
 
 LBB22_50:
-	MOVQ SI, BX
-
-LBB22_51:
-	SUBQ -56(BP), BX
-	MOVQ BX, R12
+	SUBQ DI, SI
+	MOVQ SI, R12
 	JMP  LBB22_13
 
-LBB22_52:
+LBB22_51:
 	MOVQ $-2, R12
 	CMPQ AX, $-1
 	JNE  LBB22_22
-	SUBQ -56(BP), BX
+	SUBQ DI, SI
 	BSFQ R8, AX
-	JMP  LBB22_24
+	JMP  LBB22_31
 
-LBB22_54:
+LBB22_53:
 	TESTQ R12, R12
 	MOVQ  -48(BP), R14
 	JE    LBB22_18
-	MOVQ  -56(BP), CX
+	MOVQ  DI, CX
 	NOTQ  CX
-	ADDQ  BX, CX
+	ADDQ  SI, CX
 	CMPQ  AX, $-1
 	LONG  $0xc1440f48  // cmoveq       %rcx, %rax
-	INCQ  BX
+	INCQ  SI
 	DECQ  R12
 	TESTQ R12, R12
-	JNE   LBB22_42
-	JMP   LBB22_51
+	JNE   LBB22_41
+	JMP   LBB22_50
 
-LBB22_56:
+LBB22_55:
 	MOVQ $-2, R12
 	CMPQ AX, $-1
 	JNE  LBB22_22
-	ADDQ R8, SI
-	MOVQ SI, AX
+	ADDQ R8, DX
+	MOVQ DX, AX
 	MOVQ -48(BP), R14
 	JMP  LBB22_20
 
 _utf8_validate:
-	BYTE  $0x55               // pushq        %rbp
-	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
-	WORD  $0x5641             // pushq        %r14
-	BYTE  $0x53               // pushq        %rbx
+	BYTE  $0x55                                 // pushq        %rbp
+	WORD  $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD  $0x5741                               // pushq        %r15
+	WORD  $0x5641                               // pushq        %r14
+	BYTE  $0x53                                 // pushq        %rbx
 	MOVQ  $-1, AX
 	TESTQ SI, SI
-	JLE   LBB23_38
-	MOVQ  DI, R9
+	JLE   LBB23_33
+	LONG  $0x550d8d4c; WORD $0x00af; BYTE $0x00 // leaq         $44885(%rip), %r9  /* _first(%rip) */
+	LONG  $0x4e058d4c; WORD $0x00b0; BYTE $0x00 // leaq         $45134(%rip), %r8  /* _ranges(%rip) */
+	LONG  $0x4e158d4c; WORD $0x0001; BYTE $0x00 // leaq         $334(%rip), %r10  /* LJTI23_0(%rip) */
+	MOVQ  DI, R11
 
 LBB23_2:
-	CMPB 0(R9), $0
+	CMPB 0(R11), $0
 	JS   LBB23_3
-	MOVQ DX, R8
-	MOVQ SI, CX
-	MOVQ R9, R10
-	CMPQ DX, $32
-	JL   LBB23_11
-	MOVQ R9, R10
-	MOVQ SI, CX
-	MOVQ DX, R11
+	MOVQ SI, DX
+	MOVQ R11, CX
+	CMPQ SI, $32
+	JL   LBB23_10
+	MOVQ R11, CX
+	MOVQ SI, DX
 
 LBB23_6:
-	LONG  $0x6f7ec1c4; BYTE $0x02 // vmovdqu      (%r10), %ymm0
-	LONG  $0xd8d7fdc5             // vpmovmskb    %ymm0, %ebx
+	LONG  $0x016ffec5 // vmovdqu      (%rcx), %ymm0
+	LONG  $0xd8d7fdc5 // vpmovmskb    %ymm0, %ebx
 	TESTL BX, BX
 	JNE   LBB23_7
-	LEAQ  -32(R11), R8
-	ADDQ  $32, R10
-	CMPQ  CX, $33
-	LEAQ  -32(CX), CX
-	JL    LBB23_11
-	CMPQ  R11, $63
-	MOVQ  R8, R11
+	ADDQ  $32, CX
+	CMPQ  DX, $63
+	LEAQ  -32(DX), DX
 	JG    LBB23_6
 
-LBB23_11:
-	WORD  $0xf8c5; BYTE $0x77 // vzeroupper
-	CMPQ  R8, $16
-	JL    LBB23_13
-	TESTQ CX, CX
-	JLE   LBB23_13
+LBB23_10:
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	CMPQ DX, $16
+	JL   LBB23_11
 
 LBB23_16:
-	LONG  $0x6f7ac1c4; BYTE $0x02 // vmovdqu      (%r10), %xmm0
-	LONG  $0xd8d7f9c5             // vpmovmskb    %xmm0, %ebx
+	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
+	LONG  $0xd8d7f9c5 // vpmovmskb    %xmm0, %ebx
 	TESTW BX, BX
 	JNE   LBB23_17
-	ADDQ  $16, R10
-	CMPQ  CX, $17
-	LEAQ  -16(CX), CX
-	JL    LBB23_13
-	CMPQ  R8, $31
-	LEAQ  -16(R8), R8
+	ADDQ  $16, CX
+	CMPQ  DX, $31
+	LEAQ  -16(DX), DX
 	JG    LBB23_16
-	JMP   LBB23_13
 
-LBB23_15:
-	DECQ CX
-	INCQ R10
+LBB23_11:
+	TESTQ DX, DX
+	JLE   LBB23_33
+	INCQ  DX
 
 LBB23_13:
-	TESTQ CX, CX
-	JE    LBB23_38
-	CMPB  0(R10), $0
-	JNS   LBB23_15
-	SUBQ  R9, R10
-	MOVQ  R10, R8
-	CMPQ  R8, $-1
-	JNE   LBB23_22
-	JMP   LBB23_38
+	CMPB 0(CX), $0
+	JS   LBB23_18
+	INCQ CX
+	DECQ DX
+	CMPQ DX, $1
+	JG   LBB23_13
+	JMP  LBB23_33
 
 LBB23_3:
-	XORL R8, R8
-	CMPQ R8, $-1
-	JE   LBB23_38
+	XORL DX, DX
+	CMPQ DX, $-1
+	JNE  LBB23_20
+	JMP  LBB23_33
 
-LBB23_22:
-	SUBQ    R8, SI
-	JLE     LBB23_38
-	LEAQ    0(R9)(R8*1), R10
-	CMPQ    SI, $2
-	JB      LBB23_37
-	MOVBLZX 1(R9)(R8*1), R11
-	MOVL    R11, CX
-	ANDL    $-64, CX
-	CMPL    CX, $128
-	JNE     LBB23_37
-	MOVBLZX 0(R10), R14
-	MOVL    R14, CX
-	ANDL    $-32, CX
-	CMPL    CX, $192
-	JE      LBB23_26
-	CMPQ    SI, $3
-	JB      LBB23_37
-	MOVBLZX 2(R9)(R8*1), CX
-	MOVL    CX, BX
-	ANDL    $-64, BX
-	CMPL    BX, $128
-	JNE     LBB23_37
-	CMPB    R14, $-17
-	JA      LBB23_33
-	SHLL    $12, R14
-	MOVWLZX R14, R9
-	ANDL    $63, R11
-	SHLL    $6, R11
-	ANDL    $63, CX
-	ORL     R11, CX
-	LEAL    0(CX)(R9*1), BX
-	MOVL    $3, R11
-	CMPL    BX, $57343
-	JA      LBB23_32
-	LEAL    -2048(R9)(CX*1), CX
-	CMPL    CX, $53248
-	JAE     LBB23_37
+LBB23_18:
+	SUBQ R11, CX
+	MOVQ CX, DX
+	CMPQ DX, $-1
+	JE   LBB23_33
+
+LBB23_20:
+	SUBQ    DX, SI
+	JLE     LBB23_33
+	LEAQ    0(R11)(DX*1), R14
+	MOVBLZX 0(R11)(DX*1), R11
+	MOVBLZX 0(R11)(R9*1), R15
+	MOVL    R15, DX
+	ANDL    $7, DX
+	CMPQ    SI, DX
+	JB      LBB23_31
+	CMPB    DX, $4
+	JA      LBB23_31
+	MOVL    $1, BX
+	MOVBLZX DX, CX
+	MOVLQSX 0(R10)(CX*4), CX
+	ADDQ    R10, CX
+	JMP     CX
+
+LBB23_24:
+	MOVB  3(R14), BX
+	TESTB BX, BX
+	JNS   LBB23_31
+	CMPB  BX, $-65
+	JA    LBB23_31
+
+LBB23_26:
+	MOVB  2(R14), BX
+	TESTB BX, BX
+	JNS   LBB23_31
+	CMPB  BX, $-65
+	JA    LBB23_31
+
+LBB23_28:
+	TESTB R11, R11
+	JNS   LBB23_31
+	SHRQ  $4, R15
+	MOVB  1(R14), R11
+	CMPB  R11, 0(R8)(R15*2)
+	JB    LBB23_31
+	MOVQ  DX, BX
+	CMPB  1(R8)(R15*2), R11
+	JB    LBB23_31
 
 LBB23_32:
-	SUBQ R8, DX
-	SUBQ R11, DX
-	ADDQ R11, R10
-	MOVQ R10, R9
-	SUBQ R11, SI
+	ADDQ BX, R14
+	MOVQ R14, R11
+	SUBQ BX, SI
 	JG   LBB23_2
-	JMP  LBB23_38
+	JMP  LBB23_33
 
 LBB23_7:
-	MOVLQSX BX, CX
+	MOVLQSX BX, DX
 	JMP     LBB23_8
 
 LBB23_17:
-	MOVWLZX BX, CX
+	MOVWLZX BX, DX
 
 LBB23_8:
-	SUBQ R9, R10
-	BSFQ CX, R8
-	ADDQ R10, R8
-	CMPQ R8, $-1
-	JNE  LBB23_22
-	JMP  LBB23_38
+	SUBQ R11, CX
+	BSFQ DX, DX
+	ADDQ CX, DX
+	CMPQ DX, $-1
+	JNE  LBB23_20
+	JMP  LBB23_33
 
-LBB23_26:
-	MOVL  $2, R11
-	TESTB $30, R14
-	JNE   LBB23_32
-	JMP   LBB23_37
+LBB23_31:
+	SUBQ DI, R14
+	MOVQ R14, AX
 
 LBB23_33:
-	CMPQ    SI, $4
-	JB      LBB23_37
-	MOVBLZX 3(R9)(R8*1), R9
-	MOVL    R9, BX
-	ANDL    $-64, BX
-	CMPL    BX, $128
-	JNE     LBB23_37
-	CMPB    R14, $-9
-	JA      LBB23_37
-	ANDL    $7, R14
-	SHLL    $18, R14
-	ANDL    $63, R11
-	SHLL    $12, R11
-	ANDL    $63, CX
-	SHLL    $6, CX
-	ORL     R11, CX
-	ANDL    $63, R9
-	ORL     CX, R9
-	LEAL    -65536(R14)(R9*1), CX
-	MOVL    $4, R11
-	CMPL    CX, $1048576
-	JB      LBB23_32
-
-LBB23_37:
-	SUBQ DI, R10
-	MOVQ R10, AX
-
-LBB23_38:
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5e41             // popq         %r14
+	WORD $0x5f41             // popq         %r15
 	BYTE $0x5d               // popq         %rbp
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	RET
+
+// .set L23_0_set_32, LBB23_32-LJTI23_0
+// .set L23_0_set_31, LBB23_31-LJTI23_0
+// .set L23_0_set_28, LBB23_28-LJTI23_0
+// .set L23_0_set_26, LBB23_26-LJTI23_0
+// .set L23_0_set_24, LBB23_24-LJTI23_0
+LJTI23_0:
+	LONG $0xffffffc1 // .long L23_0_set_32
+	LONG $0xfffffff0 // .long L23_0_set_31
+	LONG $0xffffffa4 // .long L23_0_set_28
+	LONG $0xffffff97 // .long L23_0_set_26
+	LONG $0xffffff8a // .long L23_0_set_24
 
 _skip_negative:
 	BYTE  $0x55                   // pushq        %rbp
@@ -7880,89 +7862,69 @@ _validate_one:
 	JMP  _fsm_exec
 
 _find_non_ascii:
-	BYTE  $0x55               // pushq        %rbp
-	WORD  $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
-	CMPQ  DX, $32
-	JL    LBB28_1
-	TESTQ SI, SI
-	JLE   LBB28_1
-	MOVQ  DI, CX
+	BYTE $0x55               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5 // movq         %rsp, %rbp
+	MOVQ DI, CX
+	CMPQ SI, $32
+	JL   LBB28_5
 
-LBB28_4:
+LBB28_1:
 	LONG  $0x016ffec5 // vmovdqu      (%rcx), %ymm0
 	LONG  $0xc0d7fdc5 // vpmovmskb    %ymm0, %eax
 	TESTL AX, AX
-	JNE   LBB28_5
-	LEAQ  -32(SI), AX
+	JNE   LBB28_2
 	ADDQ  $32, CX
-	CMPQ  DX, $64
-	LEAQ  -32(DX), DX
-	JL    LBB28_9
-	CMPQ  SI, $32
-	MOVQ  AX, SI
-	JG    LBB28_4
-	JMP   LBB28_9
+	CMPQ  SI, $63
+	LEAQ  -32(SI), SI
+	JG    LBB28_1
 
-LBB28_1:
-	MOVQ SI, AX
-	MOVQ DI, CX
-
-LBB28_9:
-	WORD  $0xf8c5; BYTE $0x77 // vzeroupper
-	CMPQ  DX, $16
-	JL    LBB28_11
-	TESTQ AX, AX
-	JLE   LBB28_11
-
-LBB28_16:
-	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
-	LONG  $0xf0d7f9c5 // vpmovmskb    %xmm0, %esi
-	TESTW SI, SI
-	JNE   LBB28_17
-	LEAQ  -16(AX), SI
-	ADDQ  $16, CX
-	CMPQ  DX, $32
-	JL    LBB28_12
-	ADDQ  $-16, DX
-	CMPQ  AX, $16
-	MOVQ  SI, AX
-	JG    LBB28_16
-	JMP   LBB28_12
+LBB28_5:
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	CMPQ SI, $16
+	JL   LBB28_6
 
 LBB28_11:
-	MOVQ AX, SI
+	LONG  $0x016ffac5 // vmovdqu      (%rcx), %xmm0
+	LONG  $0xc0d7f9c5 // vpmovmskb    %xmm0, %eax
+	TESTW AX, AX
+	JNE   LBB28_12
+	ADDQ  $16, CX
+	CMPQ  SI, $31
+	LEAQ  -16(SI), SI
+	JG    LBB28_11
 
-LBB28_12:
+LBB28_6:
 	MOVQ  $-1, AX
 	TESTQ SI, SI
-	JE    LBB28_21
+	JLE   LBB28_14
+	INCQ  SI
+
+LBB28_8:
+	CMPB 0(CX), $0
+	JS   LBB28_13
+	INCQ CX
+	DECQ SI
+	CMPQ SI, $1
+	JG   LBB28_8
 
 LBB28_14:
-	CMPB  0(CX), $0
-	JS    LBB28_20
-	DECQ  SI
-	INCQ  CX
-	TESTQ SI, SI
-	JNE   LBB28_14
-
-LBB28_21:
 	BYTE $0x5d // popq         %rbp
 	RET
 
-LBB28_20:
+LBB28_13:
 	SUBQ DI, CX
 	MOVQ CX, AX
 	BYTE $0x5d  // popq         %rbp
 	RET
 
-LBB28_5:
+LBB28_2:
 	WORD $0x9848 // cltq
-	JMP  LBB28_6
+	JMP  LBB28_3
 
-LBB28_17:
-	MOVWLZX SI, AX
+LBB28_12:
+	MOVWLZX AX, AX
 
-LBB28_6:
+LBB28_3:
 	SUBQ DI, CX
 	BSFQ AX, AX
 	ADDQ CX, AX
@@ -12533,6 +12495,36 @@ _P10_TAB:
 	QUAD $0x444b1ae4d6e2ef50 // .quad 4921056587992461136
 	QUAD $0x4480f0cf064dd592 // .quad 4936209963552724370
 
+_first:
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf0f0f0f0f0f0f0f0; QUAD $0xf0f0f0f0f0f0f0f0 // .ascii 16, '\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0\xf0'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0xf1f1f1f1f1f1f1f1; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+	QUAD $0x020202020202f1f1; QUAD $0x0202020202020202 // .ascii 16, '\xf1\xf1\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02'
+	QUAD $0x0202020202020202; QUAD $0x0202020202020202 // .ascii 16, '\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02\x02'
+	QUAD $0x0303030303030313; QUAD $0x0303230303030303 // .ascii 16, '\x13\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03\x03#\x03\x03'
+	QUAD $0xf1f1f14404040434; QUAD $0xf1f1f1f1f1f1f1f1 // .ascii 16, '4\x04\x04\x04D\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1\xf1'
+
+_ranges:
+	BYTE $0x80 // .byte 128
+	BYTE $0xbf // .byte 191
+	BYTE $0xa0 // .byte 160
+	BYTE $0xbf // .byte 191
+	BYTE $0x80 // .byte 128
+	BYTE $0x9f // .byte 159
+	BYTE $0x90 // .byte 144
+	BYTE $0xbf // .byte 191
+	BYTE $0x80 // .byte 128
+	BYTE $0x8f // .byte 143
+
 TEXT ·__f64toa(SB), NOSPLIT | NOFRAME, $0 - 24
 	NO_LOCAL_POINTERS
 
@@ -12778,7 +12770,7 @@ _validate_one:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+25117(SB) // _validate_one
+	CALL ·__native_entry__+24949(SB) // _validate_one
 	MOVQ AX, ret+24(FP)
 	RET
 

--- a/internal/native/avx2/native_amd64_test.go
+++ b/internal/native/avx2/native_amd64_test.go
@@ -260,6 +260,13 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
 func TestNative_ValidateOne(t *testing.T) {
     {
         p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n\\r\\b\\f😁ſ景\xef\xbf\xbf\xf4\x8f\xbf\xbf\xc2\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\""
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, len(s), p)
+        assert.Equal(t, 0, r)
+    }
+    {
+        p := 0
         s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
         r := __validate_one(&s, &p, &types.StateMachine{})
         assert.Equal(t, 64, p)

--- a/internal/native/avx2/native_amd64_test.go
+++ b/internal/native/avx2/native_amd64_test.go
@@ -257,6 +257,44 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
     assert.Equal(t, int64(0), v.Iv)
 }
 
+func TestNative_ValidateOne(t *testing.T) {
+    {
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\x00\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\x80\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\xed\xbf\xbf\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+}
+
 func TestNative_VstringHangUpOnRandomData(t *testing.T) {
     v, e := hex.DecodeString(
         "228dc61efd54ef80a908fb6026b7f2d5f92a257ba8b347c995f259eb8685376a" +

--- a/internal/native/avx2/native_subr_amd64.go
+++ b/internal/native/avx2/native_subr_amd64.go
@@ -20,7 +20,7 @@ var (
     _subr__skip_one     = __native_entry__() + 18201
     _subr__u64toa       = __native_entry__() + 4008
     _subr__unquote      = __native_entry__() + 7080
-    _subr__validate_one = __native_entry__() + 25117
+    _subr__validate_one = __native_entry__() + 24949
     _subr__value        = __native_entry__() + 13707
     _subr__vnumber      = __native_entry__() + 16359
     _subr__vsigned      = __native_entry__() + 17673

--- a/internal/native/avx2/native_subr_amd64.go
+++ b/internal/native/avx2/native_subr_amd64.go
@@ -9,22 +9,23 @@ package avx2
 func __native_entry__() uintptr
 
 var (
-    _subr__f64toa      = __native_entry__() + 903
-    _subr__html_escape = __native_entry__() + 9535
-    _subr__i64toa      = __native_entry__() + 3915
-    _subr__lspace      = __native_entry__() + 429
-    _subr__lzero       = __native_entry__() + 13
-    _subr__quote       = __native_entry__() + 5328
-    _subr__skip_array  = __native_entry__() + 21058
-    _subr__skip_object = __native_entry__() + 21093
-    _subr__skip_one    = __native_entry__() + 18201
-    _subr__u64toa      = __native_entry__() + 4008
-    _subr__unquote     = __native_entry__() + 7080
-    _subr__value       = __native_entry__() + 13707
-    _subr__vnumber     = __native_entry__() + 16359
-    _subr__vsigned     = __native_entry__() + 17673
-    _subr__vstring     = __native_entry__() + 15482
-    _subr__vunsigned   = __native_entry__() + 17932
+    _subr__f64toa       = __native_entry__() + 903
+    _subr__html_escape  = __native_entry__() + 9535
+    _subr__i64toa       = __native_entry__() + 3915
+    _subr__lspace       = __native_entry__() + 429
+    _subr__lzero        = __native_entry__() + 13
+    _subr__quote        = __native_entry__() + 5328
+    _subr__skip_array   = __native_entry__() + 21301
+    _subr__skip_object  = __native_entry__() + 21338
+    _subr__skip_one     = __native_entry__() + 18201
+    _subr__u64toa       = __native_entry__() + 4008
+    _subr__unquote      = __native_entry__() + 7080
+    _subr__validate_one = __native_entry__() + 25117
+    _subr__value        = __native_entry__() + 13707
+    _subr__vnumber      = __native_entry__() + 16359
+    _subr__vsigned      = __native_entry__() + 17673
+    _subr__vstring      = __native_entry__() + 15482
+    _subr__vunsigned    = __native_entry__() + 17932
 )
 
 const (
@@ -39,6 +40,7 @@ const (
     _stack__skip_one = 136
     _stack__u64toa = 8
     _stack__unquote = 72
+    _stack__validate_one = 136
     _stack__value = 392
     _stack__vnumber = 312
     _stack__vsigned = 16
@@ -58,6 +60,7 @@ var (
     _ = _subr__skip_one
     _ = _subr__u64toa
     _ = _subr__unquote
+    _ = _subr__validate_one
     _ = _subr__value
     _ = _subr__vnumber
     _ = _subr__vsigned
@@ -77,6 +80,7 @@ const (
     _ = _stack__skip_one
     _ = _stack__u64toa
     _ = _stack__unquote
+    _ = _stack__validate_one
     _ = _stack__value
     _ = _stack__vnumber
     _ = _stack__vsigned

--- a/internal/native/dispatch_amd64.go
+++ b/internal/native/dispatch_amd64.go
@@ -86,6 +86,11 @@ func SkipOne(s *string, p *int, m *types.StateMachine) int
 //go:nosplit
 //go:noescape
 //goland:noinspection GoUnusedParameter
+func ValidateOne(s *string, p *int, m *types.StateMachine) int
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
 func I64toa(out *byte, val int64) (ret int)
 
 //go:nosplit

--- a/internal/native/dispatch_amd64.s
+++ b/internal/native/dispatch_amd64.s
@@ -54,6 +54,12 @@ TEXT ·SkipOne(SB), NOSPLIT, $0 - 32
     JMP  github·com∕bytedance∕sonic∕internal∕native∕avx2·__skip_one(SB)
     JMP  github·com∕bytedance∕sonic∕internal∕native∕avx·__skip_one(SB)
 
+TEXT ·ValidateOne(SB), NOSPLIT, $0 - 32
+    CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX2(SB), $0
+    JE   2(PC)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx2·__validate_one(SB)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx·__validate_one(SB)
+
 TEXT ·I64toa(SB), NOSPLIT, $0 - 32
     CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX2(SB), $0
     JE   2(PC)

--- a/internal/native/native_amd64.tmpl
+++ b/internal/native/native_amd64.tmpl
@@ -101,3 +101,8 @@ func __skip_array(s *string, p *int, m *types.StateMachine) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __skip_object(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)

--- a/internal/native/native_amd64_test.tmpl
+++ b/internal/native/native_amd64_test.tmpl
@@ -255,22 +255,34 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
     assert.Equal(t, int64(0), v.Iv)
 }
 
-func TestNative_VstringUnEscapedControlChars(t *testing.T) {
+func TestNative_ValidateOne(t *testing.T) {
     {
-        var v types.JsonState
-        i := 0
-        s := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
-        __vstring(&s, &i, &v)
-        assert.Equal(t, 63, i) // Error Postion
-        assert.Equal(t, types.ValueType(-int(types.ERR_INVALID_CHAR)), v.Vt)
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
     }
     {
-        var v types.JsonState
-        i := 0
-        s := "\x00\"x"
-        __vstring(&s, &i, &v)
-        assert.Equal(t, 0, i) // Error Postion
-        assert.Equal(t, types.ValueType(-int(types.ERR_INVALID_CHAR)), v.Vt)
+        p := 0
+        s := "\"\x00\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 64, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
+    {
+        p := 0
+        s := "\"\x80\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
     }
 }
 

--- a/internal/native/native_amd64_test.tmpl
+++ b/internal/native/native_amd64_test.tmpl
@@ -258,6 +258,13 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
 func TestNative_ValidateOne(t *testing.T) {
     {
         p := 0
+        s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n\\r\\b\\f😁ſ景\xef\xbf\xbf\xf4\x8f\xbf\xbf\xc2\x80xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\""
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, len(s), p)
+        assert.Equal(t, 0, r)
+    }
+    {
+        p := 0
         s := "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
         r := __validate_one(&s, &p, &types.StateMachine{})
         assert.Equal(t, 64, p)

--- a/internal/native/native_amd64_test.tmpl
+++ b/internal/native/native_amd64_test.tmpl
@@ -284,6 +284,13 @@ func TestNative_ValidateOne(t *testing.T) {
         assert.Equal(t, 1, p)
         assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
     }
+    {
+        p := 0
+        s := "\"\xed\xbf\xbf\"x"
+        r := __validate_one(&s, &p, &types.StateMachine{})
+        assert.Equal(t, 1, p)
+        assert.Equal(t, -int(types.ERR_INVALID_CHAR), r)
+    }
 }
 
 func TestNative_VstringHangUpOnRandomData(t *testing.T) {

--- a/internal/native/native_amd64_test.tmpl
+++ b/internal/native/native_amd64_test.tmpl
@@ -255,6 +255,25 @@ func TestNative_VstringEscapeEOF(t *testing.T) {
     assert.Equal(t, int64(0), v.Iv)
 }
 
+func TestNative_VstringUnEscapedControlChars(t *testing.T) {
+    {
+        var v types.JsonState
+        i := 0
+        s := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\bxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"x"
+        __vstring(&s, &i, &v)
+        assert.Equal(t, 63, i) // Error Postion
+        assert.Equal(t, types.ValueType(-int(types.ERR_INVALID_CHAR)), v.Vt)
+    }
+    {
+        var v types.JsonState
+        i := 0
+        s := "\x00\"x"
+        __vstring(&s, &i, &v)
+        assert.Equal(t, 0, i) // Error Postion
+        assert.Equal(t, types.ValueType(-int(types.ERR_INVALID_CHAR)), v.Vt)
+    }
+}
+
 func TestNative_VstringHangUpOnRandomData(t *testing.T) {
     v, e := hex.DecodeString(
         "228dc61efd54ef80a908fb6026b7f2d5f92a257ba8b347c995f259eb8685376a" +

--- a/internal/native/types/types.go
+++ b/internal/native/types/types.go
@@ -18,6 +18,7 @@ package types
 
 import (
     `fmt`
+    `sync`
 )
 
 type ValueType int
@@ -103,3 +104,18 @@ type StateMachine struct {
     Sp int
     Vt [MAX_RECURSE]int
 }
+
+var stackPool = sync.Pool{
+    New: func()interface{}{
+        return &StateMachine{}
+    },
+}
+
+func NewStateMachine() *StateMachine {
+    return stackPool.Get().(*StateMachine)
+}
+
+func FreeStateMachine(fsm *StateMachine) {
+    stackPool.Put(fsm)
+}
+

--- a/internal/native/types/types.go
+++ b/internal/native/types/types.go
@@ -57,6 +57,10 @@ const (
 )
 
 const (
+    SPACE_MASK = (1 << ' ') | (1 << '\t') | (1 << '\r') | (1 << '\n')
+)
+
+const (
     ERR_EOF                ParsingError = 1
     ERR_INVALID_CHAR       ParsingError = 2
     ERR_INVALID_ESCAPE     ParsingError = 3

--- a/internal/rt/fastvalue.go
+++ b/internal/rt/fastvalue.go
@@ -90,7 +90,7 @@ type GoMapIterator struct {
 
 type GoItab struct {
     it unsafe.Pointer
-    vt *GoType
+    Vt *GoType
     hv uint32
     _  [4]byte
     fn [1]uintptr
@@ -184,6 +184,10 @@ func UnpackType(t reflect.Type) *GoType {
 
 func UnpackEface(v interface{}) GoEface {
     return *(*GoEface)(unsafe.Pointer(&v))
+}
+
+func UnpackIface(v interface{}) GoIface {
+    return *(*GoIface)(unsafe.Pointer(&v))
 }
 
 func findReflectRtypeItab() *GoItab {

--- a/native/native.c
+++ b/native/native.c
@@ -22,3 +22,4 @@
 #include "atof_eisel_lemire.c"
 #include "atof_native.c"
 #include "scanning.c"
+#include "utf8.c"

--- a/native/native.h
+++ b/native/native.h
@@ -124,5 +124,6 @@ long skip_positive(const GoString *src, long *p);
 
 bool atof_eisel_lemire64(uint64_t mant, int exp10, int sgn, double *val);
 double atof_native(const char *sp, ssize_t nb, char* dbuf, ssize_t cap);
+ssize_t utf8_validate(const char *sp, ssize_t nb, ssize_t rb);
 
 #endif

--- a/native/native.h
+++ b/native/native.h
@@ -124,6 +124,9 @@ long skip_positive(const GoString *src, long *p);
 
 bool atof_eisel_lemire64(uint64_t mant, int exp10, int sgn, double *val);
 double atof_native(const char *sp, ssize_t nb, char* dbuf, ssize_t cap);
+
 ssize_t utf8_validate(const char *sp, ssize_t nb, ssize_t rb);
+long validate_string(const GoString *src, long *p);
+long validate_one(const GoString *src, long *p, StateMachine *m);
 
 #endif

--- a/native/native.h
+++ b/native/native.h
@@ -125,7 +125,7 @@ long skip_positive(const GoString *src, long *p);
 bool atof_eisel_lemire64(uint64_t mant, int exp10, int sgn, double *val);
 double atof_native(const char *sp, ssize_t nb, char* dbuf, ssize_t cap);
 
-ssize_t utf8_validate(const char *sp, ssize_t nb, ssize_t rb);
+ssize_t utf8_validate(const char *sp, ssize_t nb);
 long validate_string(const GoString *src, long *p);
 long validate_one(const GoString *src, long *p, StateMachine *m);
 

--- a/native/scanning.c
+++ b/native/scanning.c
@@ -317,27 +317,27 @@ static inline ssize_t advance_string(const GoString *src, long p, int64_t *ep) {
     }
 }
 
-static inline int _mm_get_mask(__m128i v0, __m128i t) {
-    return _mm_movemask_epi8(_mm_cmpeq_epi8(v0, t));
+static inline int _mm_get_mask(__m128i v, __m128i t) {
+    return _mm_movemask_epi8(_mm_cmpeq_epi8(v, t));
 }
 
 // contrl char: 0x00 ~ 0x1F
-static inline int _mm_cchars_mask(__m128i vv) {
-    __m128i e1 = _mm_cmpgt_epi8 (vv, _mm_set1_epi8(-1));
-    __m128i e2 = _mm_cmpgt_epi8 (vv, _mm_set1_epi8(31));
+static inline int _mm_cchars_mask(__m128i v) {
+    __m128i e1 = _mm_cmpgt_epi8 (v, _mm_set1_epi8(-1));
+    __m128i e2 = _mm_cmpgt_epi8 (v, _mm_set1_epi8(31));
     return    _mm_movemask_epi8 (_mm_andnot_si128 (e2, e1));
 }
 
 #if USE_AVX2
 
-static inline int _mm256_get_mask(__m256i v0, __m256i t) {
-    return _mm256_movemask_epi8(_mm256_cmpeq_epi8(v0, t));
+static inline int _mm256_get_mask(__m256i v, __m256i t) {
+    return _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, t));
 }
 
 // contrl char: 0x00 ~ 0x1F
-static inline int _mm256_cchars_mask(__m256i vv) {
-    __m256i e1 = _mm256_cmpgt_epi8 (vv, _mm256_set1_epi8(-1));
-    __m256i e2 = _mm256_cmpgt_epi8 (vv, _mm256_set1_epi8(31));
+static inline int _mm256_cchars_mask(__m256i v) {
+    __m256i e1 = _mm256_cmpgt_epi8 (v, _mm256_set1_epi8(-1));
+    __m256i e2 = _mm256_cmpgt_epi8 (v, _mm256_set1_epi8(31));
     return    _mm256_movemask_epi8 (_mm256_andnot_si256 (e2, e1));
 }
 

--- a/native/scanning.c
+++ b/native/scanning.c
@@ -1367,10 +1367,9 @@ long validate_string(const GoString *src, long *p) {
         return e;
     }
 
-    /* check for errors in UTF8 validate */
+    /* check for errors in UTF-8 validate */
     ssize_t nb = e - *p - 1;
-    ssize_t rb = src->len - *p;
-    ssize_t r = utf8_validate(src->buf + *p, nb, rb);
+    ssize_t r = utf8_validate(src->buf + *p, nb);
     if (r >= 0) {
         *p += r;
         return -ERR_INVAL;

--- a/native/scanning.c
+++ b/native/scanning.c
@@ -134,6 +134,58 @@ static inline int _mm256_ascii_mask(__m256i vv) {
 
 #endif
 
+//      code point    | first byte | second byte | thrid byte | fourth byte
+//  U+0000  -  U+007F | 0___ ____
+//  U+0080  -  U+07FF | 110_ ____  | 10__ ____
+//  U+0800  -  U+FFFF | 1110 ____  | 10__ ____   | 10__ ____
+// U+10000 - U+10FFFF | 1111 0___  | 10__ ____   | 10__ ____  | 10__ ____
+// checks non-ascii characters, and returns the utf-8 length
+static inline size_t is_utf8(const uint8_t* noascii, size_t n) {
+#define is_next(b) (((b) >> 6) == 2)
+    uint8_t b0 = *noascii;
+    uint8_t b1 = *(noascii + 1);
+    uint8_t b2 = *(noascii + 2);
+    uint8_t b3 = *(noascii + 3);
+    uint32_t r;
+
+    /* 2-byte */
+    if (unlikely(n < 2 || !is_next(b1))) {
+        return 0;
+    }
+    if (unlikely(b0 < 0xe0 && b0 >= 0xc0)) {
+        r = ((uint32_t)(b0 & 0x1f) << 6) | (b1 & 0x3f);
+        if (likely(r >= 0x0080 && r <= 0x07ff)) {
+            return 2;
+        }
+        return 0;
+    }
+
+    /* 3-byte */
+    if (unlikely(n < 3 || !is_next(b2))) {
+        return 0;
+    }
+    if (likely(b0 < 0xf0)) {
+        r = ((uint32_t)(b0 & 0x0f) << 12) | ((uint32_t)(b1 & 0x3f) << 6) | (b2 & 0x3f);
+        if (likely(r >= 0x0800u && r <= 0xffffu)) {
+            return 3;
+        }
+        return 0;
+    }
+
+    /* 4-byte */
+    if (unlikely(n < 4 || !is_next(b3))) {
+        return 0;
+    }
+    if (likely(b0 < 0xf8)) {
+        r = ((uint32_t)(b0 & 0x07) << 18) | ((uint32_t)(b1 & 0x3f) << 12) | ((uint32_t)(b2 & 0x3f) << 6) | (b3 & 0x3f);
+        if (likely(r >= 0x10000u && r <= 0x10ffffu)) {
+            return 4;
+        }
+    }
+    return 0;
+#undef is_next
+}
+
 static inline ssize_t advance_string(const GoString *src, long p, int64_t *ep) {
     char     ch;
     uint64_t es;
@@ -342,7 +394,7 @@ static inline ssize_t advance_string(const GoString *src, long p, int64_t *ep) {
                 ep_setc()
                 sp++, nb--;
             }
-        } else if (unlikely( ch >= 0 && ch <= 0x1f)) {
+        } else if (unlikely( ch >= 0 && ch <= 0x1f)) { // control chars
             ep_setc()
             return -ERR_INVAL;
         }
@@ -402,7 +454,7 @@ void vstring(const GoString *src, long *p, JsonState *ret) {
 
     /* check for errors */
     if (e < 0) {
-        *p = src->len;
+        *p = e == -ERR_EOF ? src->len : v;
         ret->vt = e;
         return;
     }

--- a/native/utf8.c
+++ b/native/utf8.c
@@ -86,7 +86,7 @@ const static struct AcceptRange ranges[5] = {
     {locb, 0x8F}, // 4
 };
 
-//  UTF-8 code point  | first byte | second byte | thrid byte | fourth byte
+//  UTF-8 code point  | first byte | second byte | third byte | fourth byte
 //  U+0000  -  U+007F | 0___ ____
 //  U+0080  -  U+07FF | 110_ ____  | 10__ ____
 //  U+0800  -  U+D7FF | 1110 ____  | 10__ ____   | 10__ ____
@@ -104,8 +104,9 @@ static inline ssize_t nonascii_is_utf8(const uint8_t* sp, size_t n) {
     switch (size) {
         case 4 : if (sp[3] < locb || hicb < sp[3]) return 0;
         case 3 : if (sp[2] < locb || hicb < sp[2]) return 0;
-        case 2 : if (sp[1] < accept.lo || accept.hi < sp[1]) return 0;
-        case 1 : // only validate non-ascii chars here
+        case 2 : if (sp[1] < accept.lo || accept.hi < sp[1]) return 0; break;
+        case 1 : return 0; // invalid chars
+        case 0 : return 1; // ascii chars
         default: return 0;
     }
     return size;

--- a/native/utf8.c
+++ b/native/utf8.c
@@ -1,7 +1,6 @@
 
 #include "native.h"
 
-
 // ascii: 0x00 ~ 0x7F
 static inline int _mm_ascii_mask(__m128i vv) {
     return _mm_movemask_epi8(vv);
@@ -102,7 +101,7 @@ ssize_t find_non_ascii(const uint8_t*sp, ssize_t nb, ssize_t rb) {
 
     /* remaining bytes, do with scalar code */
     while (nb--) {
-        if (!is_ascii(*sp)) {
+        if (is_ascii(*sp)) {
             sp++;
         } else {
             return sp - ss;
@@ -123,7 +122,7 @@ ssize_t utf8_validate(const char *sp, ssize_t nb, ssize_t rb) {
     ssize_t b;
 
     // Optimize for the continuous non-ascii chars */
-    while (nb > 0 && (n = (is_ascii(*p) ? 0 : find_non_ascii(p, nb, rb))) != -1) {
+    while (nb > 0 && (n = (!is_ascii(*p) ? 0 : find_non_ascii(p, nb, rb))) != -1) {
         /* not found non-ascii in string */
         if (n >= nb) {
             return -1;

--- a/native/utf8.c
+++ b/native/utf8.c
@@ -1,0 +1,147 @@
+
+#include "native.h"
+
+
+// ascii: 0x00 ~ 0x7F
+static inline int _mm_ascii_mask(__m128i vv) {
+    return _mm_movemask_epi8(vv);
+}
+
+#if USE_AVX2
+
+// ascii: 0x00 ~ 0x7F
+static inline int _mm256_ascii_mask(__m256i vv) {
+    return _mm256_movemask_epi8(vv);
+}
+
+#endif
+
+static inline bool is_ascii(uint8_t ch) {
+    return ch < 0x80;
+}
+
+//      code point    | first byte | second byte | thrid byte | fourth byte
+//  U+0000  -  U+007F | 0___ ____
+//  U+0080  -  U+07FF | 110_ ____  | 10__ ____
+//  U+0800  -  U+FFFF | 1110 ____  | 10__ ____   | 10__ ____
+// U+10000 - U+10FFFF | 1111 0___  | 10__ ____   | 10__ ____  | 10__ ____
+// checks non-ascii characters, and returns the utf-8 length
+static inline ssize_t is_utf8(const uint8_t* noascii, size_t n) {
+#define is_next(b) (((b) >> 6) == 2)
+    uint8_t b0 = *noascii;
+    uint8_t b1 = *(noascii + 1);
+    uint8_t b2 = *(noascii + 2);
+    uint8_t b3 = *(noascii + 3);
+    uint32_t r;
+
+    /* 2-byte */
+    if (unlikely(n < 2 || !is_next(b1))) {
+        return 0;
+    }
+    if (unlikely(b0 < 0xe0 && b0 >= 0xc0)) {
+        r = ((uint32_t)(b0 & 0x1f) << 6) | (b1 & 0x3f);
+        if (likely(r >= 0x0080 && r <= 0x07ff)) {
+            return 2;
+        }
+        return 0;
+    }
+
+    /* 3-byte */
+    if (unlikely(n < 3 || !is_next(b2))) {
+        return 0;
+    }
+    if (likely(b0 < 0xf0)) {
+        r = ((uint32_t)(b0 & 0x0f) << 12) | ((uint32_t)(b1 & 0x3f) << 6) | (b2 & 0x3f);
+        if (likely(r >= 0x0800u && r <= 0xffffu)) {
+            return 3;
+        }
+        return 0;
+    }
+
+    /* 4-byte */
+    if (unlikely(n < 4 || !is_next(b3))) {
+        return 0;
+    }
+    if (likely(b0 < 0xf8)) {
+        r = ((uint32_t)(b0 & 0x07) << 18) | ((uint32_t)(b1 & 0x3f) << 12) | ((uint32_t)(b2 & 0x3f) << 6) | (b3 & 0x3f);
+        if (likely(r >= 0x10000u && r <= 0x10ffffu)) {
+            return 4;
+        }
+    }
+    return 0;
+#undef is_next
+}
+
+ssize_t find_non_ascii(const uint8_t*sp, ssize_t nb, ssize_t rb) {
+    const uint8_t* ss = sp;
+    int64_t m;
+
+#if USE_AVX2
+    while (rb >= 32 && nb > 0) {
+        __m256i v = _mm256_loadu_si256 ((const void *)(sp));
+        if (unlikely((m = _mm256_ascii_mask(v)) != 0)) {
+            return sp - ss + __builtin_ctzll(m);
+        }
+        rb -= 32;
+        nb -= 32;
+        sp += 32;
+    }
+
+    /* clear spper half to avoid AVX-SSE transition penalty */
+     _mm256_zeroupper();
+#endif
+    while (rb >= 16 && nb > 0) {
+        __m128i v = _mm_loadu_si128 ((const void *)(sp));
+        if (unlikely((m = _mm_ascii_mask(v)) != 0)) {
+            return sp - ss + __builtin_ctzll(m);
+        }
+        rb -= 16;
+        nb -= 16;
+        sp += 16;
+    }
+
+    /* remaining bytes, do with scalar code */
+    while (nb--) {
+        if (!is_ascii(*sp)) {
+            sp++;
+        } else {
+            return sp - ss;
+        }
+    }
+
+    /* nothing found */
+    return -1;
+}
+
+// utf8_validate validates whether the JSON string is valid UTF-8.
+// nb is string length, rb is the remain JSON length
+// return -1 if validate, otherwise, return the error postion.
+ssize_t utf8_validate(const char *sp, ssize_t nb, ssize_t rb) {
+    const uint8_t* p = (const uint8_t*)sp;
+    const uint8_t* s = (const uint8_t*)sp;
+    ssize_t n;
+    ssize_t b;
+
+    // Optimize for the continuous non-ascii chars */
+    while (nb > 0 && (n = (is_ascii(*p) ? 0 : find_non_ascii(p, nb, rb))) != -1) {
+        /* not found non-ascii in string */
+        if (n >= nb) {
+            return -1;
+        }
+
+        nb -= n;
+        rb -= n;
+        p  += n;
+
+        /* validate the non-ascii */
+        if (unlikely((b = is_utf8(p, nb)) == 0)) {
+            return p - s;
+        }
+
+        nb -= b;
+        rb -= b;
+        p  += b;
+    }
+
+    return -1;
+}

--- a/sonic.go
+++ b/sonic.go
@@ -28,10 +28,6 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
-const (
-    _SpaceMask = (1 << ' ') | (1 << '\t') | (1 << '\r') | (1 << '\n')
-)
-
 // Marshal returns the JSON encoding of v.
 func Marshal(val interface{}) ([]byte, error) {
     return encoder.Encode(val, 0)
@@ -56,7 +52,7 @@ func UnmarshalString(buf string, val interface{}) error {
 
     /* skip all the trailing spaces */
     if pos != len(buf) {
-        for pos < len(buf) && (_SpaceMask & (1 << buf[pos])) != 0 {
+        for pos < len(buf) && (types.SPACE_MASK & (1 << buf[pos])) != 0 {
             pos++
         }
     }


### PR DESCRIPTION
# Intro
To support the FULL validation, add ValidateOne API in Golang.
The API can make more validations as follows:
1. check whether there are UNESCAPED control chars in JSON strings, e.g. "\"\n\b\"" is an invalid JSON string.
2. check whether the JSON strings are validated UTF-8. e.g. "\"\x80\"" is an invalid JSON string.

# Bench
the validate is 2.5x faster of encoding/json(std library) :
```
➜  encoder git:(feat/validate) ✗ export SONIC_NO_ASYNC_GC=1 && go test -v -run none  -bench "(BenchmarkValidate_Sonic|BenchmarkSkip_Sonic|BenchmarkValidate_Std|BenchmarkCompact_Std)"
goos: darwin
goarch: amd64
pkg: github.com/bytedance/sonic/encoder
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkValidate_Sonic
BenchmarkValidate_Sonic-12         70855             16522 ns/op         788.93 MB/s
BenchmarkSkip_Sonic
BenchmarkSkip_Sonic-12             79969             15106 ns/op         862.88 MB/s
BenchmarkValidate_Std
BenchmarkValidate_Std-12           28736             41890 ns/op         311.17 MB/s
BenchmarkCompact_Std
BenchmarkCompact_Std-12            16968             70632 ns/op         184.55 MB/s
PASS
ok      github.com/bytedance/sonic/encoder      7.802s
```

# Test
The Validate API has passed the go-fuzz testing
```
go-fuzz-build -func=FuzzValidate -o ./sonic-fuzz.zip && \
	go-fuzz -bin=./sonic-fuzz.zip -workdir=./gofuzz-workdir  -timeout=60 -testoutput=true -procs=1
2022/02/21 11:18:02 workers: 1, corpus: 1990 (3s ago), crashers: 0, restarts: 1/0, execs: 0 (0/sec), cover: 0, uptime: 3s
2022/02/21 11:18:05 workers: 1, corpus: 1990 (6s ago), crashers: 0, restarts: 1/0, execs: 0 (0/sec), cover: 157, uptime: 6s
2022/02/21 11:18:08 workers: 1, corpus: 1990 (9s ago), crashers: 0, restarts: 1/4252, execs: 12757 (1391/sec), cover: 157, uptime: 9s
2022/02/21 11:18:11 workers: 1, corpus: 1990 (12s ago), crashers: 0, restarts: 1/8731, execs: 69848 (5738/sec), cover: 157, uptime: 12s
2022/02/21 11:18:14 workers: 1, corpus: 1990 (15s ago), crashers: 0, restarts: 1/8751, execs: 122527 (8075/sec), cover: 157, uptime: 15s
2022/02/21 11:18:17 workers: 1, corpus: 1990 (18s ago), crashers: 0, restarts: 1/9166, execs: 174171 (9584/sec), cover: 157, uptime: 18s
2022/02/21 11:18:20 workers: 1, corpus: 1990 (21s ago), crashers: 0, restarts: 1/9522, execs: 228542 (10794/sec), cover: 157, uptime: 21s
2022/02/21 11:18:23 workers: 1, corpus: 1990 (24s ago), crashers: 0, restarts: 1/9362, execs: 280871 (11619/sec), cover: 157, uptime: 24s
2022/02/21 11:18:26 workers: 1, corpus: 1990 (27s ago), crashers: 0, restarts: 1/9597, execs: 335926 (12362/sec), cover: 157, uptime: 27s
2022/02/21 11:18:29 workers: 1, corpus: 1990 (30s ago), crashers: 0, restarts: 1/9532, execs: 390839 (12953/sec), cover: 157, uptime: 30s
2022/02/21 11:18:32 workers: 1, corpus: 1990 (33s ago), crashers: 0, restarts: 1/9709, execs: 446658 (13464/sec), cover: 157, uptime: 33s
2022/02/21 11:18:35 workers: 1, corpus: 1990 (36s ago), crashers: 0, restarts: 1/9668, execs: 502773 (13899/sec), cover: 157, uptime: 36s
2022/02/21 11:18:38 workers: 1, corpus: 1990 (39s ago), crashers: 0, restarts: 1/9820, execs: 559782 (14290/sec), cover: 157, uptime: 39s
2022/02/21 11:18:41 workers: 1, corpus: 1990 (42s ago), crashers: 0, restarts: 1/9773, execs: 615743 (14600/sec), cover: 157, uptime: 42s
2022/02/21 11:18:44 workers: 1, corpus: 1990 (45s ago), crashers: 0, restarts: 1/9745, execs: 672413 (14885/sec), cover: 157, uptime: 45s
2022/02/21 11:18:47 workers: 1, corpus: 1990 (48s ago), crashers: 0, restarts: 1/9813, execs: 726223 (15075/sec), cover: 157, uptime: 48s
2022/02/21 11:18:50 workers: 1, corpus: 1990 (51s ago), crashers: 0, restarts: 1/9783, execs: 782693 (15295/sec), cover: 157, uptime: 51s
2022/02/21 11:18:53 workers: 1, corpus: 1990 (54s ago), crashers: 0, restarts: 1/9835, execs: 835983 (15432/sec), cover: 157, uptime: 54s
2022/02/21 11:18:56 workers: 1, corpus: 1990 (57s ago), crashers: 0, restarts: 1/9898, execs: 890835 (15581/sec), cover: 157, uptime: 57s
2022/02/21 11:18:59 workers: 1, corpus: 1990 (1m0s ago), crashers: 0, restarts: 1/9853, execs: 945938 (15720/sec), cover: 157, uptime: 1m0s
2022/02/21 11:19:02 workers: 1, corpus: 1990 (1m3s ago), crashers: 0, restarts: 1/9888, execs: 998761 (15810/sec), cover: 157, uptime: 1m3s
2022/02/21 11:19:05 workers: 1, corpus: 1990 (1m6s ago), crashers: 0, restarts: 1/9845, execs: 1053434 (15919/sec), cover: 157, uptime: 1m6s
2022/02/21 11:19:08 workers: 1, corpus: 1990 (1m9s ago), crashers: 0, restarts: 1/9847, execs: 1102898 (15944/sec), cover: 157, uptime: 1m9s
```