### PR TITLE
feat:(decoder) support skip mismatche-typed value

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -19,8 +19,7 @@ import os
 import subprocess
 import argparse
 
-repeat_time = 100
-gbench_prefix = "SONIC_NO_ASYNC_GC=1 go test -benchmem -run=none -count=%d "%(repeat_time)
+gbench_prefix = "SONIC_NO_ASYNC_GC=1 go test -benchmem -run=none "
 
 def run(cmd):
     print(cmd)
@@ -105,6 +104,8 @@ def main():
         help='Compare with the main benchmarking')
     argparser.add_argument('-t', '--times', dest='times', required=False,
         help='benchmark the times')
+    argparser.add_argument('-r', '--repeat_times', dest='count', required=False,
+        help='benchmark the count')
     args = argparser.parse_args()
     
     if args.filter:
@@ -114,6 +115,11 @@ def main():
         
     if args.times:
         gbench_args += " -benchtime=%s"%(args.times)
+        
+    if args.count:
+        gbench_args += " -count=%s"%(args.count)
+    else:
+        gbench_args += " -count=10"
 
     if args.compare:
         target = compare(gbench_args)

--- a/decode_test.go
+++ b/decode_test.go
@@ -436,317 +436,317 @@ func (self *JsonSyntaxError) err() *json.SyntaxError {
 
 var unmarshalTests = []unmarshalTest{
     // basic types
-    {in: `true`, ptr: new(bool), out: true},
-    {in: `1`, ptr: new(int), out: 1},
-    {in: `1.2`, ptr: new(float64), out: 1.2},
-    {in: `-5`, ptr: new(int16), out: int16(-5)},
-    {in: `2`, ptr: new(json.Number), out: json.Number("2"), useNumber: true},
-    {in: `2`, ptr: new(json.Number), out: json.Number("2")},
-    {in: `2`, ptr: new(interface{}), out: 2.0},
-    {in: `2`, ptr: new(interface{}), out: json.Number("2"), useNumber: true},
-    {in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
-    {in: `"http:\/\/"`, ptr: new(string), out: "http://"},
-    {in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
-    {in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
-    {in: "null", ptr: new(interface{}), out: nil},
-    {in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(""), Offset: 7, Struct: "T", Field: "X"}},
-    {in: `{"X": 23}`, ptr: new(T), out: T{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 8, Struct: "T", Field: "X"}},
-    {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
-    {in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
-    {in: `{"S": 23}`, ptr: new(W), out: W{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(SS("")), Struct: "W", Field: "S"}},
-    {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: json.Number("3")}},
-    {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: json.Number("1"), F2: int32(2), F3: json.Number("3")}, useNumber: true},
-    {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsFloat64},
-    {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsNumber, useNumber: true},
+    // {in: `true`, ptr: new(bool), out: true},
+    // {in: `1`, ptr: new(int), out: 1},
+    // {in: `1.2`, ptr: new(float64), out: 1.2},
+    // {in: `-5`, ptr: new(int16), out: int16(-5)},
+    // {in: `2`, ptr: new(json.Number), out: json.Number("2"), useNumber: true},
+    // {in: `2`, ptr: new(json.Number), out: json.Number("2")},
+    // {in: `2`, ptr: new(interface{}), out: 2.0},
+    // {in: `2`, ptr: new(interface{}), out: json.Number("2"), useNumber: true},
+    // {in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
+    // {in: `"http:\/\/"`, ptr: new(string), out: "http://"},
+    // {in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
+    // {in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
+    // {in: "null", ptr: new(interface{}), out: nil},
+    // {in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(""), Offset: 7, Struct: "T", Field: "X"}},
+    // {in: `{"X": 23}`, ptr: new(T), out: T{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 8, Struct: "T", Field: "X"}},
+    // {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+    // {in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+    // {in: `{"S": 23}`, ptr: new(W), out: W{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(SS("")), Struct: "W", Field: "S"}},
+    // {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: json.Number("3")}},
+    // {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: json.Number("1"), F2: int32(2), F3: json.Number("3")}, useNumber: true},
+    // {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsFloat64},
+    // {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsNumber, useNumber: true},
 
-    // raw values with whitespace
-    {in: "\n true ", ptr: new(bool), out: true},
-    {in: "\t 1 ", ptr: new(int), out: 1},
-    {in: "\r 1.2 ", ptr: new(float64), out: 1.2},
-    {in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
-    {in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
+    // // raw values with whitespace
+    // {in: "\n true ", ptr: new(bool), out: true},
+    // {in: "\t 1 ", ptr: new(int), out: 1},
+    // {in: "\r 1.2 ", ptr: new(float64), out: 1.2},
+    // {in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
+    // {in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
 
-    // Z has a "-" tag.
-    {in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
-    {in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
+    // // Z has a "-" tag.
+    // {in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
+    // {in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
 
-    {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-    {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
-    {in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-    {in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
-    {in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+    // {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+    // {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+    // {in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+    // {in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
+    // {in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
 
-    // syntax errors
-    {in: `{"X": "foo", "Y"}`, err: (&JsonSyntaxError{"invalid character '}' after object key", 17}).err()},
-    {in: `[1, 2, 3+]`, err: (&JsonSyntaxError{"invalid character '+' after array element", 9}).err()},
-    {in: `{"X":12x}`, err: (&JsonSyntaxError{"invalid character 'x' after object key:value pair", 8}).err(), useNumber: true},
-    {in: `[2, 3`, err: (&JsonSyntaxError{Msg:  "unexpected end of JSON input", Offset: 5}).err()},
-    {in: `{"F3": -}`, ptr: new(V), out: V{F3: json.Number("-")}, err: (&JsonSyntaxError{Msg:  "invalid character '}' in numeric literal", Offset: 9}).err()},
+    // // syntax errors
+    // {in: `{"X": "foo", "Y"}`, err: (&JsonSyntaxError{"invalid character '}' after object key", 17}).err()},
+    // {in: `[1, 2, 3+]`, err: (&JsonSyntaxError{"invalid character '+' after array element", 9}).err()},
+    // {in: `{"X":12x}`, err: (&JsonSyntaxError{"invalid character 'x' after object key:value pair", 8}).err(), useNumber: true},
+    // {in: `[2, 3`, err: (&JsonSyntaxError{Msg:  "unexpected end of JSON input", Offset: 5}).err()},
+    // {in: `{"F3": -}`, ptr: new(V), out: V{F3: json.Number("-")}, err: (&JsonSyntaxError{Msg:  "invalid character '}' in numeric literal", Offset: 9}).err()},
 
-    // raw value errors
-    {in: "\x01 42", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    {in: " 42 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 5}).err()},
-    {in: "\x01 true", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    {in: " false \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 8}).err()},
-    {in: "\x01 1.2", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    {in: " 3.4 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 6}).err()},
-    {in: "\x01 \"string\"", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    {in: " \"string\" \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 11}).err()},
+    // // raw value errors
+    // {in: "\x01 42", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    // {in: " 42 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 5}).err()},
+    // {in: "\x01 true", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    // {in: " false \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 8}).err()},
+    // {in: "\x01 1.2", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    // {in: " 3.4 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 6}).err()},
+    // {in: "\x01 \"string\"", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    // {in: " \"string\" \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 11}).err()},
 
-    // array tests
-    {in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
-    {in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
-    {in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
-    {in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
+    // // array tests
+    // {in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
+    // {in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
+    // {in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
+    // {in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
 
-    // empty array to interface test
-    {in: `[]`, ptr: new([]interface{}), out: []interface{}{}},
-    {in: `null`, ptr: new([]interface{}), out: []interface{}(nil)},
-    {in: `{"T":[]}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": []interface{}{}}},
-    {in: `{"T":null}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": interface{}(nil)}},
+    // // empty array to interface test
+    // {in: `[]`, ptr: new([]interface{}), out: []interface{}{}},
+    // {in: `null`, ptr: new([]interface{}), out: []interface{}(nil)},
+    // {in: `{"T":[]}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": []interface{}{}}},
+    // {in: `{"T":null}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": interface{}(nil)}},
 
-    // composite tests
-    {in: allValueIndent, ptr: new(All), out: allValue},
-    {in: allValueCompact, ptr: new(All), out: allValue},
-    {in: allValueIndent, ptr: new(*All), out: &allValue},
-    {in: allValueCompact, ptr: new(*All), out: &allValue},
-    {in: pallValueIndent, ptr: new(All), out: pallValue},
-    {in: pallValueCompact, ptr: new(All), out: pallValue},
-    {in: pallValueIndent, ptr: new(*All), out: &pallValue},
-    {in: pallValueCompact, ptr: new(*All), out: &pallValue},
+    // // composite tests
+    // {in: allValueIndent, ptr: new(All), out: allValue},
+    // {in: allValueCompact, ptr: new(All), out: allValue},
+    // {in: allValueIndent, ptr: new(*All), out: &allValue},
+    // {in: allValueCompact, ptr: new(*All), out: &allValue},
+    // {in: pallValueIndent, ptr: new(All), out: pallValue},
+    // {in: pallValueCompact, ptr: new(All), out: pallValue},
+    // {in: pallValueIndent, ptr: new(*All), out: &pallValue},
+    // {in: pallValueCompact, ptr: new(*All), out: &pallValue},
 
-    // unmarshal interface test
-    {in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
-    {in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
-    {in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
-    {in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
-    {in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
+    // // unmarshal interface test
+    // {in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
+    // {in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
+    // {in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
+    // {in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
+    // {in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
 
-    // UnmarshalText interface test
-    {in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
-    {in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
-    {in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
-    {in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
-    {in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
+    // // UnmarshalText interface test
+    // {in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
+    // {in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
+    // {in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
+    // {in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
+    // {in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
 
-    // integer-keyed map test
-    {
-        in:  `{"-1":"a","0":"b","1":"c"}`,
-        ptr: new(map[int]string),
-        out: map[int]string{-1: "a", 0: "b", 1: "c"},
-    },
-    {
-        in:  `{"0":"a","10":"c","9":"b"}`,
-        ptr: new(map[u8]string),
-        out: map[u8]string{0: "a", 9: "b", 10: "c"},
-    },
-    {
-        in:  `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
-        ptr: new(map[int64]string),
-        out: map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
-    },
-    {
-        in:  `{"18446744073709551615":"max"}`,
-        ptr: new(map[uint64]string),
-        out: map[uint64]string{math.MaxUint64: "max"},
-    },
-    {
-        in:  `{"0":false,"10":true}`,
-        ptr: new(map[uintptr]bool),
-        out: map[uintptr]bool{0: false, 10: true},
-    },
+    // // integer-keyed map test
+    // {
+    //     in:  `{"-1":"a","0":"b","1":"c"}`,
+    //     ptr: new(map[int]string),
+    //     out: map[int]string{-1: "a", 0: "b", 1: "c"},
+    // },
+    // {
+    //     in:  `{"0":"a","10":"c","9":"b"}`,
+    //     ptr: new(map[u8]string),
+    //     out: map[u8]string{0: "a", 9: "b", 10: "c"},
+    // },
+    // {
+    //     in:  `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
+    //     ptr: new(map[int64]string),
+    //     out: map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
+    // },
+    // {
+    //     in:  `{"18446744073709551615":"max"}`,
+    //     ptr: new(map[uint64]string),
+    //     out: map[uint64]string{math.MaxUint64: "max"},
+    // },
+    // {
+    //     in:  `{"0":false,"10":true}`,
+    //     ptr: new(map[uintptr]bool),
+    //     out: map[uintptr]bool{0: false, 10: true},
+    // },
 
-    // Check that MarshalText and UnmarshalText take precedence
-    // over default integer handling in map keys.
-    {
-        in:  `{"u2":4}`,
-        ptr: new(map[u8marshal]int),
-        out: map[u8marshal]int{2: 4},
-    },
-    {
-        in:  `{"2":4}`,
-        ptr: new(map[u8marshal]int),
-        err: errMissingU8Prefix,
-    },
+    // // Check that MarshalText and UnmarshalText take precedence
+    // // over default integer handling in map keys.
+    // {
+    //     in:  `{"u2":4}`,
+    //     ptr: new(map[u8marshal]int),
+    //     out: map[u8marshal]int{2: 4},
+    // },
+    // {
+    //     in:  `{"2":4}`,
+    //     ptr: new(map[u8marshal]int),
+    //     err: errMissingU8Prefix,
+    // },
 
-    // integer-keyed map errors
-    {
-        in:  `{"abc":"abc"}`,
-        ptr: new(map[int]string),
-        err: &json.UnmarshalTypeError{Value: "number abc", Type: reflect.TypeOf(0), Offset: 2},
-    },
-    {
-        in:  `{"256":"abc"}`,
-        ptr: new(map[uint8]string),
-        err: &json.UnmarshalTypeError{Value: "number 256", Type: reflect.TypeOf(uint8(0)), Offset: 2},
-    },
-    {
-        in:  `{"128":"abc"}`,
-        ptr: new(map[int8]string),
-        err: &json.UnmarshalTypeError{Value: "number 128", Type: reflect.TypeOf(int8(0)), Offset: 2},
-    },
-    {
-        in:  `{"-1":"abc"}`,
-        ptr: new(map[uint8]string),
-        err: &json.UnmarshalTypeError{Value: "number -1", Type: reflect.TypeOf(uint8(0)), Offset: 2},
-    },
-    {
-        in:  `{"F":{"a":2,"3":4}}`,
-        ptr: new(map[string]map[int]int),
-        err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(0), Offset: 7},
-    },
-    {
-        in:  `{"F":{"a":2,"3":4}}`,
-        ptr: new(map[string]map[uint]int),
-        err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(uint(0)), Offset: 7},
-    },
+    // // integer-keyed map errors
+    // {
+    //     in:  `{"abc":"abc"}`,
+    //     ptr: new(map[int]string),
+    //     err: &json.UnmarshalTypeError{Value: "number abc", Type: reflect.TypeOf(0), Offset: 2},
+    // },
+    // {
+    //     in:  `{"256":"abc"}`,
+    //     ptr: new(map[uint8]string),
+    //     err: &json.UnmarshalTypeError{Value: "number 256", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+    // },
+    // {
+    //     in:  `{"128":"abc"}`,
+    //     ptr: new(map[int8]string),
+    //     err: &json.UnmarshalTypeError{Value: "number 128", Type: reflect.TypeOf(int8(0)), Offset: 2},
+    // },
+    // {
+    //     in:  `{"-1":"abc"}`,
+    //     ptr: new(map[uint8]string),
+    //     err: &json.UnmarshalTypeError{Value: "number -1", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+    // },
+    // {
+    //     in:  `{"F":{"a":2,"3":4}}`,
+    //     ptr: new(map[string]map[int]int),
+    //     err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(0), Offset: 7},
+    // },
+    // {
+    //     in:  `{"F":{"a":2,"3":4}}`,
+    //     ptr: new(map[string]map[uint]int),
+    //     err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(uint(0)), Offset: 7},
+    // },
 
-    // Map keys can be encoding.TextUnmarshalers.
-    {in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
-    // If multiple values for the same key exists, only the most recent value is used.
-    {in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+    // // Map keys can be encoding.TextUnmarshalers.
+    // {in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+    // // If multiple values for the same key exists, only the most recent value is used.
+    // {in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
 
-    {
-        in: `{
-            "Level0": 1,
-            "Level1b": 2,
-            "Level1c": 3,
-            "x": 4,
-            "Level1a": 5,
-            "LEVEL1B": 6,
-            "e": {
-                "Level1a": 8,
-                "Level1b": 9,
-                "Level1c": 10,
-                "Level1d": 11,
-                "x": 12
-            },
-            "Loop1": 13,
-            "Loop2": 14,
-            "X": 15,
-            "Y": 16,
-            "Z": 17,
-            "Q": 18
-        }`,
-        ptr: new(Top),
-        out: Top{
-            Level0: 1,
-            Embed0: Embed0{
-                Level1b: 2,
-                Level1c: 3,
-            },
-            Embed0a: &Embed0a{
-                Level1a: 5,
-                Level1b: 6,
-            },
-            Embed0b: &Embed0b{
-                Level1a: 8,
-                Level1b: 9,
-                Level1c: 10,
-                Level1d: 11,
-                Level1e: 12,
-            },
-            Loop: Loop{
-                Loop1: 13,
-                Loop2: 14,
-            },
-            Embed0p: Embed0p{
-                Point: image.Point{X: 15, Y: 16},
-            },
-            Embed0q: Embed0q{
-                Point: Point{Z: 17},
-            },
-            embed: embed{
-                Q: 18,
-            },
-        },
-    },
-    {
-        in:  `{"hello": 1}`,
-        ptr: new(Ambig),
-        out: Ambig{First: 1},
-    },
+    // {
+    //     in: `{
+    //         "Level0": 1,
+    //         "Level1b": 2,
+    //         "Level1c": 3,
+    //         "x": 4,
+    //         "Level1a": 5,
+    //         "LEVEL1B": 6,
+    //         "e": {
+    //             "Level1a": 8,
+    //             "Level1b": 9,
+    //             "Level1c": 10,
+    //             "Level1d": 11,
+    //             "x": 12
+    //         },
+    //         "Loop1": 13,
+    //         "Loop2": 14,
+    //         "X": 15,
+    //         "Y": 16,
+    //         "Z": 17,
+    //         "Q": 18
+    //     }`,
+    //     ptr: new(Top),
+    //     out: Top{
+    //         Level0: 1,
+    //         Embed0: Embed0{
+    //             Level1b: 2,
+    //             Level1c: 3,
+    //         },
+    //         Embed0a: &Embed0a{
+    //             Level1a: 5,
+    //             Level1b: 6,
+    //         },
+    //         Embed0b: &Embed0b{
+    //             Level1a: 8,
+    //             Level1b: 9,
+    //             Level1c: 10,
+    //             Level1d: 11,
+    //             Level1e: 12,
+    //         },
+    //         Loop: Loop{
+    //             Loop1: 13,
+    //             Loop2: 14,
+    //         },
+    //         Embed0p: Embed0p{
+    //             Point: image.Point{X: 15, Y: 16},
+    //         },
+    //         Embed0q: Embed0q{
+    //             Point: Point{Z: 17},
+    //         },
+    //         embed: embed{
+    //             Q: 18,
+    //         },
+    //     },
+    // },
+    // {
+    //     in:  `{"hello": 1}`,
+    //     ptr: new(Ambig),
+    //     out: Ambig{First: 1},
+    // },
 
-    {
-        in:  `{"X": 1,"Y":2}`,
-        ptr: new(S5),
-        out: S5{S8: S8{S9: S9{Y: 2}}},
-    },
-    {
-        in:                    `{"X": 1,"Y":2}`,
-        ptr:                   new(S5),
-        err:                   fmt.Errorf("json: unknown field \"X\""),
-        disallowUnknownFields: true,
-    },
-    {
-        in:  `{"X": 1,"Y":2}`,
-        ptr: new(S10),
-        out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
-    },
-    {
-        in:                    `{"X": 1,"Y":2}`,
-        ptr:                   new(S10),
-        err:                   fmt.Errorf("json: unknown field \"X\""),
-        disallowUnknownFields: true,
-    },
-    {
-        in:  `{"I": 0, "I": null, "J": null}`,
-        ptr: new(DoublePtr),
-        out: DoublePtr{I: nil, J: nil},
-    },
+    // {
+    //     in:  `{"X": 1,"Y":2}`,
+    //     ptr: new(S5),
+    //     out: S5{S8: S8{S9: S9{Y: 2}}},
+    // },
+    // {
+    //     in:                    `{"X": 1,"Y":2}`,
+    //     ptr:                   new(S5),
+    //     err:                   fmt.Errorf("json: unknown field \"X\""),
+    //     disallowUnknownFields: true,
+    // },
+    // {
+    //     in:  `{"X": 1,"Y":2}`,
+    //     ptr: new(S10),
+    //     out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
+    // },
+    // {
+    //     in:                    `{"X": 1,"Y":2}`,
+    //     ptr:                   new(S10),
+    //     err:                   fmt.Errorf("json: unknown field \"X\""),
+    //     disallowUnknownFields: true,
+    // },
+    // {
+    //     in:  `{"I": 0, "I": null, "J": null}`,
+    //     ptr: new(DoublePtr),
+    //     out: DoublePtr{I: nil, J: nil},
+    // },
 
-    // invalid UTF-8 is coerced to valid UTF-8.
-    {
-        in:  "\"hello\xffworld\"",
-        ptr: new(string),
-        out: "hello\xffworld",
-        validateString: false,
-    },
-    {
-        in:  "\"hello\xc2\xc2world\"",
-        ptr: new(string),
-        out: "hello\xc2\xc2world",
-        validateString: false,
-    },
-    {
-        in:  "\"hello\xc2\xffworld\"",
-        ptr: new(string),
-        out: "hello\xc2\xffworld",
-    },
-    {
-        in:  "\"hello\\ud800world\"",
-        ptr: new(string),
-        out: "hello\ufffdworld",
-    },
-    {
-        in:  "\"hello\\ud800\\ud800world\"",
-        ptr: new(string),
-        out: "hello\ufffd\ufffdworld",
-    },
-    {
-        in:  "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
-        ptr: new(string),
-        out: "hello\xed\xa0\x80\xed\xb0\x80world",
-    },
+    // // invalid UTF-8 is coerced to valid UTF-8.
+    // {
+    //     in:  "\"hello\xffworld\"",
+    //     ptr: new(string),
+    //     out: "hello\xffworld",
+    //     validateString: false,
+    // },
+    // {
+    //     in:  "\"hello\xc2\xc2world\"",
+    //     ptr: new(string),
+    //     out: "hello\xc2\xc2world",
+    //     validateString: false,
+    // },
+    // {
+    //     in:  "\"hello\xc2\xffworld\"",
+    //     ptr: new(string),
+    //     out: "hello\xc2\xffworld",
+    // },
+    // {
+    //     in:  "\"hello\\ud800world\"",
+    //     ptr: new(string),
+    //     out: "hello\ufffdworld",
+    // },
+    // {
+    //     in:  "\"hello\\ud800\\ud800world\"",
+    //     ptr: new(string),
+    //     out: "hello\ufffd\ufffdworld",
+    // },
+    // {
+    //     in:  "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
+    //     ptr: new(string),
+    //     out: "hello\xed\xa0\x80\xed\xb0\x80world",
+    // },
 
-    // Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
-    {
-        in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-        ptr: new(map[time.Time]string),
-        out: map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
-    },
+    // // Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
+    // {
+    //     in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
+    //     ptr: new(map[time.Time]string),
+    //     out: map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
+    // },
 
-    // issue 8305
-    {
-        in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-        ptr: new(map[Point]string),
-        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[Point]string{}), Offset: 1},
-    },
-    {
-        in:  `{"asdf": "hello world"}`,
-        ptr: new(map[unmarshaler]string),
-        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[unmarshaler]string{}), Offset: 1},
-    },
+    // // issue 8305
+    // {
+    //     in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
+    //     ptr: new(map[Point]string),
+    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[Point]string{}), Offset: 1},
+    // },
+    // {
+    //     in:  `{"asdf": "hello world"}`,
+    //     ptr: new(map[unmarshaler]string),
+    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[unmarshaler]string{}), Offset: 1},
+    // },
 
     // related to issue 13783.
     // Go 1.7 changed marshaling a slice of typed byte to use the methods on the byte type,
@@ -760,262 +760,262 @@ var unmarshalTests = []unmarshalTest{
         ptr: new([]byteWithMarshalJSON),
         out: []byteWithMarshalJSON{1, 2, 3},
     },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]byteWithMarshalJSON),
-        out:    []byteWithMarshalJSON{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:  `"AQID"`,
-        ptr: new([]byteWithMarshalText),
-        out: []byteWithMarshalText{1, 2, 3},
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]byteWithMarshalText),
-        out:    []byteWithMarshalText{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:  `"AQID"`,
-        ptr: new([]byteWithPtrMarshalJSON),
-        out: []byteWithPtrMarshalJSON{1, 2, 3},
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]byteWithPtrMarshalJSON),
-        out:    []byteWithPtrMarshalJSON{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:  `"AQID"`,
-        ptr: new([]byteWithPtrMarshalText),
-        out: []byteWithPtrMarshalText{1, 2, 3},
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]byteWithPtrMarshalText),
-        out:    []byteWithPtrMarshalText{1, 2, 3},
-        golden: true,
-    },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]byteWithMarshalJSON),
+    //     out:    []byteWithMarshalJSON{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:  `"AQID"`,
+    //     ptr: new([]byteWithMarshalText),
+    //     out: []byteWithMarshalText{1, 2, 3},
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]byteWithMarshalText),
+    //     out:    []byteWithMarshalText{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:  `"AQID"`,
+    //     ptr: new([]byteWithPtrMarshalJSON),
+    //     out: []byteWithPtrMarshalJSON{1, 2, 3},
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]byteWithPtrMarshalJSON),
+    //     out:    []byteWithPtrMarshalJSON{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:  `"AQID"`,
+    //     ptr: new([]byteWithPtrMarshalText),
+    //     out: []byteWithPtrMarshalText{1, 2, 3},
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]byteWithPtrMarshalText),
+    //     out:    []byteWithPtrMarshalText{1, 2, 3},
+    //     golden: true,
+    // },
 
-    // ints work with the marshaler but not the base64 []byte case
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]intWithMarshalJSON),
-        out:    []intWithMarshalJSON{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]intWithMarshalText),
-        out:    []intWithMarshalText{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]intWithPtrMarshalJSON),
-        out:    []intWithPtrMarshalJSON{1, 2, 3},
-        golden: true,
-    },
-    {
-        in:     `["Z01","Z02","Z03"]`,
-        ptr:    new([]intWithPtrMarshalText),
-        out:    []intWithPtrMarshalText{1, 2, 3},
-        golden: true,
-    },
+    // // ints work with the marshaler but not the base64 []byte case
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]intWithMarshalJSON),
+    //     out:    []intWithMarshalJSON{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]intWithMarshalText),
+    //     out:    []intWithMarshalText{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]intWithPtrMarshalJSON),
+    //     out:    []intWithPtrMarshalJSON{1, 2, 3},
+    //     golden: true,
+    // },
+    // {
+    //     in:     `["Z01","Z02","Z03"]`,
+    //     ptr:    new([]intWithPtrMarshalText),
+    //     out:    []intWithPtrMarshalText{1, 2, 3},
+    //     golden: true,
+    // },
 
-    {in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
-    {in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
-    {in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
-    {in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
-    {in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
-    {in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
-    {in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
-    {in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
-    {in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
-    {in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
-    {in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
+    // {in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
+    // {in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
+    // {in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
+    // {in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
+    // {in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
+    // {in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
+    // {in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
+    // {in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
+    // {in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
+    // {in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
+    // {in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
 
-    {
-        in:  `{"V": {"F2": "hello"}}`,
-        ptr: new(VOuter),
-        err: &json.UnmarshalTypeError{
-            Value:  "string",
-            Struct: "V",
-            Field:  "V.F2",
-            Type:   reflect.TypeOf(int32(0)),
-            Offset: 20,
-        },
-    },
-    {
-        in:  `{"V": {"F4": {}, "F2": "hello"}}`,
-        ptr: new(VOuter),
-        err: &json.UnmarshalTypeError{
-            Value:  "string",
-            Struct: "V",
-            Field:  "V.F2",
-            Type:   reflect.TypeOf(int32(0)),
-            Offset: 30,
-        },
-    },
+    // {
+    //     in:  `{"V": {"F2": "hello"}}`,
+    //     ptr: new(VOuter),
+    //     err: &json.UnmarshalTypeError{
+    //         Value:  "string",
+    //         Struct: "V",
+    //         Field:  "V.F2",
+    //         Type:   reflect.TypeOf(int32(0)),
+    //         Offset: 20,
+    //     },
+    // },
+    // {
+    //     in:  `{"V": {"F4": {}, "F2": "hello"}}`,
+    //     ptr: new(VOuter),
+    //     err: &json.UnmarshalTypeError{
+    //         Value:  "string",
+    //         Struct: "V",
+    //         Field:  "V.F2",
+    //         Type:   reflect.TypeOf(int32(0)),
+    //         Offset: 30,
+    //     },
+    // },
 
-    // issue 15146.
-    // invalid inputs in wrongStringTests below.
-    {in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
-    {in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
-    {in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
-    {in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
-    {in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
-    {in: `{"B": "null"}`, ptr: new(B), out: B{false}},
-    {in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
-    {in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
+    // // issue 15146.
+    // // invalid inputs in wrongStringTests below.
+    // {in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
+    // {in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
+    // {in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
+    // {in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
+    // {in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
+    // {in: `{"B": "null"}`, ptr: new(B), out: B{false}},
+    // {in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
+    // {in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
 
-    // additional tests for disallowUnknownFields
-    {
-        in: `{
-            "Level0": 1,
-            "Level1b": 2,
-            "Level1c": 3,
-            "x": 4,
-            "Level1a": 5,
-            "LEVEL1B": 6,
-            "e": {
-                "Level1a": 8,
-                "Level1b": 9,
-                "Level1c": 10,
-                "Level1d": 11,
-                "x": 12
-            },
-            "Loop1": 13,
-            "Loop2": 14,
-            "X": 15,
-            "Y": 16,
-            "Z": 17,
-            "Q": 18,
-            "extra": true
-        }`,
-        ptr:                   new(Top),
-        err:                   fmt.Errorf("json: unknown field \"extra\""),
-        disallowUnknownFields: true,
-    },
-    {
-        in: `{
-            "Level0": 1,
-            "Level1b": 2,
-            "Level1c": 3,
-            "x": 4,
-            "Level1a": 5,
-            "LEVEL1B": 6,
-            "e": {
-                "Level1a": 8,
-                "Level1b": 9,
-                "Level1c": 10,
-                "Level1d": 11,
-                "x": 12,
-                "extra": null
-            },
-            "Loop1": 13,
-            "Loop2": 14,
-            "X": 15,
-            "Y": 16,
-            "Z": 17,
-            "Q": 18
-        }`,
-        ptr:                   new(Top),
-        err:                   fmt.Errorf("json: unknown field \"extra\""),
-        disallowUnknownFields: true,
-    },
-    // issue 26444
-    // json.UnmarshalTypeError without field & struct values
-    {
-        in:  `{"data":{"test1": "bob", "test2": 123}}`,
-        ptr: new(mapStringToStringData),
-        err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
-    },
-    {
-        in:  `{"data":{"test1": 123, "test2": "bob"}}`,
-        ptr: new(mapStringToStringData),
-        err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
-    },
+    // // additional tests for disallowUnknownFields
+    // {
+    //     in: `{
+    //         "Level0": 1,
+    //         "Level1b": 2,
+    //         "Level1c": 3,
+    //         "x": 4,
+    //         "Level1a": 5,
+    //         "LEVEL1B": 6,
+    //         "e": {
+    //             "Level1a": 8,
+    //             "Level1b": 9,
+    //             "Level1c": 10,
+    //             "Level1d": 11,
+    //             "x": 12
+    //         },
+    //         "Loop1": 13,
+    //         "Loop2": 14,
+    //         "X": 15,
+    //         "Y": 16,
+    //         "Z": 17,
+    //         "Q": 18,
+    //         "extra": true
+    //     }`,
+    //     ptr:                   new(Top),
+    //     err:                   fmt.Errorf("json: unknown field \"extra\""),
+    //     disallowUnknownFields: true,
+    // },
+    // {
+    //     in: `{
+    //         "Level0": 1,
+    //         "Level1b": 2,
+    //         "Level1c": 3,
+    //         "x": 4,
+    //         "Level1a": 5,
+    //         "LEVEL1B": 6,
+    //         "e": {
+    //             "Level1a": 8,
+    //             "Level1b": 9,
+    //             "Level1c": 10,
+    //             "Level1d": 11,
+    //             "x": 12,
+    //             "extra": null
+    //         },
+    //         "Loop1": 13,
+    //         "Loop2": 14,
+    //         "X": 15,
+    //         "Y": 16,
+    //         "Z": 17,
+    //         "Q": 18
+    //     }`,
+    //     ptr:                   new(Top),
+    //     err:                   fmt.Errorf("json: unknown field \"extra\""),
+    //     disallowUnknownFields: true,
+    // },
+    // // issue 26444
+    // // json.UnmarshalTypeError without field & struct values
+    // {
+    //     in:  `{"data":{"test1": "bob", "test2": 123}}`,
+    //     ptr: new(mapStringToStringData),
+    //     err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
+    // },
+    // {
+    //     in:  `{"data":{"test1": 123, "test2": "bob"}}`,
+    //     ptr: new(mapStringToStringData),
+    //     err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
+    // },
 
-    // trying to decode JSON arrays or objects via TextUnmarshaler
-    {
-        in:  `[1, 2, 3]`,
-        ptr: new(MustNotUnmarshalText),
-        err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
-    },
-    {
-        in:  `{"foo": "bar"}`,
-        ptr: new(MustNotUnmarshalText),
-        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
-    },
-    // #22369
-    {
-        in:  `{"PP": {"T": {"Y": "bad-type"}}}`,
-        ptr: new(P),
-        err: &json.UnmarshalTypeError{
-            Value:  "string",
-            Struct: "T",
-            Field:  "PP.T.Y",
-            Type:   reflect.TypeOf(0),
-            Offset: 29,
-        },
-    },
-    {
-        in:  `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
-        ptr: new(PP),
-        err: &json.UnmarshalTypeError{
-            Value:  "string",
-            Struct: "T",
-            Field:  "Ts.Y",
-            Type:   reflect.TypeOf(0),
-            Offset: 29,
-        },
-    },
-    // #14702
-    {
-        in:  `invalid`,
-        ptr: new(json.Number),
-        err: (&JsonSyntaxError{
-            Msg:    "invalid character 'i' looking for beginning of value",
-            Offset: 1,
-        }).err(),
-    },
-    {
-        in:  `"invalid"`,
-        ptr: new(json.Number),
-        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    },
-    {
-        in:  `{"A":"invalid"}`,
-        ptr: new(struct{ A json.Number }),
-        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    },
-    {
-        in: `{"A":"invalid"}`,
-        ptr: new(struct {
-            A json.Number `json:",string"`
-        }),
-        err: fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into json.Number", `invalid`),
-    },
-    {
-        in:  `{"A":"invalid"}`,
-        ptr: new(map[string]json.Number),
-        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    },
-    {in: `\u`, ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    {in: `\u`, ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    // // trying to decode JSON arrays or objects via TextUnmarshaler
+    // {
+    //     in:  `[1, 2, 3]`,
+    //     ptr: new(MustNotUnmarshalText),
+    //     err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+    // },
+    // {
+    //     in:  `{"foo": "bar"}`,
+    //     ptr: new(MustNotUnmarshalText),
+    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+    // },
+    // // #22369
+    // {
+    //     in:  `{"PP": {"T": {"Y": "bad-type"}}}`,
+    //     ptr: new(P),
+    //     err: &json.UnmarshalTypeError{
+    //         Value:  "string",
+    //         Struct: "T",
+    //         Field:  "PP.T.Y",
+    //         Type:   reflect.TypeOf(0),
+    //         Offset: 29,
+    //     },
+    // },
+    // {
+    //     in:  `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
+    //     ptr: new(PP),
+    //     err: &json.UnmarshalTypeError{
+    //         Value:  "string",
+    //         Struct: "T",
+    //         Field:  "Ts.Y",
+    //         Type:   reflect.TypeOf(0),
+    //         Offset: 29,
+    //     },
+    // },
+    // // #14702
+    // {
+    //     in:  `invalid`,
+    //     ptr: new(json.Number),
+    //     err: (&JsonSyntaxError{
+    //         Msg:    "invalid character 'i' looking for beginning of value",
+    //         Offset: 1,
+    //     }).err(),
+    // },
+    // {
+    //     in:  `"invalid"`,
+    //     ptr: new(json.Number),
+    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    // },
+    // {
+    //     in:  `{"A":"invalid"}`,
+    //     ptr: new(struct{ A json.Number }),
+    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    // },
+    // {
+    //     in: `{"A":"invalid"}`,
+    //     ptr: new(struct {
+    //         A json.Number `json:",string"`
+    //     }),
+    //     err: fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into json.Number", `invalid`),
+    // },
+    // {
+    //     in:  `{"A":"invalid"}`,
+    //     ptr: new(map[string]json.Number),
+    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    // },
+    // {in: `\u`, ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    // {in: `\u`, ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
 
-    {in: "\"\x00\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    {in: "\"\x00\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
-    {in: "\"\xff\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    {in: "\"\xff\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
-    {in: "\"\x00\"", ptr: new(interface{}), out: interface{}("\x00"), validateString: false},
-    {in: "\"\x00\"", ptr: new(string), out: "\x00", validateString: false},
-    {in: "\"\xff\"", ptr: new(interface{}), out: interface{}("\xff"), validateString: false},
-    {in: "\"\xff\"", ptr: new(string), out: "\xff", validateString: false},
+    // {in: "\"\x00\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    // {in: "\"\x00\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    // {in: "\"\xff\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    // {in: "\"\xff\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    // {in: "\"\x00\"", ptr: new(interface{}), out: interface{}("\x00"), validateString: false},
+    // {in: "\"\x00\"", ptr: new(string), out: "\x00", validateString: false},
+    // {in: "\"\xff\"", ptr: new(interface{}), out: interface{}("\xff"), validateString: false},
+    // {in: "\"\xff\"", ptr: new(string), out: "\xff", validateString: false},
 }
 
 func trim(b []byte) []byte {
@@ -1116,6 +1116,7 @@ func TestMarshalEmbeds(t *testing.T) {
 
 func TestUnmarshal(t *testing.T) {
     for i, tt := range unmarshalTests {
+        t.Log(i, tt.in)
         if !json.Valid([]byte(tt.in)) {
             continue
         }
@@ -2005,7 +2006,6 @@ var decodeTypeErrorTests = []struct {
     dest interface{}
     src  string
 }{
-    {new(string), `{"user": "name"}`}, // issue 4628.
     {new(error), `{}`},                // issue 4222
     {new(error), `[]`},
     {new(error), `""`},
@@ -2019,6 +2019,28 @@ func TestUnmarshalTypeError(t *testing.T) {
         if _, ok := err.(*json.UnmarshalTypeError); !ok {
             if _, ok = err.(decoder.SyntaxError); !ok {
                 t.Errorf("expected type error for Unmarshal(%q, type %T): got %T",
+                    item.src, item.dest, err)
+            }
+        }
+    }
+}
+
+var decodeMismatchErrorTests = []struct {
+    dest interface{}
+    src  string
+}{
+    {new(int), `{}`},               
+    {new(string), `{}`},               
+    {new(bool), `{}`},               
+    {new([]byte), `{}`},               
+}
+
+func TestMismatchTypeError(t *testing.T) {
+    for _, item := range decodeMismatchErrorTests {
+        err := Unmarshal([]byte(item.src), item.dest)
+        if _, ok := err.(*decoder.MismatchTypeError); !ok {
+            if _, ok = err.(decoder.SyntaxError); !ok {
+                t.Errorf("expected mismatch error for Unmarshal(%q, type %T): got %T",
                     item.src, item.dest, err)
             }
         }

--- a/decode_test.go
+++ b/decode_test.go
@@ -436,317 +436,317 @@ func (self *JsonSyntaxError) err() *json.SyntaxError {
 
 var unmarshalTests = []unmarshalTest{
     // basic types
-    // {in: `true`, ptr: new(bool), out: true},
-    // {in: `1`, ptr: new(int), out: 1},
-    // {in: `1.2`, ptr: new(float64), out: 1.2},
-    // {in: `-5`, ptr: new(int16), out: int16(-5)},
-    // {in: `2`, ptr: new(json.Number), out: json.Number("2"), useNumber: true},
-    // {in: `2`, ptr: new(json.Number), out: json.Number("2")},
-    // {in: `2`, ptr: new(interface{}), out: 2.0},
-    // {in: `2`, ptr: new(interface{}), out: json.Number("2"), useNumber: true},
-    // {in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
-    // {in: `"http:\/\/"`, ptr: new(string), out: "http://"},
-    // {in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
-    // {in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
-    // {in: "null", ptr: new(interface{}), out: nil},
-    // {in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(""), Offset: 7, Struct: "T", Field: "X"}},
-    // {in: `{"X": 23}`, ptr: new(T), out: T{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 8, Struct: "T", Field: "X"}},
-    // {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
-    // {in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
-    // {in: `{"S": 23}`, ptr: new(W), out: W{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(SS("")), Struct: "W", Field: "S"}},
-    // {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: json.Number("3")}},
-    // {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: json.Number("1"), F2: int32(2), F3: json.Number("3")}, useNumber: true},
-    // {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsFloat64},
-    // {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsNumber, useNumber: true},
+    {in: `true`, ptr: new(bool), out: true},
+    {in: `1`, ptr: new(int), out: 1},
+    {in: `1.2`, ptr: new(float64), out: 1.2},
+    {in: `-5`, ptr: new(int16), out: int16(-5)},
+    {in: `2`, ptr: new(json.Number), out: json.Number("2"), useNumber: true},
+    {in: `2`, ptr: new(json.Number), out: json.Number("2")},
+    {in: `2`, ptr: new(interface{}), out: 2.0},
+    {in: `2`, ptr: new(interface{}), out: json.Number("2"), useNumber: true},
+    {in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
+    {in: `"http:\/\/"`, ptr: new(string), out: "http://"},
+    {in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
+    {in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
+    {in: "null", ptr: new(interface{}), out: nil},
+    {in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(""), Offset: 7, Struct: "T", Field: "X"}},
+    {in: `{"X": 23}`, ptr: new(T), out: T{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 8, Struct: "T", Field: "X"}},
+    {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+    {in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+    {in: `{"S": 23}`, ptr: new(W), out: W{}, err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(SS("")), Struct: "W", Field: "S"}},
+    {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: json.Number("3")}},
+    {in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: json.Number("1"), F2: int32(2), F3: json.Number("3")}, useNumber: true},
+    {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsFloat64},
+    {in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsNumber, useNumber: true},
 
-    // // raw values with whitespace
-    // {in: "\n true ", ptr: new(bool), out: true},
-    // {in: "\t 1 ", ptr: new(int), out: 1},
-    // {in: "\r 1.2 ", ptr: new(float64), out: 1.2},
-    // {in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
-    // {in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
+    // raw values with whitespace
+    {in: "\n true ", ptr: new(bool), out: true},
+    {in: "\t 1 ", ptr: new(int), out: 1},
+    {in: "\r 1.2 ", ptr: new(float64), out: 1.2},
+    {in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
+    {in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
 
-    // // Z has a "-" tag.
-    // {in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
-    // {in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
+    // Z has a "-" tag.
+    {in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
+    {in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
 
-    // {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-    // {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
-    // {in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-    // {in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
-    // {in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+    {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+    {in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+    {in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+    {in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
+    {in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
 
-    // // syntax errors
-    // {in: `{"X": "foo", "Y"}`, err: (&JsonSyntaxError{"invalid character '}' after object key", 17}).err()},
-    // {in: `[1, 2, 3+]`, err: (&JsonSyntaxError{"invalid character '+' after array element", 9}).err()},
-    // {in: `{"X":12x}`, err: (&JsonSyntaxError{"invalid character 'x' after object key:value pair", 8}).err(), useNumber: true},
-    // {in: `[2, 3`, err: (&JsonSyntaxError{Msg:  "unexpected end of JSON input", Offset: 5}).err()},
-    // {in: `{"F3": -}`, ptr: new(V), out: V{F3: json.Number("-")}, err: (&JsonSyntaxError{Msg:  "invalid character '}' in numeric literal", Offset: 9}).err()},
+    // syntax errors
+    {in: `{"X": "foo", "Y"}`, err: (&JsonSyntaxError{"invalid character '}' after object key", 17}).err()},
+    {in: `[1, 2, 3+]`, err: (&JsonSyntaxError{"invalid character '+' after array element", 9}).err()},
+    {in: `{"X":12x}`, err: (&JsonSyntaxError{"invalid character 'x' after object key:value pair", 8}).err(), useNumber: true},
+    {in: `[2, 3`, err: (&JsonSyntaxError{Msg:  "unexpected end of JSON input", Offset: 5}).err()},
+    {in: `{"F3": -}`, ptr: new(V), out: V{F3: json.Number("-")}, err: (&JsonSyntaxError{Msg:  "invalid character '}' in numeric literal", Offset: 9}).err()},
 
-    // // raw value errors
-    // {in: "\x01 42", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    // {in: " 42 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 5}).err()},
-    // {in: "\x01 true", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    // {in: " false \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 8}).err()},
-    // {in: "\x01 1.2", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    // {in: " 3.4 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 6}).err()},
-    // {in: "\x01 \"string\"", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
-    // {in: " \"string\" \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 11}).err()},
+    // raw value errors
+    {in: "\x01 42", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    {in: " 42 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 5}).err()},
+    {in: "\x01 true", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    {in: " false \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 8}).err()},
+    {in: "\x01 1.2", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    {in: " 3.4 \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 6}).err()},
+    {in: "\x01 \"string\"", err: (&JsonSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}).err()},
+    {in: " \"string\" \x01", err: (&JsonSyntaxError{"invalid character '\\x01' after top-level value", 11}).err()},
 
-    // // array tests
-    // {in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
-    // {in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
-    // {in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
-    // {in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
+    // array tests
+    {in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
+    {in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
+    {in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
+    {in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
 
-    // // empty array to interface test
-    // {in: `[]`, ptr: new([]interface{}), out: []interface{}{}},
-    // {in: `null`, ptr: new([]interface{}), out: []interface{}(nil)},
-    // {in: `{"T":[]}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": []interface{}{}}},
-    // {in: `{"T":null}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": interface{}(nil)}},
+    // empty array to interface test
+    {in: `[]`, ptr: new([]interface{}), out: []interface{}{}},
+    {in: `null`, ptr: new([]interface{}), out: []interface{}(nil)},
+    {in: `{"T":[]}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": []interface{}{}}},
+    {in: `{"T":null}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": interface{}(nil)}},
 
-    // // composite tests
-    // {in: allValueIndent, ptr: new(All), out: allValue},
-    // {in: allValueCompact, ptr: new(All), out: allValue},
-    // {in: allValueIndent, ptr: new(*All), out: &allValue},
-    // {in: allValueCompact, ptr: new(*All), out: &allValue},
-    // {in: pallValueIndent, ptr: new(All), out: pallValue},
-    // {in: pallValueCompact, ptr: new(All), out: pallValue},
-    // {in: pallValueIndent, ptr: new(*All), out: &pallValue},
-    // {in: pallValueCompact, ptr: new(*All), out: &pallValue},
+    // composite tests
+    {in: allValueIndent, ptr: new(All), out: allValue},
+    {in: allValueCompact, ptr: new(All), out: allValue},
+    {in: allValueIndent, ptr: new(*All), out: &allValue},
+    {in: allValueCompact, ptr: new(*All), out: &allValue},
+    {in: pallValueIndent, ptr: new(All), out: pallValue},
+    {in: pallValueCompact, ptr: new(All), out: pallValue},
+    {in: pallValueIndent, ptr: new(*All), out: &pallValue},
+    {in: pallValueCompact, ptr: new(*All), out: &pallValue},
 
-    // // unmarshal interface test
-    // {in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
-    // {in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
-    // {in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
-    // {in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
-    // {in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
+    // unmarshal interface test
+    {in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
+    {in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
+    {in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
+    {in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
+    {in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
 
-    // // UnmarshalText interface test
-    // {in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
-    // {in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
-    // {in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
-    // {in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
-    // {in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
+    // UnmarshalText interface test
+    {in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
+    {in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
+    {in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
+    {in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
+    {in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
 
-    // // integer-keyed map test
-    // {
-    //     in:  `{"-1":"a","0":"b","1":"c"}`,
-    //     ptr: new(map[int]string),
-    //     out: map[int]string{-1: "a", 0: "b", 1: "c"},
-    // },
-    // {
-    //     in:  `{"0":"a","10":"c","9":"b"}`,
-    //     ptr: new(map[u8]string),
-    //     out: map[u8]string{0: "a", 9: "b", 10: "c"},
-    // },
-    // {
-    //     in:  `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
-    //     ptr: new(map[int64]string),
-    //     out: map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
-    // },
-    // {
-    //     in:  `{"18446744073709551615":"max"}`,
-    //     ptr: new(map[uint64]string),
-    //     out: map[uint64]string{math.MaxUint64: "max"},
-    // },
-    // {
-    //     in:  `{"0":false,"10":true}`,
-    //     ptr: new(map[uintptr]bool),
-    //     out: map[uintptr]bool{0: false, 10: true},
-    // },
+    // integer-keyed map test
+    {
+        in:  `{"-1":"a","0":"b","1":"c"}`,
+        ptr: new(map[int]string),
+        out: map[int]string{-1: "a", 0: "b", 1: "c"},
+    },
+    {
+        in:  `{"0":"a","10":"c","9":"b"}`,
+        ptr: new(map[u8]string),
+        out: map[u8]string{0: "a", 9: "b", 10: "c"},
+    },
+    {
+        in:  `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
+        ptr: new(map[int64]string),
+        out: map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
+    },
+    {
+        in:  `{"18446744073709551615":"max"}`,
+        ptr: new(map[uint64]string),
+        out: map[uint64]string{math.MaxUint64: "max"},
+    },
+    {
+        in:  `{"0":false,"10":true}`,
+        ptr: new(map[uintptr]bool),
+        out: map[uintptr]bool{0: false, 10: true},
+    },
 
-    // // Check that MarshalText and UnmarshalText take precedence
-    // // over default integer handling in map keys.
-    // {
-    //     in:  `{"u2":4}`,
-    //     ptr: new(map[u8marshal]int),
-    //     out: map[u8marshal]int{2: 4},
-    // },
-    // {
-    //     in:  `{"2":4}`,
-    //     ptr: new(map[u8marshal]int),
-    //     err: errMissingU8Prefix,
-    // },
+    // Check that MarshalText and UnmarshalText take precedence
+    // over default integer handling in map keys.
+    {
+        in:  `{"u2":4}`,
+        ptr: new(map[u8marshal]int),
+        out: map[u8marshal]int{2: 4},
+    },
+    {
+        in:  `{"2":4}`,
+        ptr: new(map[u8marshal]int),
+        err: errMissingU8Prefix,
+    },
 
-    // // integer-keyed map errors
-    // {
-    //     in:  `{"abc":"abc"}`,
-    //     ptr: new(map[int]string),
-    //     err: &json.UnmarshalTypeError{Value: "number abc", Type: reflect.TypeOf(0), Offset: 2},
-    // },
-    // {
-    //     in:  `{"256":"abc"}`,
-    //     ptr: new(map[uint8]string),
-    //     err: &json.UnmarshalTypeError{Value: "number 256", Type: reflect.TypeOf(uint8(0)), Offset: 2},
-    // },
-    // {
-    //     in:  `{"128":"abc"}`,
-    //     ptr: new(map[int8]string),
-    //     err: &json.UnmarshalTypeError{Value: "number 128", Type: reflect.TypeOf(int8(0)), Offset: 2},
-    // },
-    // {
-    //     in:  `{"-1":"abc"}`,
-    //     ptr: new(map[uint8]string),
-    //     err: &json.UnmarshalTypeError{Value: "number -1", Type: reflect.TypeOf(uint8(0)), Offset: 2},
-    // },
-    // {
-    //     in:  `{"F":{"a":2,"3":4}}`,
-    //     ptr: new(map[string]map[int]int),
-    //     err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(0), Offset: 7},
-    // },
-    // {
-    //     in:  `{"F":{"a":2,"3":4}}`,
-    //     ptr: new(map[string]map[uint]int),
-    //     err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(uint(0)), Offset: 7},
-    // },
+    // integer-keyed map errors
+    {
+        in:  `{"abc":"abc"}`,
+        ptr: new(map[int]string),
+        err: &json.UnmarshalTypeError{Value: "number abc", Type: reflect.TypeOf(0), Offset: 2},
+    },
+    {
+        in:  `{"256":"abc"}`,
+        ptr: new(map[uint8]string),
+        err: &json.UnmarshalTypeError{Value: "number 256", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+    },
+    {
+        in:  `{"128":"abc"}`,
+        ptr: new(map[int8]string),
+        err: &json.UnmarshalTypeError{Value: "number 128", Type: reflect.TypeOf(int8(0)), Offset: 2},
+    },
+    {
+        in:  `{"-1":"abc"}`,
+        ptr: new(map[uint8]string),
+        err: &json.UnmarshalTypeError{Value: "number -1", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+    },
+    {
+        in:  `{"F":{"a":2,"3":4}}`,
+        ptr: new(map[string]map[int]int),
+        err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(0), Offset: 7},
+    },
+    {
+        in:  `{"F":{"a":2,"3":4}}`,
+        ptr: new(map[string]map[uint]int),
+        err: &json.UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(uint(0)), Offset: 7},
+    },
 
-    // // Map keys can be encoding.TextUnmarshalers.
-    // {in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
-    // // If multiple values for the same key exists, only the most recent value is used.
-    // {in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+    // Map keys can be encoding.TextUnmarshalers.
+    {in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+    // If multiple values for the same key exists, only the most recent value is used.
+    {in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
 
-    // {
-    //     in: `{
-    //         "Level0": 1,
-    //         "Level1b": 2,
-    //         "Level1c": 3,
-    //         "x": 4,
-    //         "Level1a": 5,
-    //         "LEVEL1B": 6,
-    //         "e": {
-    //             "Level1a": 8,
-    //             "Level1b": 9,
-    //             "Level1c": 10,
-    //             "Level1d": 11,
-    //             "x": 12
-    //         },
-    //         "Loop1": 13,
-    //         "Loop2": 14,
-    //         "X": 15,
-    //         "Y": 16,
-    //         "Z": 17,
-    //         "Q": 18
-    //     }`,
-    //     ptr: new(Top),
-    //     out: Top{
-    //         Level0: 1,
-    //         Embed0: Embed0{
-    //             Level1b: 2,
-    //             Level1c: 3,
-    //         },
-    //         Embed0a: &Embed0a{
-    //             Level1a: 5,
-    //             Level1b: 6,
-    //         },
-    //         Embed0b: &Embed0b{
-    //             Level1a: 8,
-    //             Level1b: 9,
-    //             Level1c: 10,
-    //             Level1d: 11,
-    //             Level1e: 12,
-    //         },
-    //         Loop: Loop{
-    //             Loop1: 13,
-    //             Loop2: 14,
-    //         },
-    //         Embed0p: Embed0p{
-    //             Point: image.Point{X: 15, Y: 16},
-    //         },
-    //         Embed0q: Embed0q{
-    //             Point: Point{Z: 17},
-    //         },
-    //         embed: embed{
-    //             Q: 18,
-    //         },
-    //     },
-    // },
-    // {
-    //     in:  `{"hello": 1}`,
-    //     ptr: new(Ambig),
-    //     out: Ambig{First: 1},
-    // },
+    {
+        in: `{
+            "Level0": 1,
+            "Level1b": 2,
+            "Level1c": 3,
+            "x": 4,
+            "Level1a": 5,
+            "LEVEL1B": 6,
+            "e": {
+                "Level1a": 8,
+                "Level1b": 9,
+                "Level1c": 10,
+                "Level1d": 11,
+                "x": 12
+            },
+            "Loop1": 13,
+            "Loop2": 14,
+            "X": 15,
+            "Y": 16,
+            "Z": 17,
+            "Q": 18
+        }`,
+        ptr: new(Top),
+        out: Top{
+            Level0: 1,
+            Embed0: Embed0{
+                Level1b: 2,
+                Level1c: 3,
+            },
+            Embed0a: &Embed0a{
+                Level1a: 5,
+                Level1b: 6,
+            },
+            Embed0b: &Embed0b{
+                Level1a: 8,
+                Level1b: 9,
+                Level1c: 10,
+                Level1d: 11,
+                Level1e: 12,
+            },
+            Loop: Loop{
+                Loop1: 13,
+                Loop2: 14,
+            },
+            Embed0p: Embed0p{
+                Point: image.Point{X: 15, Y: 16},
+            },
+            Embed0q: Embed0q{
+                Point: Point{Z: 17},
+            },
+            embed: embed{
+                Q: 18,
+            },
+        },
+    },
+    {
+        in:  `{"hello": 1}`,
+        ptr: new(Ambig),
+        out: Ambig{First: 1},
+    },
 
-    // {
-    //     in:  `{"X": 1,"Y":2}`,
-    //     ptr: new(S5),
-    //     out: S5{S8: S8{S9: S9{Y: 2}}},
-    // },
-    // {
-    //     in:                    `{"X": 1,"Y":2}`,
-    //     ptr:                   new(S5),
-    //     err:                   fmt.Errorf("json: unknown field \"X\""),
-    //     disallowUnknownFields: true,
-    // },
-    // {
-    //     in:  `{"X": 1,"Y":2}`,
-    //     ptr: new(S10),
-    //     out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
-    // },
-    // {
-    //     in:                    `{"X": 1,"Y":2}`,
-    //     ptr:                   new(S10),
-    //     err:                   fmt.Errorf("json: unknown field \"X\""),
-    //     disallowUnknownFields: true,
-    // },
-    // {
-    //     in:  `{"I": 0, "I": null, "J": null}`,
-    //     ptr: new(DoublePtr),
-    //     out: DoublePtr{I: nil, J: nil},
-    // },
+    {
+        in:  `{"X": 1,"Y":2}`,
+        ptr: new(S5),
+        out: S5{S8: S8{S9: S9{Y: 2}}},
+    },
+    {
+        in:                    `{"X": 1,"Y":2}`,
+        ptr:                   new(S5),
+        err:                   fmt.Errorf("json: unknown field \"X\""),
+        disallowUnknownFields: true,
+    },
+    {
+        in:  `{"X": 1,"Y":2}`,
+        ptr: new(S10),
+        out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
+    },
+    {
+        in:                    `{"X": 1,"Y":2}`,
+        ptr:                   new(S10),
+        err:                   fmt.Errorf("json: unknown field \"X\""),
+        disallowUnknownFields: true,
+    },
+    {
+        in:  `{"I": 0, "I": null, "J": null}`,
+        ptr: new(DoublePtr),
+        out: DoublePtr{I: nil, J: nil},
+    },
 
-    // // invalid UTF-8 is coerced to valid UTF-8.
-    // {
-    //     in:  "\"hello\xffworld\"",
-    //     ptr: new(string),
-    //     out: "hello\xffworld",
-    //     validateString: false,
-    // },
-    // {
-    //     in:  "\"hello\xc2\xc2world\"",
-    //     ptr: new(string),
-    //     out: "hello\xc2\xc2world",
-    //     validateString: false,
-    // },
-    // {
-    //     in:  "\"hello\xc2\xffworld\"",
-    //     ptr: new(string),
-    //     out: "hello\xc2\xffworld",
-    // },
-    // {
-    //     in:  "\"hello\\ud800world\"",
-    //     ptr: new(string),
-    //     out: "hello\ufffdworld",
-    // },
-    // {
-    //     in:  "\"hello\\ud800\\ud800world\"",
-    //     ptr: new(string),
-    //     out: "hello\ufffd\ufffdworld",
-    // },
-    // {
-    //     in:  "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
-    //     ptr: new(string),
-    //     out: "hello\xed\xa0\x80\xed\xb0\x80world",
-    // },
+    // invalid UTF-8 is coerced to valid UTF-8.
+    {
+        in:  "\"hello\xffworld\"",
+        ptr: new(string),
+        out: "hello\xffworld",
+        validateString: false,
+    },
+    {
+        in:  "\"hello\xc2\xc2world\"",
+        ptr: new(string),
+        out: "hello\xc2\xc2world",
+        validateString: false,
+    },
+    {
+        in:  "\"hello\xc2\xffworld\"",
+        ptr: new(string),
+        out: "hello\xc2\xffworld",
+    },
+    {
+        in:  "\"hello\\ud800world\"",
+        ptr: new(string),
+        out: "hello\ufffdworld",
+    },
+    {
+        in:  "\"hello\\ud800\\ud800world\"",
+        ptr: new(string),
+        out: "hello\ufffd\ufffdworld",
+    },
+    {
+        in:  "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
+        ptr: new(string),
+        out: "hello\xed\xa0\x80\xed\xb0\x80world",
+    },
 
-    // // Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
-    // {
-    //     in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-    //     ptr: new(map[time.Time]string),
-    //     out: map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
-    // },
+    // Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
+    {
+        in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
+        ptr: new(map[time.Time]string),
+        out: map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
+    },
 
-    // // issue 8305
-    // {
-    //     in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-    //     ptr: new(map[Point]string),
-    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[Point]string{}), Offset: 1},
-    // },
-    // {
-    //     in:  `{"asdf": "hello world"}`,
-    //     ptr: new(map[unmarshaler]string),
-    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[unmarshaler]string{}), Offset: 1},
-    // },
+    // issue 8305
+    {
+        in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
+        ptr: new(map[Point]string),
+        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[Point]string{}), Offset: 1},
+    },
+    {
+        in:  `{"asdf": "hello world"}`,
+        ptr: new(map[unmarshaler]string),
+        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[unmarshaler]string{}), Offset: 1},
+    },
 
     // related to issue 13783.
     // Go 1.7 changed marshaling a slice of typed byte to use the methods on the byte type,
@@ -760,262 +760,262 @@ var unmarshalTests = []unmarshalTest{
         ptr: new([]byteWithMarshalJSON),
         out: []byteWithMarshalJSON{1, 2, 3},
     },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]byteWithMarshalJSON),
-    //     out:    []byteWithMarshalJSON{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:  `"AQID"`,
-    //     ptr: new([]byteWithMarshalText),
-    //     out: []byteWithMarshalText{1, 2, 3},
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]byteWithMarshalText),
-    //     out:    []byteWithMarshalText{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:  `"AQID"`,
-    //     ptr: new([]byteWithPtrMarshalJSON),
-    //     out: []byteWithPtrMarshalJSON{1, 2, 3},
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]byteWithPtrMarshalJSON),
-    //     out:    []byteWithPtrMarshalJSON{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:  `"AQID"`,
-    //     ptr: new([]byteWithPtrMarshalText),
-    //     out: []byteWithPtrMarshalText{1, 2, 3},
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]byteWithPtrMarshalText),
-    //     out:    []byteWithPtrMarshalText{1, 2, 3},
-    //     golden: true,
-    // },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]byteWithMarshalJSON),
+        out:    []byteWithMarshalJSON{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:  `"AQID"`,
+        ptr: new([]byteWithMarshalText),
+        out: []byteWithMarshalText{1, 2, 3},
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]byteWithMarshalText),
+        out:    []byteWithMarshalText{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:  `"AQID"`,
+        ptr: new([]byteWithPtrMarshalJSON),
+        out: []byteWithPtrMarshalJSON{1, 2, 3},
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]byteWithPtrMarshalJSON),
+        out:    []byteWithPtrMarshalJSON{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:  `"AQID"`,
+        ptr: new([]byteWithPtrMarshalText),
+        out: []byteWithPtrMarshalText{1, 2, 3},
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]byteWithPtrMarshalText),
+        out:    []byteWithPtrMarshalText{1, 2, 3},
+        golden: true,
+    },
 
-    // // ints work with the marshaler but not the base64 []byte case
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]intWithMarshalJSON),
-    //     out:    []intWithMarshalJSON{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]intWithMarshalText),
-    //     out:    []intWithMarshalText{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]intWithPtrMarshalJSON),
-    //     out:    []intWithPtrMarshalJSON{1, 2, 3},
-    //     golden: true,
-    // },
-    // {
-    //     in:     `["Z01","Z02","Z03"]`,
-    //     ptr:    new([]intWithPtrMarshalText),
-    //     out:    []intWithPtrMarshalText{1, 2, 3},
-    //     golden: true,
-    // },
+    // ints work with the marshaler but not the base64 []byte case
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]intWithMarshalJSON),
+        out:    []intWithMarshalJSON{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]intWithMarshalText),
+        out:    []intWithMarshalText{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]intWithPtrMarshalJSON),
+        out:    []intWithPtrMarshalJSON{1, 2, 3},
+        golden: true,
+    },
+    {
+        in:     `["Z01","Z02","Z03"]`,
+        ptr:    new([]intWithPtrMarshalText),
+        out:    []intWithPtrMarshalText{1, 2, 3},
+        golden: true,
+    },
 
-    // {in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
-    // {in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
-    // {in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
-    // {in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
-    // {in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
-    // {in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
-    // {in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
-    // {in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
-    // {in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
-    // {in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
-    // {in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
+    {in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
+    {in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
+    {in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
+    {in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
+    {in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
+    {in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
+    {in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
+    {in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
+    {in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
+    {in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
+    {in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
 
-    // {
-    //     in:  `{"V": {"F2": "hello"}}`,
-    //     ptr: new(VOuter),
-    //     err: &json.UnmarshalTypeError{
-    //         Value:  "string",
-    //         Struct: "V",
-    //         Field:  "V.F2",
-    //         Type:   reflect.TypeOf(int32(0)),
-    //         Offset: 20,
-    //     },
-    // },
-    // {
-    //     in:  `{"V": {"F4": {}, "F2": "hello"}}`,
-    //     ptr: new(VOuter),
-    //     err: &json.UnmarshalTypeError{
-    //         Value:  "string",
-    //         Struct: "V",
-    //         Field:  "V.F2",
-    //         Type:   reflect.TypeOf(int32(0)),
-    //         Offset: 30,
-    //     },
-    // },
+    {
+        in:  `{"V": {"F2": "hello"}}`,
+        ptr: new(VOuter),
+        err: &json.UnmarshalTypeError{
+            Value:  "string",
+            Struct: "V",
+            Field:  "V.F2",
+            Type:   reflect.TypeOf(int32(0)),
+            Offset: 20,
+        },
+    },
+    {
+        in:  `{"V": {"F4": {}, "F2": "hello"}}`,
+        ptr: new(VOuter),
+        err: &json.UnmarshalTypeError{
+            Value:  "string",
+            Struct: "V",
+            Field:  "V.F2",
+            Type:   reflect.TypeOf(int32(0)),
+            Offset: 30,
+        },
+    },
 
-    // // issue 15146.
-    // // invalid inputs in wrongStringTests below.
-    // {in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
-    // {in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
-    // {in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
-    // {in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
-    // {in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
-    // {in: `{"B": "null"}`, ptr: new(B), out: B{false}},
-    // {in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
-    // {in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
+    // issue 15146.
+    // invalid inputs in wrongStringTests below.
+    {in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
+    {in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
+    {in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
+    {in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
+    {in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
+    {in: `{"B": "null"}`, ptr: new(B), out: B{false}},
+    {in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
+    {in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
 
-    // // additional tests for disallowUnknownFields
-    // {
-    //     in: `{
-    //         "Level0": 1,
-    //         "Level1b": 2,
-    //         "Level1c": 3,
-    //         "x": 4,
-    //         "Level1a": 5,
-    //         "LEVEL1B": 6,
-    //         "e": {
-    //             "Level1a": 8,
-    //             "Level1b": 9,
-    //             "Level1c": 10,
-    //             "Level1d": 11,
-    //             "x": 12
-    //         },
-    //         "Loop1": 13,
-    //         "Loop2": 14,
-    //         "X": 15,
-    //         "Y": 16,
-    //         "Z": 17,
-    //         "Q": 18,
-    //         "extra": true
-    //     }`,
-    //     ptr:                   new(Top),
-    //     err:                   fmt.Errorf("json: unknown field \"extra\""),
-    //     disallowUnknownFields: true,
-    // },
-    // {
-    //     in: `{
-    //         "Level0": 1,
-    //         "Level1b": 2,
-    //         "Level1c": 3,
-    //         "x": 4,
-    //         "Level1a": 5,
-    //         "LEVEL1B": 6,
-    //         "e": {
-    //             "Level1a": 8,
-    //             "Level1b": 9,
-    //             "Level1c": 10,
-    //             "Level1d": 11,
-    //             "x": 12,
-    //             "extra": null
-    //         },
-    //         "Loop1": 13,
-    //         "Loop2": 14,
-    //         "X": 15,
-    //         "Y": 16,
-    //         "Z": 17,
-    //         "Q": 18
-    //     }`,
-    //     ptr:                   new(Top),
-    //     err:                   fmt.Errorf("json: unknown field \"extra\""),
-    //     disallowUnknownFields: true,
-    // },
-    // // issue 26444
-    // // json.UnmarshalTypeError without field & struct values
-    // {
-    //     in:  `{"data":{"test1": "bob", "test2": 123}}`,
-    //     ptr: new(mapStringToStringData),
-    //     err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
-    // },
-    // {
-    //     in:  `{"data":{"test1": 123, "test2": "bob"}}`,
-    //     ptr: new(mapStringToStringData),
-    //     err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
-    // },
+    // additional tests for disallowUnknownFields
+    {
+        in: `{
+            "Level0": 1,
+            "Level1b": 2,
+            "Level1c": 3,
+            "x": 4,
+            "Level1a": 5,
+            "LEVEL1B": 6,
+            "e": {
+                "Level1a": 8,
+                "Level1b": 9,
+                "Level1c": 10,
+                "Level1d": 11,
+                "x": 12
+            },
+            "Loop1": 13,
+            "Loop2": 14,
+            "X": 15,
+            "Y": 16,
+            "Z": 17,
+            "Q": 18,
+            "extra": true
+        }`,
+        ptr:                   new(Top),
+        err:                   fmt.Errorf("json: unknown field \"extra\""),
+        disallowUnknownFields: true,
+    },
+    {
+        in: `{
+            "Level0": 1,
+            "Level1b": 2,
+            "Level1c": 3,
+            "x": 4,
+            "Level1a": 5,
+            "LEVEL1B": 6,
+            "e": {
+                "Level1a": 8,
+                "Level1b": 9,
+                "Level1c": 10,
+                "Level1d": 11,
+                "x": 12,
+                "extra": null
+            },
+            "Loop1": 13,
+            "Loop2": 14,
+            "X": 15,
+            "Y": 16,
+            "Z": 17,
+            "Q": 18
+        }`,
+        ptr:                   new(Top),
+        err:                   fmt.Errorf("json: unknown field \"extra\""),
+        disallowUnknownFields: true,
+    },
+    // issue 26444
+    // json.UnmarshalTypeError without field & struct values
+    {
+        in:  `{"data":{"test1": "bob", "test2": 123}}`,
+        ptr: new(mapStringToStringData),
+        err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
+    },
+    {
+        in:  `{"data":{"test1": 123, "test2": "bob"}}`,
+        ptr: new(mapStringToStringData),
+        err: &json.UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
+    },
 
-    // // trying to decode JSON arrays or objects via TextUnmarshaler
-    // {
-    //     in:  `[1, 2, 3]`,
-    //     ptr: new(MustNotUnmarshalText),
-    //     err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
-    // },
-    // {
-    //     in:  `{"foo": "bar"}`,
-    //     ptr: new(MustNotUnmarshalText),
-    //     err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
-    // },
-    // // #22369
-    // {
-    //     in:  `{"PP": {"T": {"Y": "bad-type"}}}`,
-    //     ptr: new(P),
-    //     err: &json.UnmarshalTypeError{
-    //         Value:  "string",
-    //         Struct: "T",
-    //         Field:  "PP.T.Y",
-    //         Type:   reflect.TypeOf(0),
-    //         Offset: 29,
-    //     },
-    // },
-    // {
-    //     in:  `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
-    //     ptr: new(PP),
-    //     err: &json.UnmarshalTypeError{
-    //         Value:  "string",
-    //         Struct: "T",
-    //         Field:  "Ts.Y",
-    //         Type:   reflect.TypeOf(0),
-    //         Offset: 29,
-    //     },
-    // },
-    // // #14702
-    // {
-    //     in:  `invalid`,
-    //     ptr: new(json.Number),
-    //     err: (&JsonSyntaxError{
-    //         Msg:    "invalid character 'i' looking for beginning of value",
-    //         Offset: 1,
-    //     }).err(),
-    // },
-    // {
-    //     in:  `"invalid"`,
-    //     ptr: new(json.Number),
-    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    // },
-    // {
-    //     in:  `{"A":"invalid"}`,
-    //     ptr: new(struct{ A json.Number }),
-    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    // },
-    // {
-    //     in: `{"A":"invalid"}`,
-    //     ptr: new(struct {
-    //         A json.Number `json:",string"`
-    //     }),
-    //     err: fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into json.Number", `invalid`),
-    // },
-    // {
-    //     in:  `{"A":"invalid"}`,
-    //     ptr: new(map[string]json.Number),
-    //     err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
-    // },
-    // {in: `\u`, ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    // {in: `\u`, ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    // trying to decode JSON arrays or objects via TextUnmarshaler
+    {
+        in:  `[1, 2, 3]`,
+        ptr: new(MustNotUnmarshalText),
+        err: &json.UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+    },
+    {
+        in:  `{"foo": "bar"}`,
+        ptr: new(MustNotUnmarshalText),
+        err: &json.UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+    },
+    // #22369
+    {
+        in:  `{"PP": {"T": {"Y": "bad-type"}}}`,
+        ptr: new(P),
+        err: &json.UnmarshalTypeError{
+            Value:  "string",
+            Struct: "T",
+            Field:  "PP.T.Y",
+            Type:   reflect.TypeOf(0),
+            Offset: 29,
+        },
+    },
+    {
+        in:  `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
+        ptr: new(PP),
+        err: &json.UnmarshalTypeError{
+            Value:  "string",
+            Struct: "T",
+            Field:  "Ts.Y",
+            Type:   reflect.TypeOf(0),
+            Offset: 29,
+        },
+    },
+    // #14702
+    {
+        in:  `invalid`,
+        ptr: new(json.Number),
+        err: (&JsonSyntaxError{
+            Msg:    "invalid character 'i' looking for beginning of value",
+            Offset: 1,
+        }).err(),
+    },
+    {
+        in:  `"invalid"`,
+        ptr: new(json.Number),
+        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    },
+    {
+        in:  `{"A":"invalid"}`,
+        ptr: new(struct{ A json.Number }),
+        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    },
+    {
+        in: `{"A":"invalid"}`,
+        ptr: new(struct {
+            A json.Number `json:",string"`
+        }),
+        err: fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into json.Number", `invalid`),
+    },
+    {
+        in:  `{"A":"invalid"}`,
+        ptr: new(map[string]json.Number),
+        err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+    },
+    {in: `\u`, ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    {in: `\u`, ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
 
-    // {in: "\"\x00\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    // {in: "\"\x00\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
-    // {in: "\"\xff\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
-    // {in: "\"\xff\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
-    // {in: "\"\x00\"", ptr: new(interface{}), out: interface{}("\x00"), validateString: false},
-    // {in: "\"\x00\"", ptr: new(string), out: "\x00", validateString: false},
-    // {in: "\"\xff\"", ptr: new(interface{}), out: interface{}("\xff"), validateString: false},
-    // {in: "\"\xff\"", ptr: new(string), out: "\xff", validateString: false},
+    {in: "\"\x00\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    {in: "\"\x00\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    {in: "\"\xff\"", ptr: new(interface{}), err: fmt.Errorf("json: invald char"), validateString: true},
+    {in: "\"\xff\"", ptr: new(string), err: fmt.Errorf("json: invald char"), validateString: true},
+    {in: "\"\x00\"", ptr: new(interface{}), out: interface{}("\x00"), validateString: false},
+    {in: "\"\x00\"", ptr: new(string), out: "\x00", validateString: false},
+    {in: "\"\xff\"", ptr: new(interface{}), out: interface{}("\xff"), validateString: false},
+    {in: "\"\xff\"", ptr: new(string), out: "\xff", validateString: false},
 }
 
 func trim(b []byte) []byte {

--- a/decoder/assembler_amd64_go116.go
+++ b/decoder/assembler_amd64_go116.go
@@ -356,7 +356,8 @@ func (self *_Assembler) prologue() {
     self.Emit("MOVQ", jit.Imm(_MaxDigitNums), _VAR_st_Dc)    // MOVQ $_MaxDigitNums, ss.Dcap
     self.Emit("LEAQ", jit.Ptr(_ST, _DbufOffset), _AX)           // LEAQ _DbufOffset(ST), AX
     self.Emit("MOVQ", _AX, _VAR_st_Db)                          // MOVQ AX, ss.Dbuf
-    self.Emit("MOVQ", jit.Imm(0), _VAR_et)                          // MOVQ AX, ss.Dp
+    self.Emit("XORL", _AX, _AX)                                 // XORL AX, AX
+    self.Emit("MOVQ", _AX, _VAR_et)                          // MOVQ AX, ss.Dp
 }
 
 /** Function Calling Helpers **/
@@ -477,8 +478,9 @@ func (self *_Assembler) mismatch_error() {
 }
 
 func (self *_Assembler) _asm_OP_dismatch_err(p *_Instr) {
-    self.Emit("MOVQ", _IC, _VAR_ic)           
-    self.Emit("MOVQ", jit.Type(p.vt()), _VAR_et)
+    self.Emit("MOVQ", _IC, _VAR_ic)  
+    self.Emit("MOVQ", jit.Type(p.vt()), _ET)       
+    self.Emit("MOVQ", _ET, _VAR_et)
 }
 
 func (self *_Assembler) _asm_OP_go_skip(p *_Instr) {
@@ -640,7 +642,8 @@ func (self *_Assembler) check_err(vt reflect.Type) {
     if vt != nil {
         self.Sjmp("JNS" , "_check_err_{n}")        // JNE  _parsing_error_v
         self.Emit("MOVQ", _BP, _VAR_ic)
-        self.Emit("MOVQ", jit.Type(vt), _VAR_et)
+        self.Emit("MOVQ", jit.Type(vt), _ET)         
+        self.Emit("MOVQ", _ET, _VAR_et)
         self.Byte(0x4c  , 0x8d, 0x0d)         // LEAQ (PC), R9
         self.Sref("_check_err_{n}", 4)
         self.Emit("MOVQ", _R9, _VAR_pc)
@@ -1221,7 +1224,8 @@ func (self *_Assembler) _asm_OP_bool(_ *_Instr) {
 
     // try to skip the value
     self.Emit("MOVQ", _IC, _VAR_ic)           
-    self.Emit("MOVQ", _T_bool, _VAR_et)
+    self.Emit("MOVQ", _T_bool, _ET)         
+    self.Emit("MOVQ", _ET, _VAR_et)
     self.Byte(0x4c, 0x8d, 0x0d)         // LEAQ (PC), R9
     self.Sref("_end_{n}", 4)
     self.Emit("MOVQ", _R9, _VAR_pc)
@@ -1261,7 +1265,8 @@ func (self *_Assembler) _asm_OP_num(_ *_Instr) {
 
     /* call skip one */
     self.Emit("MOVQ", _BP, _VAR_ic)           
-    self.Emit("MOVQ", _T_number, _VAR_et)
+    self.Emit("MOVQ", _T_number, _ET)       
+    self.Emit("MOVQ", _ET, _VAR_et)
     self.Byte(0x4c, 0x8d, 0x0d)       
     self.Sref("_num_end_{n}", 4)
     self.Emit("MOVQ", _R9, _VAR_pc)

--- a/decoder/assembler_amd64_go117.go
+++ b/decoder/assembler_amd64_go117.go
@@ -298,10 +298,11 @@ var _OpFuncTab = [256]func(*_Assembler, *_Instr) {
     _OP_goto             : (*_Assembler)._asm_OP_goto,
     _OP_switch           : (*_Assembler)._asm_OP_switch,
     _OP_check_bool       : (*_Assembler)._asm_OP_check_bool,
-    _OP_check_bytes      : (*_Assembler)._asm_OP_check_bytes,
+    // _OP_check_bytes      : (*_Assembler)._asm_OP_check_bytes,
     _OP_check_num        : (*_Assembler)._asm_OP_check_num,
     _OP_check_char_0     : (*_Assembler)._asm_OP_check_char_0,
     _OP_dismatch_err     : (*_Assembler)._asm_OP_dismatch_err,
+    _OP_add              : (*_Assembler)._asm_OP_add,
 }
 
 func (self *_Assembler) instr(v *_Instr) {
@@ -327,7 +328,6 @@ func (self *_Assembler) epilogue() {
     self.Emit("TESTQ", _ET, _ET)                    // TESTQ ET, ET
     self.Sjmp("JNZ", _LB_mismatch_error)            // JNZ _LB_mismatch_error
     self.Link(_LB_error)                            // _error:
-    // self.Byte(0xcc)
     self.Emit("MOVQ", _EP, _CX)                     // MOVQ BX, CX
     self.Emit("MOVQ", _ET, _BX)                     // MOVQ AX, BX
     self.Emit("MOVQ", _IC, _AX)                     // MOVQ IC, AX
@@ -1659,14 +1659,14 @@ func (self *_Assembler) _asm_OP_check_bool(p *_Instr) {
     self.Xjmp("JE"  , p.vi())                               
 }
 
-func (self *_Assembler) _asm_OP_check_bytes(p *_Instr) {
-    self.check_eof(1)
-    self.Emit("MOVBLZX", jit.Sib(_IP, _IC, 1, 0), _AX)       
-    self.Emit("CMPB", _AX, jit.Imm(int64('"')))  
-    self.Xjmp("JE"  , p.vi())               
-    self.Emit("CMPB", _AX, jit.Imm(int64('[')))
-    self.Xjmp("JE"  , p.vi())                               
-}
+// func (self *_Assembler) _asm_OP_check_bytes(p *_Instr) {
+//     self.check_eof(1)
+//     self.Emit("MOVBLZX", jit.Sib(_IP, _IC, 1, 0), _AX)       
+//     self.Emit("CMPB", _AX, jit.Imm(int64('"')))  
+//     self.Xjmp("JE"  , p.vi())               
+//     self.Emit("CMPB", _AX, jit.Imm(int64('[')))
+//     self.Xjmp("JE"  , p.vi())                               
+// }
 
 func (self *_Assembler) _asm_OP_check_num(p *_Instr) {
     self.check_eof(1)
@@ -1683,6 +1683,10 @@ func (self *_Assembler) _asm_OP_check_num(p *_Instr) {
     self.Emit("LEAL", jit.Ptr(_AX, -int64('0')), _CX)
     self.Emit("CMPB", _CX, jit.Imm(int64('9'-'0')))  
     self.Xjmp("JLS" , p.vi())   
+}
+
+func (self *_Assembler) _asm_OP_add(p *_Instr) {
+    self.Emit("ADDQ", jit.Imm(int64(p.vi())), _IC)  // ADDQ ${p.vi()}, IC
 }
 
 func (self *_Assembler) _asm_OP_dismatch_err(p *_Instr) {

--- a/decoder/assembler_amd64_go117.go
+++ b/decoder/assembler_amd64_go117.go
@@ -1210,7 +1210,6 @@ func (self *_Assembler) _asm_OP_bool(_ *_Instr) {
     self.Emit("MOVL", jit.Imm(_IM_true), _CX)                   // MOVL $"true", CX
     self.Emit("CMPL", _CX, jit.Sib(_IP, _IC, 1, 0))             // CMPL CX, (IP)(IC)
     self.Sjmp("JE" , "_bool_true_{n}")          
-
     // try to skip the value
     self.Emit("MOVQ", _IC, _VAR_ic)           
     self.Emit("MOVQ", jit.Type(reflect.TypeOf(true)), _AX)  

--- a/decoder/assembler_test.go
+++ b/decoder/assembler_test.go
@@ -271,7 +271,16 @@ func TestAssembler_OpCode(t *testing.T) {
         src: "true",
         exp: true,
         val: new(bool),
-    }, {
+    }, 
+    {
+        key: "_OP_bool/skip",
+        ins: []_Instr{newInsOp(_OP_bool)},
+        src: `"true"`,
+        exp: nil,
+        val: new(bool),
+        err: &MismatchTypeError{Src: `"true"`, Pos: 0, Type: reflect.TypeOf(true)},
+    }, 
+    {
         key: "_OP_bool/false",
         ins: []_Instr{newInsOp(_OP_bool)},
         src: "false",
@@ -307,7 +316,8 @@ func TestAssembler_OpCode(t *testing.T) {
         src: "falsx",
         err: SyntaxError{Src: `falsx`, Pos: 4, Code: types.ERR_INVALID_CHAR},
         val: new(bool),
-    }, {
+    },
+    {
         key: "_OP_num/positive",
         ins: []_Instr{newInsOp(_OP_num)},
         src: "1.234e5",
@@ -343,11 +353,12 @@ func TestAssembler_OpCode(t *testing.T) {
         src: "1234",
         err: error_value("1234", reflect.TypeOf(int8(0))),
         val: new(int8),
-    }, {
+    }, 
+    {
         key: "_OP_i8/error_wrong_type",
         ins: []_Instr{newInsOp(_OP_i8)},
         src: "12.34",
-        err: SyntaxError{Src: `12.34`, Pos: 2, Code: types.ERR_INVALID_NUMBER_FMT},
+        err: &MismatchTypeError{Src: `12.34`, Pos: 0, Type: intType},
         val: new(int8),
     }, {
         key: "_OP_u8",
@@ -365,13 +376,13 @@ func TestAssembler_OpCode(t *testing.T) {
         key: "_OP_u8/error_underflow",
         ins: []_Instr{newInsOp(_OP_u8)},
         src: "-123",
-        err: SyntaxError{Src: `-123`, Pos: 0, Code: types.ERR_INVALID_NUMBER_FMT},
+        err: &MismatchTypeError{Src: `-123`, Pos: 0, Type: uintType},
         val: new(uint8),
     }, {
         key: "_OP_u8/error_wrong_type",
         ins: []_Instr{newInsOp(_OP_u8)},
         src: "12.34",
-        err: SyntaxError{Src: `12.34`, Pos: 2, Code: types.ERR_INVALID_NUMBER_FMT},
+        err: &MismatchTypeError{Src: `12.34`, Pos: 0, Type: uintType},
         val: new(uint8),
     }, {
         key: "_OP_f32",

--- a/decoder/assembler_test.go
+++ b/decoder/assembler_test.go
@@ -38,24 +38,29 @@ func TestSkipError(t *testing.T) {
         A int `json:"a"`
         B string `json:"b"`
 
-        Pass int `json:"pass"`
+        Pass *int `json:"pass"`
 
         C struct{
+            
+            Pass4 interface{} `json:"pass4"`
+
             D struct{
                 E float32 `json:"e"`
             } `json:"d"`
 
-            Pass int `json:"pass"`
+            Pass2 int `json:"pass2"`
 
         } `json:"c"`
+
         E bool `json:"e"`
         F []int `json:"f"`
         G map[string]int `json:"g"`
+        // I json.Number `json:"i"`
 
-        Pass2 int `json:"pass2"`
+        Pass3 int `json:"pass2"`
     }
-    var obj, obj2 = &skiptype{}, &skiptype{}
-    var data = `{"a":"","b":1,"c":{"d":true,"pass":1},"e":{},"f":"","g":[],"pass":null,"pass2":1}`
+    var obj, obj2 = &skiptype{Pass:new(int)}, &skiptype{Pass:new(int)}
+    var data = `{"a":"","b":1,"c":{"d":true,"pass2":1,"pass4":true},"e":{},"f":"","g":[],"pass":null,"i":true,"pass3":1}`
     d := NewDecoder(data)
     err := d.Decode(obj)
     // println("decoder out: ", err.Error())

--- a/decoder/assembler_test.go
+++ b/decoder/assembler_test.go
@@ -17,19 +17,19 @@
 package decoder
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"reflect"
-	"strings"
-	"testing"
-	"unsafe"
+    `encoding/base64`
+    `encoding/json`
+    `reflect`
+    `strings`
+    `testing`
+    `unsafe`
 
-	"github.com/bytedance/sonic/internal/caching"
-	"github.com/bytedance/sonic/internal/jit"
-	"github.com/bytedance/sonic/internal/native/types"
-	"github.com/bytedance/sonic/internal/rt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+    `github.com/bytedance/sonic/internal/caching`
+    `github.com/bytedance/sonic/internal/jit`
+    `github.com/bytedance/sonic/internal/native/types`
+    `github.com/bytedance/sonic/internal/rt`
+    `github.com/stretchr/testify/assert`
+    `github.com/stretchr/testify/require`
 )
 
 func TestSkipError(t *testing.T) {
@@ -38,16 +38,16 @@ func TestSkipError(t *testing.T) {
         A int `json:"a"`
         B string `json:"b"`
 
-		Pass int `json:"pass"`
+        Pass int `json:"pass"`
 
         C struct{
             D struct{
                 E float32 `json:"e"`
             } `json:"d"`
 
-			Pass int `json:"pass"`
+            Pass int `json:"pass"`
 
-		} `json:"c"`
+        } `json:"c"`
         E bool `json:"e"`
         F []int `json:"f"`
         G map[string]int `json:"g"`
@@ -58,7 +58,7 @@ func TestSkipError(t *testing.T) {
     var data = `{"a":"","b":1,"c":{"d":true,"pass":1},"e":{},"f":"","g":[],"pass":null,"pass2":1}`
     d := NewDecoder(data)
     err := d.Decode(obj)
-	// println("decoder out: ", err.Error())
+    // println("decoder out: ", err.Error())
     err2 := json.Unmarshal([]byte(data), obj2)
     assert.Equal(t, err2 == nil, err == nil)
     // assert.Equal(t, len(data), d.i)

--- a/decoder/assembler_test.go
+++ b/decoder/assembler_test.go
@@ -20,7 +20,6 @@ import (
     `encoding/base64`
     `encoding/json`
     `reflect`
-    `strings`
     `testing`
     `unsafe`
 
@@ -31,51 +30,6 @@ import (
     `github.com/stretchr/testify/assert`
     `github.com/stretchr/testify/require`
 )
-
-func TestSkipError(t *testing.T) {
-    println("TestSkipError")
-    type skiptype struct {
-        A int `json:"a"`
-        B string `json:"b"`
-
-        Pass *int `json:"pass"`
-
-        C struct{
-            
-            Pass4 interface{} `json:"pass4"`
-
-            D struct{
-                E float32 `json:"e"`
-            } `json:"d"`
-
-            Pass2 int `json:"pass2"`
-
-        } `json:"c"`
-
-        E bool `json:"e"`
-        F []int `json:"f"`
-        G map[string]int `json:"g"`
-        // I json.Number `json:"i"`
-
-        Pass3 int `json:"pass2"`
-    }
-    var obj, obj2 = &skiptype{Pass:new(int)}, &skiptype{Pass:new(int)}
-    var data = `{"a":"","b":1,"c":{"d":true,"pass2":1,"pass4":true},"e":{},"f":"","g":[],"pass":null,"i":true,"pass3":1}`
-    d := NewDecoder(data)
-    err := d.Decode(obj)
-    // println("decoder out: ", err.Error())
-    err2 := json.Unmarshal([]byte(data), obj2)
-    assert.Equal(t, err2 == nil, err == nil)
-    // assert.Equal(t, len(data), d.i)
-    assert.Equal(t, obj2, obj)
-    if te, ok := err.(*MismatchTypeError); ok {
-        assert.Equal(t, reflect.TypeOf(obj.G), te.Type)
-        assert.Equal(t, strings.Index(data, `"g":[`)+4, te.Pos)
-        println(err.Error())
-    } else {
-        t.Fatal("invalid error")
-    }
-}
 
 func TestAssembler_PrologueAndEpilogue(t *testing.T) {
     a := newAssembler(nil)
@@ -338,13 +292,13 @@ func TestAssembler_OpCode(t *testing.T) {
         key: "_OP_num/error_eof",
         ins: []_Instr{newInsOp(_OP_num)},
         src: "-",
-        err: SyntaxError{Src: `-`, Pos: 1, Code: types.ERR_EOF},
+        err: SyntaxError{Src: `-`, Pos: 1, Code: types.ERR_INVALID_CHAR},
         val: new(json.Number),
     }, {
         key: "_OP_num/error_invalid_char",
         ins: []_Instr{newInsOp(_OP_num)},
         src: "xxx",
-        err: SyntaxError{Src: `xxx`, Pos: 0, Code: types.ERR_INVALID_CHAR},
+        err: SyntaxError{Src: `xxx`, Pos: 1, Code: types.ERR_INVALID_CHAR},
         val: new(json.Number),
     }, {
         key: "_OP_i8",

--- a/decoder/assembler_test.go
+++ b/decoder/assembler_test.go
@@ -55,7 +55,7 @@ func TestSkipError(t *testing.T) {
         Pass2 int `json:"pass2"`
     }
     var obj, obj2 = &skiptype{}, &skiptype{}
-    var data = `{"a":"","b":1,"c":{"d":true,"pass":1},"e":{},"f":"","g":[],"pass":1,"pass2":1}`
+    var data = `{"a":"","b":1,"c":{"d":true,"pass":1},"e":{},"f":"","g":[],"pass":null,"pass2":1}`
     d := NewDecoder(data)
     err := d.Decode(obj)
 	// println("decoder out: ", err.Error())

--- a/decoder/compiler.go
+++ b/decoder/compiler.go
@@ -98,6 +98,7 @@ const (
     _OP_dismatch_err
     _OP_go_skip
     _OP_add
+    _OP_debug
 )
 
 const (
@@ -951,7 +952,7 @@ func (self *_Compiler) compileStructFieldStr(p *_Program, sp int, vt reflect.Typ
     n0 := p.pc()
     p.add(_OP_is_null)
     
-    skip := self.checkIfSkip(p, vt, '"')
+    skip := self.checkIfSkip(p, stringType, '"')
 
     /* also check for inner "null" */
     n1 = p.pc()
@@ -1108,7 +1109,7 @@ func (self *_Compiler) checkIfSkip(p *_Program, vt reflect.Type, c byte) int {
     p.chr(_OP_check_char_0, c)
     p.rtt(_OP_dismatch_err, vt)
     s := p.pc()
-    p.int(_OP_go_skip, s)
+    p.add(_OP_go_skip)
     p.pin(j)
     p.int(_OP_add, 1)
     return s

--- a/decoder/compiler.go
+++ b/decoder/compiler.go
@@ -914,6 +914,8 @@ func (self *_Compiler) checkType(p *_Program, vt reflect.Type) int {
     } else if k == reflect.Interface {
         return -1
     } else {
+        n := p.pc()
+        p.add(_OP_is_null)
         x := p.pc()
         switch vt.Kind() {
             case reflect.Bool      : p.add(_OP_check_bool)
@@ -930,7 +932,7 @@ func (self *_Compiler) checkType(p *_Program, vt reflect.Type) int {
             case reflect.Array     : p.chr(_OP_check_char_0, '[')
             case reflect.Map       : p.chr(_OP_check_char_0, '{')
             case reflect.Slice     : 
-                if vt == bytesType {
+                if vt.Elem().Kind() == byteType.Kind() {
                     p.chr(_OP_check_bytes, '"')
                 } else {
                     p.chr(_OP_check_char_0, '[')
@@ -940,6 +942,7 @@ func (self *_Compiler) checkType(p *_Program, vt reflect.Type) int {
         }
         p.rtt(_OP_dismatch_err, vt)
         p.add(_OP_object_next)
+        p.pin(n)
         y := p.pc()
         p.add(_OP_goto)
         p.pin(x)

--- a/decoder/compiler.go
+++ b/decoder/compiler.go
@@ -98,6 +98,7 @@ const (
     _OP_check_num
     _OP_check_char_0
     _OP_dismatch_err
+    _OP_go_skip
     _OP_add
 )
 
@@ -1124,26 +1125,19 @@ func (self *_Compiler) checkPrimitive(p *_Program, vt reflect.Type) int {
         default                : panic(&json.UnmarshalTypeError{Type: vt})
     }
     p.rtt(_OP_dismatch_err, vt)
-    p.add(_OP_object_next)
-    y := p.pc()
-    p.add(_OP_goto)
+    s := p.pc()
+    p.int(_OP_go_skip, s)
     p.pin(x)
-    return y
+    return s
 }
 
-func (self *_Compiler) checkIfSkip(p *_Program, vt reflect.Type, c ...byte) int {
-    var js = make([]int, len(c))
-    for _, ch := range c {
-        js = append(js, p.pc())
-        p.chr(_OP_check_char_0, ch)
-    }
+func (self *_Compiler) checkIfSkip(p *_Program, vt reflect.Type, c byte) int {
+    j := p.pc()
+    p.chr(_OP_check_char_0, c)
     p.rtt(_OP_dismatch_err, vt)
-    p.add(_OP_object_next)
-    j2 := p.pc()
-    p.add(_OP_goto)
-    for _, j := range js {
-        p.pin(j)
-    }
+    s := p.pc()
+    p.int(_OP_go_skip, s)
+    p.pin(j)
     p.int(_OP_add, 1)
-    return j2
+    return s
 }

--- a/decoder/compiler.go
+++ b/decoder/compiler.go
@@ -1044,10 +1044,10 @@ func (self *_Compiler) compileInterface(p *_Program, vt reflect.Type) {
 func (self *_Compiler) compilePrimitive(vt reflect.Type, p *_Program, op _Op) {
     i := p.pc()
     p.add(_OP_is_null)
-    skip := self.checkPrimitive(p, vt)
+    // skip := self.checkPrimitive(p, vt)
     p.add(op)
     p.pin(i)
-    p.pin(skip)
+    // p.pin(skip)
 }
 
 func (self *_Compiler) compileUnmarshalEnd(p *_Program, vt reflect.Type, i int) {

--- a/decoder/compiler.go
+++ b/decoder/compiler.go
@@ -94,8 +94,6 @@ const (
     _OP_recurse
     _OP_goto
     _OP_switch
-    _OP_check_bool
-    _OP_check_num
     _OP_check_char_0
     _OP_dismatch_err
     _OP_go_skip
@@ -171,8 +169,6 @@ var _OpNames = [256]string {
     _OP_recurse          : "recurse",
     _OP_goto             : "goto",
     _OP_switch           : "switch",
-    _OP_check_bool       : "check_bool",
-    _OP_check_num        : "check_num",
     _OP_check_char_0     : "check_char_0",
     _OP_dismatch_err     : "dismatch_err",
     _OP_add              : "add",
@@ -1105,30 +1101,6 @@ func (self *_Compiler) compileUnmarshalTextPtr(p *_Program, vt reflect.Type) {
     p.chr(_OP_match_char, '"')
     p.rtt(_OP_unmarshal_text_p, vt)
     p.pin(i)
-}
-
-
-func (self *_Compiler) checkPrimitive(p *_Program, vt reflect.Type) int {
-    x := p.pc()
-    switch vt.Kind() {
-        case reflect.Bool      : p.add(_OP_check_bool)
-        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float32, reflect.Float64: 
-            p.chr(_OP_check_num, 1)
-        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr: 
-            p.chr(_OP_check_num, 0)
-        case reflect.String    : 
-            if vt == jsonNumberType {
-                p.chr(_OP_check_num, 2)
-            }else {
-                p.chr(_OP_check_char_0, '"')
-            }
-        default                : panic(&json.UnmarshalTypeError{Type: vt})
-    }
-    p.rtt(_OP_dismatch_err, vt)
-    s := p.pc()
-    p.int(_OP_go_skip, s)
-    p.pin(x)
-    return s
 }
 
 func (self *_Compiler) checkIfSkip(p *_Program, vt reflect.Type, c byte) int {

--- a/decoder/errors.go
+++ b/decoder/errors.go
@@ -117,7 +117,7 @@ func error_wrap(src string, pos int, code types.ParsingError) error {
 }
 
 //go:nosplit
-func error_type(vt *rt.GoType, c byte) error {
+func error_type(vt *rt.GoType) error {
     return &json.UnmarshalTypeError{Type: vt.Pack()}
 }
 

--- a/decoder/errors.go
+++ b/decoder/errors.go
@@ -40,6 +40,10 @@ func (self SyntaxError) Error() string {
 }
 
 func (self SyntaxError) Description() string {
+    return "Syntax error " + self.description()
+}
+
+func (self SyntaxError) description() string {
     i := 16
     p := self.Pos - i
     q := self.Pos + i
@@ -72,7 +76,7 @@ func (self SyntaxError) Description() string {
 
     /* compose the error description */
     return fmt.Sprintf(
-        "Syntax error at index %d: %s\n\n\t%s\n\t%s^%s\n",
+        "at index %d: %s\n\n\t%s\n\t%s^%s\n",
         self.Pos,
         self.Message(),
         self.Src[p:q],
@@ -113,8 +117,42 @@ func error_wrap(src string, pos int, code types.ParsingError) error {
 }
 
 //go:nosplit
-func error_type(vt *rt.GoType) error {
+func error_type(vt *rt.GoType, c byte) error {
     return &json.UnmarshalTypeError{Type: vt.Pack()}
+}
+
+type MismatchTypeError struct {
+    Pos  int
+    Src  string
+    Type reflect.Type
+}
+
+func (self *MismatchTypeError) Error() string {
+    var val string
+    switch self.Src[self.Pos] {
+        case 'f': fallthrough
+        case 't': val = "bool"
+        case '"': val = "string"
+        case '{': val = "object"
+        case '[': val = "array"
+        case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9': val = "number"        
+    }
+
+    se := SyntaxError {
+        Pos  : self.Pos,
+        Src  : self.Src,
+        Code : types.ERR_MISMATCH,
+    }
+    return fmt.Sprintf("Mismatch type %s with value %s %s", self.Type.String(), val, se.description())
+}
+
+//go:nosplit
+func error_mismatch(src string, pos int, vt *rt.GoType) error {
+    return &MismatchTypeError {
+        Pos  : pos,
+        Src  : src,
+        Type : vt.Pack(),
+    }
 }
 
 //go:nosplit

--- a/decoder/errors.go
+++ b/decoder/errors.go
@@ -127,9 +127,9 @@ type MismatchTypeError struct {
     Type reflect.Type
 }
 
-func (self *MismatchTypeError) Error() string {
+func swithchJSONType (src string, pos int) string {
     var val string
-    switch self.Src[self.Pos] {
+    switch src[pos] {
         case 'f': fallthrough
         case 't': val = "bool"
         case '"': val = "string"
@@ -137,13 +137,25 @@ func (self *MismatchTypeError) Error() string {
         case '[': val = "array"
         case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9': val = "number"        
     }
+    return val
+}
 
+func (self MismatchTypeError) Error() string {
     se := SyntaxError {
         Pos  : self.Pos,
         Src  : self.Src,
         Code : types.ERR_MISMATCH,
     }
-    return fmt.Sprintf("Mismatch type %s with value %s %s", self.Type.String(), val, se.description())
+    return fmt.Sprintf("Mismatch type %s with value %s %q", self.Type.String(), swithchJSONType(self.Src, self.Pos), se.description())
+}
+
+func (self MismatchTypeError) Description() string {
+    se := SyntaxError {
+        Pos  : self.Pos,
+        Src  : self.Src,
+        Code : types.ERR_MISMATCH,
+    }
+    return fmt.Sprintf("Mismatch type %s with value %s %s", self.Type.String(), swithchJSONType(self.Src, self.Pos), se.description())
 }
 
 //go:nosplit

--- a/decoder/types.go
+++ b/decoder/types.go
@@ -28,6 +28,7 @@ import (
 
 var (
     byteType                = reflect.TypeOf(byte(0))
+    bytesType                = reflect.TypeOf([]byte(nil))
     jsonNumberType          = reflect.TypeOf(json.Number(""))
     base64CorruptInputError = reflect.TypeOf(base64.CorruptInputError(0))
 )

--- a/decoder/types.go
+++ b/decoder/types.go
@@ -28,7 +28,11 @@ import (
 
 var (
     byteType                = reflect.TypeOf(byte(0))
-    bytesType                = reflect.TypeOf([]byte(nil))
+    intType                 = reflect.TypeOf(int(0))
+    uintType                = reflect.TypeOf(uint(0))
+    floatType               = reflect.TypeOf(float64(0))
+    stringType              = reflect.TypeOf("")
+    bytesType               = reflect.TypeOf([]byte(nil))
     jsonNumberType          = reflect.TypeOf(json.Number(""))
     base64CorruptInputError = reflect.TypeOf(base64.CorruptInputError(0))
 )

--- a/internal/native/types/types.go
+++ b/internal/native/types/types.go
@@ -74,6 +74,7 @@ const (
     ERR_INVALID_NUMBER_FMT ParsingError = 6
     ERR_RECURSE_EXCEED_MAX ParsingError = 7
     ERR_FLOAT_INFINITY     ParsingError = 8
+    ERR_MISMATCH           ParsingError = 9
 )
 
 var _ParsingErrors = []string{
@@ -86,6 +87,7 @@ var _ParsingErrors = []string{
     ERR_INVALID_NUMBER_FMT : "invalid number format",
     ERR_RECURSE_EXCEED_MAX : "recursion exceeded max depth",
     ERR_FLOAT_INFINITY     : "float number is infinity",
+    ERR_MISMATCH           : "mismatched type with value",
 }
 
 func (self ParsingError) Error() string {


### PR DESCRIPTION
## Feature
- check first char of binding value if match binded type. If not, try to skip the whole value
## Benchmark
- `-benchtime=100000x` `count=50`
```
name                           old time/op    new time/op    delta
Decoder_Binding_Sonic_Fast-16    27.5µs ± 2%    27.9µs ± 2%  +1.55%  (p=0.000 n=46+48)
Decoder_Binding_Sonic-16         30.8µs ± 2%    31.0µs ± 2%  +0.68%  (p=0.000 n=47+49)

name                           old speed      new speed      delta
Decoder_Binding_Sonic_Fast-16   474MB/s ± 2%   467MB/s ± 2%  -1.52%  (p=0.000 n=46+48)
Decoder_Binding_Sonic-16        424MB/s ± 2%   421MB/s ± 2%  -0.67%  (p=0.000 n=47+49)

name                           old alloc/op   new alloc/op   delta
Decoder_Binding_Sonic-16         27.3kB ± 0%    27.3kB ± 0%    ~     (p=0.499 n=49+48)
Decoder_Binding_Sonic_Fast-16    24.3kB ± 0%    24.3kB ± 0%    ~     (p=0.325 n=49+50)

name                           old allocs/op  new allocs/op  delta
Decoder_Binding_Sonic-16            137 ± 0%       137 ± 0%    ~     (all equal)
Decoder_Binding_Sonic_Fast-16      34.0 ± 0%      34.0 ± 0%    ~     (all equal)
```
## Fuzz test
```
fuzz: elapsed: 3h1m24s, execs: 26007386 (4040/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m27s, execs: 26021440 (4663/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m30s, execs: 26032940 (3846/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m32s, execs: 26046273 (4452/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m36s, execs: 26056310 (3336/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m39s, execs: 26068162 (3908/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m42s, execs: 26079590 (3862/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m44s, execs: 26093449 (4620/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m47s, execs: 26105457 (4004/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m51s, execs: 26115312 (3284/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m54s, execs: 26124622 (3103/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m57s, execs: 26134096 (3139/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h1m59s, execs: 26144003 (3323/sec), new interesting: 93 (total: 3173)
fuzz: elapsed: 3h2m1s, execs: 26145883 (1049/sec), new interesting: 93 (total: 3173)
```
```