### PR TITLE
opt:(decoder) use `runtime.slicebytetostring()` for string copy

### DIFF
--- a/decoder/assembler_amd64_go117.go
+++ b/decoder/assembler_amd64_go117.go
@@ -626,15 +626,23 @@ func (self *_Assembler) parse_unsigned() {
 // Pointer: DI, Size: SI, Return: R9  
 func (self *_Assembler) copy_string() {
     self.Link("_copy_string")
-    self.Emit("MOVQ", _DI, _VAR_bs_p)
-    self.Emit("MOVQ", _SI, _VAR_bs_n)
-    self.Emit("MOVQ", _R9, _VAR_bs_LR)
-    self.malloc_AX(_SI, _VAR_sv_p)                              
-    self.Emit("MOVQ", _VAR_bs_p, _BX)
-    self.Emit("MOVQ", _VAR_bs_n, _CX)
-    self.call_go(_F_memmove)
-    self.Emit("MOVQ", _VAR_sv_p, _DI)
-    self.Emit("MOVQ", _VAR_bs_n, _SI)
+    self.Emit("MOVQ", _R9, _VAR_bs_LR)          // MOVQ R9, bs.LR
+    self.Emit("XORL", _AX, _AX)                 // XORL AX, AX
+    self.Emit("MOVQ", _DI, _BX)                 // MOVQ DI, BX
+    self.Emit("MOVQ", _SI, _CX)                 // MOVQ SI, CX
+    self.call_go(_F_b2s)                        // CALL_GO b2s
+    self.Emit("MOVQ", _AX, _DI)                 // MOVQ AX, DI
+    self.Emit("MOVQ", _BX, _SI)                 // MOVQ BX, SI
+    
+    // self.Emit("MOVQ", _DI, _VAR_bs_p)
+    // self.Emit("MOVQ", _SI, _VAR_bs_n)
+    // self.malloc_AX(_SI, _VAR_sv_p)                              
+    // self.Emit("MOVQ", _VAR_bs_p, _BX)
+    // self.Emit("MOVQ", _VAR_bs_n, _CX)
+    // self.call_go(_F_memmove)
+    // self.Emit("MOVQ", _VAR_sv_p, _DI)
+    // self.Emit("MOVQ", _VAR_bs_n, _SI)
+
     self.Emit("MOVQ", _VAR_bs_LR, _R9)
     self.Rjmp("JMP", _R9)
 }
@@ -1019,6 +1027,7 @@ func (self *_Assembler) decode_dynamic(vt obj.Addr, vp obj.Addr) {
 var (
     _F_memequal         = jit.Func(memequal)
     _F_memmove          = jit.Func(memmove)
+    _F_b2s              = jit.Func(slicebytetostring)
     _F_growslice        = jit.Func(growslice)
     _F_makeslice        = jit.Func(makeslice)
     _F_makemap_small    = jit.Func(makemap_small)

--- a/decoder/generic_amd64_go117.go
+++ b/decoder/generic_amd64_go117.go
@@ -645,19 +645,25 @@ func (self *_ValueDecoder) compile() {
 
     /* copy string */
     self.Link("copy_string")  // pointer: R8, length: AX, return addr: DI
-    self.Emit("MOVQ", _R8, _VAR_cs_p)
-    self.Emit("MOVQ", _AX, _VAR_cs_n)
     self.Emit("MOVQ", _DI, _VAR_cs_LR)
-    self.Emit("MOVQ", _AX, _BX)
-    self.Emit("MOVQ", _AX, _CX)
-    self.Emit("MOVQ", _T_byte, _AX)
-    self.call_go(_F_makeslice)                              
-    self.Emit("MOVQ", _AX, _VAR_cs_d)                    
-    self.Emit("MOVQ", _VAR_cs_p, _BX)
-    self.Emit("MOVQ", _VAR_cs_n, _CX)
-    self.call_go(_F_memmove)
-    self.Emit("MOVQ", _VAR_cs_d, _R8)
-    self.Emit("MOVQ", _VAR_cs_n, _AX)
+    self.Emit("MOVQ", _R8, _BX)                 // MOVQ R8, BX
+    self.Emit("MOVQ", _AX, _CX)                 // MOVQ AX, CX
+    self.Emit("XORL", _AX, _AX)                 // XORL AX, AX
+    self.call_go(_F_b2s)                        // CALL_GO runtime.b2s
+    self.Emit("MOVQ", _AX, _R8)                 // MOVQ AX, R8
+    self.Emit("MOVQ", _BX, _AX)                 // MOVQ BX, AX
+    // self.Emit("MOVQ", _R8, _VAR_cs_p)
+    // self.Emit("MOVQ", _AX, _VAR_cs_n)
+    // self.Emit("MOVQ", _AX, _BX)
+    // self.Emit("MOVQ", _AX, _CX)
+    // self.Emit("MOVQ", _T_byte, _AX)
+    // self.call_go(_F_makeslice)                              
+    // self.Emit("MOVQ", _AX, _VAR_cs_d)                    
+    // self.Emit("MOVQ", _VAR_cs_p, _BX)
+    // self.Emit("MOVQ", _VAR_cs_n, _CX)
+    // self.call_go(_F_memmove)
+    // self.Emit("MOVQ", _VAR_cs_d, _R8)
+    // self.Emit("MOVQ", _VAR_cs_n, _AX)
     self.Emit("MOVQ", _VAR_cs_LR, _DI)
     self.Rjmp("JMP", _DI)
 

--- a/decoder/stubs.go
+++ b/decoder/stubs.go
@@ -108,3 +108,8 @@ func memclrHasPointers(ptr unsafe.Pointer, n uintptr)
 //go:linkname memclrNoHeapPointers runtime.memclrNoHeapPointers
 //goland:noinspection GoUnusedParameter
 func memclrNoHeapPointers(ptr unsafe.Pointer, n uintptr)
+
+//go:noescape
+//go:linkname slicebytetostring runtime.slicebytetostring
+//goland:noinspection GoUnusedParameter
+func slicebytetostring(buf unsafe.Pointer, ptr *byte, n int) string


### PR DESCRIPTION
- cmd
`./bench.py -b "\"^(BenchmarkDecoder_Generic_Sonic|BenchmarkDecoder_Binding_Sonic)$\"" -c`
- result
```
name                      old time/op    new time/op    delta
Decoder_Generic_Sonic-16    69.2µs ± 2%    70.0µs ± 3%   ~     (p=0.190 n=10+10)
Decoder_Binding_Sonic-16    33.2µs ± 2%    33.0µs ± 1%   ~     (p=0.182 n=10+9)

name                      old speed      new speed      delta
Decoder_Generic_Sonic-16   188MB/s ± 2%   186MB/s ± 4%   ~     (p=0.190 n=10+10)
Decoder_Binding_Sonic-16   393MB/s ± 2%   394MB/s ± 2%   ~     (p=0.393 n=10+10)

name                      old alloc/op   new alloc/op   delta
Decoder_Generic_Sonic-16    57.8kB ± 1%    57.9kB ± 1%   ~     (p=0.796 n=10+10)
Decoder_Binding_Sonic-16    28.2kB ± 1%    28.3kB ± 1%   ~     (p=0.670 n=10+10)

name                      old allocs/op  new allocs/op  delta
Decoder_Generic_Sonic-16       723 ± 0%       723 ± 0%   ~     (all equal)
Decoder_Binding_Sonic-16       137 ± 0%       137 ± 0%   ~     (all equal)
```
```
name                      old time/op    new time/op    delta
Decoder_Binding_Sonic-16    32.8µs ± 1%    35.0µs ± 4%  +6.78%  (p=0.000 n=10+10)
Decoder_Generic_Sonic-16    69.5µs ± 2%    70.8µs ± 4%    ~     (p=0.190 n=10+10)

name                      old speed      new speed      delta
Decoder_Binding_Sonic-16   398MB/s ± 1%   373MB/s ± 4%  -6.32%  (p=0.000 n=10+10)
Decoder_Generic_Sonic-16   188MB/s ± 2%   184MB/s ± 3%    ~     (p=0.190 n=10+10)

name                      old alloc/op   new alloc/op   delta
Decoder_Generic_Sonic-16    57.7kB ± 1%    57.9kB ± 1%    ~     (p=0.190 n=10+10)
Decoder_Binding_Sonic-16    28.3kB ± 0%    28.3kB ± 1%    ~     (p=1.000 n=8+10)

name                      old allocs/op  new allocs/op  delta
Decoder_Generic_Sonic-16       723 ± 0%       723 ± 0%    ~     (all equal)
Decoder_Binding_Sonic-16       137 ± 0%       137 ± 0%    ~     (all equal)
```
```
name                      old time/op    new time/op    delta
Decoder_Generic_Sonic-16    69.8µs ± 1%    70.4µs ± 6%   ~     (p=0.912 n=10+10)
Decoder_Binding_Sonic-16    33.2µs ± 5%    33.7µs ± 6%   ~     (p=0.218 n=10+10)

name                      old speed      new speed      delta
Decoder_Generic_Sonic-16   187MB/s ± 1%   185MB/s ± 5%   ~     (p=0.912 n=10+10)
Decoder_Binding_Sonic-16   393MB/s ± 5%   387MB/s ± 5%   ~     (p=0.218 n=10+10)

name                      old alloc/op   new alloc/op   delta
Decoder_Generic_Sonic-16    57.8kB ± 1%    57.9kB ± 1%   ~     (p=0.529 n=10+10)
Decoder_Binding_Sonic-16    28.3kB ± 1%    28.2kB ± 1%   ~     (p=0.123 n=10+10)

name                      old allocs/op  new allocs/op  delta
Decoder_Generic_Sonic-16       723 ± 0%       723 ± 0%   ~     (all equal)
Decoder_Binding_Sonic-16       137 ± 0%       137 ± 0%   ~     (all equal)
```