### PR TITLE
fix:(encoder) handle map like pointer when calling `call_marshaler_v`

### DIFF
--- a/encoder/assembler_amd64_go116.go
+++ b/encoder/assembler_amd64_go116.go
@@ -512,9 +512,9 @@ func (self *_Assembler) call_encoder(pc obj.Addr) {
 
 func (self *_Assembler) call_marshaler(fn obj.Addr, it *rt.GoType, vt reflect.Type) {
     switch vt.Kind() {
-        case reflect.Interface : self.call_marshaler_i(fn, it)
-        case reflect.Ptr       : self.call_marshaler_v(fn, it, vt, true)
-        default                : self.call_marshaler_v(fn, it, vt, false)
+        case reflect.Interface       : self.call_marshaler_i(fn, it)
+        case reflect.Ptr, reflect.Map: self.call_marshaler_v(fn, it, vt, true)
+        default                      : self.call_marshaler_v(fn, it, vt, false)
     }
 }
 

--- a/encoder/assembler_amd64_go117.go
+++ b/encoder/assembler_amd64_go117.go
@@ -531,9 +531,9 @@ func (self *_Assembler) call_encoder(pc obj.Addr) {
 
 func (self *_Assembler) call_marshaler(fn obj.Addr, it *rt.GoType, vt reflect.Type) {
     switch vt.Kind() {
-        case reflect.Interface : self.call_marshaler_i(fn, it)
-        case reflect.Ptr       : self.call_marshaler_v(fn, it, vt, true)
-        default                : self.call_marshaler_v(fn, it, vt, false)
+        case reflect.Interface        : self.call_marshaler_i(fn, it)
+        case reflect.Ptr, reflect.Map : self.call_marshaler_v(fn, it, vt, true)
+        default                       : self.call_marshaler_v(fn, it, vt, false)
     }
 }
 

--- a/issue_test/issue258_test.go
+++ b/issue_test/issue258_test.go
@@ -1,0 +1,50 @@
+package issue_test
+
+import (
+    `encoding/json`
+    `fmt`
+    `testing`
+
+    `github.com/bytedance/sonic`
+    `github.com/davecgh/go-spew/spew`
+    `github.com/stretchr/testify/require`
+)
+
+
+type M1 map[string]int
+
+func (m *M1) MarshalJSON() ([]byte, error) {
+    return []byte(fmt.Sprintf(`{"m":%q}`, spew.Sprintf("%#+v", m))), nil
+}
+
+type M2 map[string]int
+
+func (m M2) MarshalJSON() ([]byte, error) {
+    return []byte(fmt.Sprintf(`{"m":%q}`, spew.Sprintf("%#+v", m))), nil
+}
+
+func TestIssue258(t *testing.T) {
+    m1 := M1{}
+    oe,ee := json.Marshal(m1)
+    os,es := sonic.Marshal(m1)
+    require.Equal(t, ee, es)
+    require.Equal(t, oe, os)
+
+    m1p := &M1{}
+    oe,ee = json.Marshal(m1p)
+    os,es = sonic.Marshal(m1p)
+    require.Equal(t, ee, es)
+    require.Equal(t, oe, os)
+
+    m2 := M2{}
+    oe,ee = json.Marshal(m2)
+    os,es = sonic.Marshal(m2)
+    require.Equal(t, ee, es)
+    require.Equal(t, oe, os)
+
+    m2p := &M2{}
+    oe,ee = json.Marshal(m2p)
+    os,es = sonic.Marshal(m2p)
+    require.Equal(t, ee, es)
+    require.Equal(t, oe, os)
+}


### PR DESCRIPTION
resolve #258 