### PR TITLE
fix iterator traversal empty object panic

### DIFF
--- a/ast/iterator.go
+++ b/ast/iterator.go
@@ -63,7 +63,11 @@ func (self *Iterator) HasNext() bool {
     } else if self.p.t == _V_ARRAY_LAZY {
         return self.p.skipNextNode().Valid()
     } else if self.p.t == _V_OBJECT_LAZY {
-        return self.p.skipNextPair().Value.Valid()
+        pair := self.p.skipNextPair()
+        if pair == nil {
+            return false
+        }
+        return pair.Value.Valid()
     }
     return false
 }

--- a/ast/iterator_test.go
+++ b/ast/iterator_test.go
@@ -195,6 +195,16 @@ func TestIterator(t *testing.T) {
     if i != int64(loop) {
         t.Fatal(i)
     }
+
+    str, _ = getTestIteratorSample(0)
+    root, err = NewParser(str).Parse()
+    if err != 0 {
+        t.Fatal(err)
+    }
+    mi, _ = root.Get("object").Properties()
+    if mi.HasNext() {
+        t.Fatalf("should not have next")
+    }
 }
 
 func BenchmarkArrays(b *testing.B) {


### PR DESCRIPTION
Traversal a empty object with HasNext() will cause a panic.
Reproduce bug, in ast/iterator_test.go


    str, _ := getTestIteratorSample(0)
    root, err := NewParser(str).Parse()
    if err != 0 {
        t.Fatal(err)
    }
    mi, _ := root.Get("object").Properties()
    if mi.HasNext() {
        t.Fatalf("should not have next")
    }





    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x143bf91]
    
    goroutine 8 [running]:
    testing.tRunner.func1.2({0x14af1a0, 0x189a320})
	    /usr/local/Cellar/go/1.19.1/libexec/src/testing/testing.go:1396 +0x24e
    testing.tRunner.func1()
	    /usr/local/Cellar/go/1.19.1/libexec/src/testing/testing.go:1399 +0x39f
    panic({0x14af1a0, 0x189a320})
	    /usr/local/Cellar/go/1.19.1/libexec/src/runtime/panic.go:884 +0x212
    github.com/bytedance/sonic/ast.(*Iterator).HasNext(0xc000004cb8?)
	    /Users/xks/gitproject/sonic/ast/iterator.go:70 +0x51
    github.com/bytedance/sonic/ast.TestIterator(0xc0002ae680)
	    /Users/xks/gitproject/sonic/ast/iterator_test.go:205 +0x937
    testing.tRunner(0xc0002ae680, 0x15506c0)
	    /usr/local/Cellar/go/1.19.1/libexec/src/testing/testing.go:1446 +0x10b
    created by testing.(*T).Run
	    /usr/local/Cellar/go/1.19.1/libexec/src/testing/testing.go:1493 +0x35f

