### PR TITLE
opt: faster skip in ast

### DIFF
--- a/.github/workflows/benchmark-linux-arm64.yml
+++ b/.github/workflows/benchmark-linux-arm64.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: [arm]
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Check Branch

--- a/.github/workflows/benchmark-linux-x64.yml
+++ b/.github/workflows/benchmark-linux-x64.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: [self-hosted, X64]
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Check Branch

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,6 +38,9 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: [self-hosted, X64]
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Check License Header

--- a/.github/workflows/push-check-go118.yml
+++ b/.github/workflows/push-check-go118.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     runs-on: [self-hosted, X64]
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.github/workflows/push-check-linux-arm64.yml
+++ b/.github/workflows/push-check-linux-arm64.yml
@@ -10,6 +10,9 @@ jobs:
         os: [arm]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.github/workflows/push-check-linux-x64.yml
+++ b/.github/workflows/push-check-linux-x64.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18x, 1.19.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.19.x]
     runs-on: [self-hosted, X64]
     steps:
       - name: Clear repository

--- a/.github/workflows/push-check-linux-x64.yml
+++ b/.github/workflows/push-check-linux-x64.yml
@@ -6,9 +6,12 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.19.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18x, 1.19.x]
     runs-on: [self-hosted, X64]
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.github/workflows/push-check-qemu.yml
+++ b/.github/workflows/push-check-qemu.yml
@@ -10,6 +10,9 @@ jobs:
         os: [arm]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.github/workflows/push-check-windows.yml
+++ b/.github/workflows/push-check-windows.yml
@@ -9,9 +9,6 @@ jobs:
         go-version: [1.15.x, 1.19.x]
     runs-on: windows-latest
     steps:
-      - name: Clear repository
-        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
-
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.github/workflows/push-check-windows.yml
+++ b/.github/workflows/push-check-windows.yml
@@ -9,6 +9,9 @@ jobs:
         go-version: [1.15.x, 1.19.x]
     runs-on: windows-latest
     steps:
+      - name: Clear repository
+        run: sudo rm -fr $GITHUB_WORKSPACE && mkdir $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v2
 
       - name: Set up Go

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ ast/bench.sh
 
 !testdata/*.json.gz
 fuzz/testdata
+*__debug_bin

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ TMPL_avx		:= fastint_amd64_test fastfloat_amd64_test native_amd64_test native_ex
 TMPL_avx2		:= fastint_amd64_test fastfloat_amd64_test native_amd64_test native_export_amd64
 TMPL_sse 		:= fastint_amd64_test fastfloat_amd64_test native_amd64_test native_export_amd64
 
-CFLAGS_avx		:= -msse -mno-sse4 -mavx -mno-avx2 -DUSE_AVX=1 -DUSE_AVX2=0
-CFLAGS_avx2		:= -msse -mno-sse4 -mavx -mavx2    -DUSE_AVX=1 -DUSE_AVX2=1 
-CFLAGS_sse		:= -msse -mno-sse4 -mno-avx -mno-avx2
+CFLAGS_avx		:= -msse -mno-sse4 -mavx -mpclmul -mno-avx2 -DUSE_AVX=1 -DUSE_AVX2=0
+CFLAGS_avx2		:= -msse -mno-sse4 -mavx -mpclmul -mavx2    -DUSE_AVX=1 -DUSE_AVX2=1 
+CFLAGS_sse		:= -msse -mno-sse4 -mno-avx -mno-avx2 -mpclmul
 
 CC_amd64		:= clang
 ASM2ASM_amd64	:= tools/asm2asm/asm2asm.py

--- a/ast/api_amd64.go
+++ b/ast/api_amd64.go
@@ -89,3 +89,38 @@ func (self *Node) encodeInterface(buf *[]byte) error {
     //WARN: NOT compatible with json.Encoder
     return encoder.EncodeInto(buf, self.packAny(), 0)
 }
+
+func (self *Parser) skipFast() (int, types.ParsingError) {
+    start := native.SkipOneFast(&self.s, &self.p)
+    if start < 0 {
+        return self.p, types.ParsingError(-start)
+    }
+    return start, 0
+}
+
+func (self *Parser) getByPath(path ...interface{}) (int, types.ParsingError) {
+    start := native.GetByPath(&self.s, &self.p, &path)
+    runtime.KeepAlive(path)
+    if start < 0 {
+        return self.p, types.ParsingError(-start)
+    }
+    return start, 0
+}
+
+
+func (self *Searcher) GetByPath(path ...interface{}) (Node, error) {
+    var err types.ParsingError
+    var start int
+
+    self.parser.p = 0
+    start, err = self.parser.getByPath(path...)
+    if err != 0 {
+        return Node{}, self.parser.syntaxError(err)
+    }
+
+    t := switchRawType(self.parser.s[start])
+    if t == _V_NONE {
+        return Node{}, self.parser.ExportError(err)
+    }
+    return newRawNode(self.parser.s[start:self.parser.p], t), nil
+}

--- a/ast/api_compat.go
+++ b/ast/api_compat.go
@@ -6,6 +6,7 @@ package ast
 import (
     `encoding/base64`
     `encoding/json`
+    `fmt`
 
     `github.com/bytedance/sonic/internal/native/types`
     `github.com/bytedance/sonic/internal/rt`
@@ -52,6 +53,10 @@ func (self *Parser) skip() (int, types.ParsingError) {
     return s, 0
 }
 
+func (self *Parser) skipFast() (int, types.ParsingError) {
+    return self.skip()
+}
+
 func (self *Node) encodeInterface(buf *[]byte) error {
     out, err := json.Marshal(self.packAny())
     if err != nil {
@@ -59,4 +64,40 @@ func (self *Node) encodeInterface(buf *[]byte) error {
     }
     *buf = append(*buf, out...)
     return nil
+}
+
+func (self *Searcher) GetByPath(path ...interface{}) (Node, error) {
+    self.parser.p = 0
+
+    var err types.ParsingError
+    for _, p := range path {
+        switch p := p.(type) {
+        case int:
+            if err = self.parser.searchIndex(p); err != 0 {
+                return Node{}, self.parser.ExportError(err)
+            }
+        case string:
+            if err = self.parser.searchKey(p); err != 0 {
+                return Node{}, self.parser.ExportError(err)
+            }
+        default:
+            panic("path must be either int or string")
+        }
+    }
+
+    var start = self.parser.p
+    if start, err = self.parser.skip(); err != 0 {
+        return Node{}, self.parser.ExportError(err)
+    }
+    ns := len(self.parser.s)
+    if self.parser.p > ns || start >= ns || start>=self.parser.p {
+        return Node{}, fmt.Errorf("skip %d char out of json boundary", start)
+    }
+
+    t := switchRawType(self.parser.s[start])
+    if t == _V_NONE {
+        return Node{}, self.parser.ExportError(err)
+    }
+
+    return newRawNode(self.parser.s[start:self.parser.p], t), nil
 }

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -18,7 +18,6 @@ package ast
 
 import (
     `fmt`
-
     `github.com/bytedance/sonic/internal/native/types`
     `github.com/bytedance/sonic/internal/rt`
 )
@@ -131,7 +130,7 @@ func (self *Parser) decodeArray(ret []Node) (Node, types.ParsingError) {
         if self.skipValue {
             /* skip the value */
             var start int
-            if start, err = self.skip(); err != 0 {
+            if start, err = self.skipFast(); err != 0 {
                 return Node{}, err
             }
             if self.p > ns {
@@ -217,7 +216,7 @@ func (self *Parser) decodeObject(ret []Pair) (Node, types.ParsingError) {
         if self.skipValue {
             /* skip the value */
             var start int
-            if start, err = self.skip(); err != 0 {
+            if start, err = self.skipFast(); err != 0 {
                 return Node{}, err
             }
             if self.p > ns {
@@ -228,7 +227,7 @@ func (self *Parser) decodeObject(ret []Pair) (Node, types.ParsingError) {
                 return Node{}, types.ERR_INVALID_CHAR
             }
             val = newRawNode(self.s[start:self.p], t)
-        }else{
+        } else {
             /* decode the value */
             if val, err = self.Parse(); err != 0 {
                 return Node{}, err
@@ -448,7 +447,7 @@ func (self *Node) skipNextNode() *Node {
 
     var val Node
     /* skip the value */
-    if start, err := parser.skip(); err != 0 {
+    if start, err := parser.skipFast(); err != 0 {
         return newSyntaxError(parser.syntaxError(err))
     } else {
         t := switchRawType(parser.s[start])
@@ -531,7 +530,7 @@ func (self *Node) skipNextPair() (*Pair) {
     }
 
     /* skip the value */
-    if start, err := parser.skip(); err != 0 {
+    if start, err := parser.skipFast(); err != 0 {
         return &Pair{key, *newSyntaxError(parser.syntaxError(err))}
     } else {
         t := switchRawType(parser.s[start])

--- a/ast/search.go
+++ b/ast/search.go
@@ -16,12 +16,6 @@
 
 package ast
 
-import (
-    `fmt`
-
-    `github.com/bytedance/sonic/internal/native/types`
-)
-
 type Searcher struct {
     parser Parser
 }
@@ -33,40 +27,4 @@ func NewSearcher(str string) *Searcher {
             noLazy: false,
         },
     }
-}
-
-func (self *Searcher) GetByPath(path ...interface{}) (Node, error) {
-    self.parser.p = 0
-
-    var err types.ParsingError
-    for _, p := range path {
-        switch p := p.(type) {
-        case int:
-            if err = self.parser.searchIndex(p); err != 0 {
-                return Node{}, self.parser.ExportError(err)
-            }
-        case string:
-            if err = self.parser.searchKey(p); err != 0 {
-                return Node{}, self.parser.ExportError(err)
-            }
-        default:
-            panic("path must be either int or string")
-        }
-    }
-
-    var start = self.parser.p
-    if start, err = self.parser.skip(); err != 0 {
-        return Node{}, self.parser.ExportError(err)
-    }
-    ns := len(self.parser.s)
-    if self.parser.p > ns || start >= ns || start>=self.parser.p {
-        return Node{}, fmt.Errorf("skip %d char out of json boundary", start)
-    }
-
-    t := switchRawType(self.parser.s[start])
-    if t == _V_NONE {
-        return Node{}, self.parser.ExportError(err)
-    }
-
-    return newRawNode(self.parser.s[start:self.parser.p], t), nil
 }

--- a/ast/search_test.go
+++ b/ast/search_test.go
@@ -204,6 +204,21 @@ func BenchmarkGetOne_Sonic(b *testing.B) {
     }
 }
 
+func BenchmarkGetWithManyCompare_Sonic(b *testing.B) {
+    b.SetBytes(int64(len(_LotsCompare)))
+    ast := NewSearcher(_LotsCompare)
+    for i := 0; i < b.N; i++ {
+        node, err := ast.GetByPath("is")
+        if err != nil {
+            b.Fatal(err)
+        }
+        x, _ := node.Int64()
+        if x != 1 {
+            b.Fatal(node.Interface())
+        }
+    }
+}
+
 func BenchmarkGetOne_Parallel_Sonic(b *testing.B) {
     b.SetBytes(int64(len(_TwitterJson)))
     b.RunParallel(func(pb *testing.PB) {

--- a/ast/testdata_test.go
+++ b/ast/testdata_test.go
@@ -432,6 +432,8 @@ const _TwitterJson = `{
   }
 }`
 
+const _LotsCompare = `{"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"hi":0,"is":1}`
+
 type _TwitterStruct struct {
     Statuses []struct {
         Coordinates interface{} `json:"coordinates"`

--- a/external_jsonlib_test/go.mod
+++ b/external_jsonlib_test/go.mod
@@ -3,6 +3,7 @@ module github.com/bytedance/sonic/external_jsonlib_test
 go 1.18
 
 require (
+	github.com/buger/jsonparser v1.1.1
 	github.com/bytedance/sonic v1.4.0
 	github.com/goccy/go-json v0.9.11
 	github.com/json-iterator/go v1.1.12

--- a/external_jsonlib_test/go.sum
+++ b/external_jsonlib_test/go.sum
@@ -1,3 +1,5 @@
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/sonic v1.4.0 h1:d6vgPhwgHfpmEiz/9Fzea9fGzWY7RO1TQEySBiRwDLY=
 github.com/bytedance/sonic v1.4.0/go.mod h1:V973WhNhGmvHxW6nQmsHEfHaoU9F3zTF+93rH03hcUQ=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06 h1:1sDoSuDPWzhkdzNVxCxtIaKiAe96ESVPv8coGwc1gZ4=

--- a/fuzz/corpus.go
+++ b/fuzz/corpus.go
@@ -1,0 +1,60 @@
+// +build go1.18
+
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sonic_fuzz
+
+// corpus returns the simple and basic JSON corpus for fuzzing test.
+func corpus() [][]byte {
+	data := []string {
+		`[]`, `{}`, `[{`, `}`, `{{}}`, `,`, `:`,// structural chars
+		`null`, `true`, `false`, `truf`,  // primitive types
+		`1.234567890e-123`, `01`, `00`, "+1", // numbers
+		`e`, `-`, `+`, `.`, // signs
+		" ", "\n", "\t", "\r",  // space
+		"\b",  "\f",  "\\", "/", "\"", "\u2028", "\x00", // unescaped chars
+		"\\b", "\\n", "\\f", "\\\\", "\\/", "\\\"", "\\r", "\\t", "\\u2028", // escaped chars
+		"<", ">", "&", "\u2028", "\u2029", // html escape
+		`😁`, "\xff", "\xf0", "\x80", // utf-8
+		"\xed\xa0\x80" /* \ud800 */, "\xef\xbf\xbf", /* \uffff */ "\xed\xbf\xbf", /* \udfff */
+		`"haha"`, `"你好"`, `"😁"`, `"\\uD800\\udc00"`,  `""`, // json strings
+		"\"\u2028\u2029\"", `<>&`, 
+		"\"\xff\"", "\"\x00\"", `"\\uDFFF"`,
+		`[2, 3, null, true, false, "hi"]`, // short json
+		`{
+			"object": {
+				"slice": [
+					1,
+					2.0,
+					"3",
+					[4],
+					{5: {}}
+				]
+			},
+			"slice": [[]],
+			"string": ":)",
+			"int": 1e5,
+			"float": 3e-9"
+		}`,
+		`{"a":{"a":1,"b":[1,1,1],"c":{"d":1,"e":1,"f":1},"d":"{\"你好\":\"hi\"}"}}`,
+	}
+	var corpus [][]byte
+	for _, t := range(data) {
+		corpus = append(corpus, []byte(t))
+	}
+	return corpus
+}

--- a/fuzz/fuzz_test.go
+++ b/fuzz/fuzz_test.go
@@ -33,21 +33,9 @@ import (
 )
 
 func FuzzMain(f *testing.F) {
-    f.Add([]byte(`{
-        "object": {
-            "slice": [
-                1,
-                2.0,
-                "3",
-                [4],
-                {5: {}}
-            ]
-        },
-        "slice": [[]],
-        "string": ":)",
-        "int": 1e5,
-        "float": 3e-9"
-        }`))
+    for _, corp := range(corpus()) {
+        f.Add(corp)
+    }
     f.Fuzz(fuzzMain)
 }
 
@@ -67,7 +55,6 @@ func fuzzMain(t *testing.T, data []byte) {
         func() interface{} { return new(uint64) },
         func() interface{} { return new(float64) },
         func() interface{} { return new(json.Number) },
-        func() interface{} { return new(json.RawMessage) },
         func() interface{} { return new(S) },
     } {
         sv, jv := typ(), typ()
@@ -75,7 +62,7 @@ func fuzzMain(t *testing.T, data []byte) {
         jerr := json.Unmarshal([]byte(data), jv)
         require.Equalf(t, serr != nil, jerr != nil, "different error in sonic unmarshal %v", reflect.TypeOf(jv))
         if jerr != nil {
-            return
+            continue
         }
         require.Equal(t, sv, jv, "different result in sonic unmarshal %v", reflect.TypeOf(jv))
         sout, serr := sonic.Marshal(sv)
@@ -89,7 +76,7 @@ func fuzzMain(t *testing.T, data []byte) {
             jerr := json.Unmarshal(jout, jv)
             require.Equalf(t, serr != nil, jerr != nil, "different error in sonic unmarshal again %v", reflect.TypeOf(jv))
             if jerr != nil {
-                return
+                continue
             }
             require.Equal(t, sv, jv, "different result in sonic unmarshal again %v", reflect.TypeOf(jv))
         }
@@ -127,7 +114,7 @@ type S struct {
 	U [2]int
 	V uintptr
     W json.Number
-    X json.RawMessage
+    // X json.RawMessage
     Y Marshaller 
 	Z TextMarshaller
 }

--- a/internal/native/avx/native_amd64.go
+++ b/internal/native/avx/native_amd64.go
@@ -97,6 +97,11 @@ func __skip_one(s *string, p *int, m *types.StateMachine, flags uint64) (ret int
 //go:nosplit
 //go:noescape
 //goland:noinspection GoUnusedParameter
+func __skip_one_fast(s *string, p *int) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
 func __skip_array(s *string, p *int, m *types.StateMachine, flags uint64) (ret int)
 
 //go:nosplit
@@ -113,3 +118,8 @@ func __skip_number(s *string, p *int) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __get_by_path(s *string, p *int, path *[]interface{}) (ret int)

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -210,7 +210,7 @@ LBB1_8:
 	LONG $0x04e6c148                           // shlq         $4, %rsi
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xd348; BYTE $0xe3                   // shlq         %cl, %rbx
-	LONG $0x221d8d4c; WORD $0x009e; BYTE $0x00 // leaq         $40482(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
+	LONG $0xb21d8d4c; WORD $0x00b1; BYTE $0x00 // leaq         $45490(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
 	LONG $0x1e648b4e; BYTE $0x08               // movq         $8(%rsi,%r11), %r12
 	WORD $0x8948; BYTE $0xd8                   // movq         %rbx, %rax
 	WORD $0xf749; BYTE $0xe4                   // mulq         %r12
@@ -383,7 +383,7 @@ LBB1_31:
 	LONG $0x0099820f; WORD $0x0000 // jb           LBB1_39, $153(%rip)
 	LONG $0x01678d4d               // leaq         $1(%r15), %r12
 	WORD $0x894c; BYTE $0xe6       // movq         %r12, %rsi
-	LONG $0x0068fde8; BYTE $0x00   // callq        _format_significand, $26877(%rip)
+	LONG $0x0078dde8; BYTE $0x00   // callq        _format_significand, $30941(%rip)
 	WORD $0x8948; BYTE $0xc3       // movq         %rax, %rbx
 	LONG $0xd07d8b48               // movq         $-48(%rbp), %rdi
 	WORD $0x2948; BYTE $0xf8       // subq         %rdi, %rax
@@ -420,7 +420,7 @@ LBB1_38:
 	WORD $0x0c8d; BYTE $0x12                   // leal         (%rdx,%rdx), %ecx
 	WORD $0x0c8d; BYTE $0x89                   // leal         (%rcx,%rcx,4), %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
-	LONG $0x260d8d48; WORD $0x009a; BYTE $0x00 // leaq         $39462(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb60d8d48; WORD $0x00ad; BYTE $0x00 // leaq         $44470(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x510cb70f                           // movzwl       (%rcx,%rdx,2), %ecx
 	LONG $0x024b8966                           // movw         %cx, $2(%rbx)
 	WORD $0x300c                               // orb          $48, %al
@@ -506,7 +506,7 @@ LBB1_52:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
 	LONG $0x007f8c0f; WORD $0x0000             // jl           LBB1_60, $127(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xd30d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39123(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x630d8d48; WORD $0x00ac; BYTE $0x00 // leaq         $44131(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x02438966                           // movw         %ax, $2(%rbx)
 	LONG $0x04c38348                           // addq         $4, %rbx
@@ -751,7 +751,7 @@ LBB1_96:
 LBB1_97:
 	WORD $0x894c; BYTE $0xfe     // movq         %r15, %rsi
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x006334e8; BYTE $0x00 // callq        _format_significand, $25396(%rip)
+	LONG $0x007314e8; BYTE $0x00 // callq        _format_significand, $29460(%rip)
 	WORD $0xc289                 // movl         %eax, %edx
 	WORD $0x2844; BYTE $0xfa     // subb         %r15b, %dl
 	WORD $0x2844; BYTE $0xf2     // subb         %r14b, %dl
@@ -1039,7 +1039,7 @@ LBB2_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0xf00d8d48; WORD $0x0090; BYTE $0x00 // leaq         $37104(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x800d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42112(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -1055,7 +1055,7 @@ LBB2_2:
 
 LBB2_5:
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
-	LONG $0xa9158d4c; WORD $0x0090; BYTE $0x00 // leaq         $37033(%rip), %r10  /* _Digits(%rip) */
+	LONG $0x39158d4c; WORD $0x00a4; BYTE $0x00 // leaq         $42041(%rip), %r10  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
 LBB2_6:
@@ -1087,7 +1087,7 @@ LBB2_7:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xca                   // movzwl       %dx, %ecx
-	LONG $0x31158d48; WORD $0x0090; BYTE $0x00 // leaq         $36913(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xc1158d48; WORD $0x00a3; BYTE $0x00 // leaq         $41921(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4b894166; BYTE $0xfe               // movw         %cx, $-2(%r11)
 	LONG $0xfec38349                           // addq         $-2, %r11
@@ -1097,7 +1097,7 @@ LBB2_9:
 	WORD $0xfa83; BYTE $0x0a                   // cmpl         $10, %edx
 	LONG $0x0018820f; WORD $0x0000             // jb           LBB2_11, $24(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x100d8d48; WORD $0x0090; BYTE $0x00 // leaq         $36880(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xa00d8d48; WORD $0x00a3; BYTE $0x00 // leaq         $41888(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x43894166; BYTE $0xfe               // movw         %ax, $-2(%r11)
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
@@ -1173,7 +1173,7 @@ _u64toa:
 	WORD $0x0148; BYTE $0xc0                   // addq         %rax, %rax
 	LONG $0x03e8fe81; WORD $0x0000             // cmpl         $1000, %esi
 	LONG $0x0016820f; WORD $0x0000             // jb           LBB4_3, $22(%rip)
-	LONG $0x3c0d8d48; WORD $0x008f; BYTE $0x00 // leaq         $36668(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xcc0d8d48; WORD $0x00a2; BYTE $0x00 // leaq         $41676(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x0c8a; BYTE $0x0a                   // movb         (%rdx,%rcx), %cl
 	WORD $0x0f88                               // movb         %cl, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1187,14 +1187,14 @@ LBB4_3:
 LBB4_4:
 	WORD $0xb70f; BYTE $0xd2                   // movzwl       %dx, %edx
 	LONG $0x01ca8348                           // orq          $1, %rdx
-	LONG $0x14358d48; WORD $0x008f; BYTE $0x00 // leaq         $36628(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xa4358d48; WORD $0x00a2; BYTE $0x00 // leaq         $41636(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x32                   // movb         (%rdx,%rsi), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x1488; BYTE $0x37                   // movb         %dl, (%rdi,%rsi)
 
 LBB4_6:
-	LONG $0x02158d48; WORD $0x008f; BYTE $0x00 // leaq         $36610(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x92158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41618(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x10                   // movb         (%rax,%rdx), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1203,7 +1203,7 @@ LBB4_6:
 LBB4_7:
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0xe9158d48; WORD $0x008e; BYTE $0x00 // leaq         $36585(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x79158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41593(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x10                   // movb         (%rax,%rdx), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1250,7 +1250,7 @@ LBB4_8:
 	WORD $0x014d; BYTE $0xdb                   // addq         %r11, %r11
 	LONG $0x9680fe81; WORD $0x0098             // cmpl         $10000000, %esi
 	LONG $0x0017820f; WORD $0x0000             // jb           LBB4_11, $23(%rip)
-	LONG $0x46058d48; WORD $0x008e; BYTE $0x00 // leaq         $36422(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xd6058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41430(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x02048a41                           // movb         (%r10,%rax), %al
 	WORD $0x0788                               // movb         %al, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1264,14 +1264,14 @@ LBB4_11:
 LBB4_12:
 	WORD $0x8944; BYTE $0xd0                   // movl         %r10d, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x1a358d48; WORD $0x008e; BYTE $0x00 // leaq         $36378(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xaa358d48; WORD $0x00a1; BYTE $0x00 // leaq         $41386(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x0488; BYTE $0x37                   // movb         %al, (%rdi,%rsi)
 
 LBB4_14:
-	LONG $0x08058d48; WORD $0x008e; BYTE $0x00 // leaq         $36360(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x98058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41368(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x01048a41                           // movb         (%r9,%rax), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1280,7 +1280,7 @@ LBB4_14:
 LBB4_15:
 	LONG $0xc1b70f41                           // movzwl       %r9w, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0xed358d48; WORD $0x008d; BYTE $0x00 // leaq         $36333(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x7d358d48; WORD $0x00a1; BYTE $0x00 // leaq         $41341(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0x0488; BYTE $0x17                   // movb         %al, (%rdi,%rdx)
@@ -1362,7 +1362,7 @@ LBB4_16:
 	LONG $0x000010b9; BYTE $0x00               // movl         $16, %ecx
 	WORD $0xc129                               // subl         %eax, %ecx
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0xf6158d48; WORD $0x00b3; BYTE $0x00 // leaq         $46070(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x86158d48; WORD $0x00c7; BYTE $0x00 // leaq         $51078(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	WORD $0xc889                               // movl         %ecx, %eax
@@ -1388,7 +1388,7 @@ LBB4_20:
 	WORD $0xfa83; BYTE $0x63                   // cmpl         $99, %edx
 	LONG $0x001a870f; WORD $0x0000             // ja           LBB4_22, $26(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x390d8d48; WORD $0x008c; BYTE $0x00 // leaq         $35897(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xc90d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40905(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	LONG $0x000002b9; BYTE $0x00               // movl         $2, %ecx
@@ -1411,7 +1411,7 @@ LBB4_22:
 	WORD $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xe90d8d48; WORD $0x008b; BYTE $0x00 // leaq         $35817(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x790d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40825(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x01478966                           // movw         %ax, $1(%rdi)
 	LONG $0x000003b9; BYTE $0x00               // movl         $3, %ecx
@@ -1421,7 +1421,7 @@ LBB4_24:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xc80d8d48; WORD $0x008b; BYTE $0x00 // leaq         $35784(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x580d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40792(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	WORD $0xb70f; BYTE $0xc2                   // movzwl       %dx, %eax
@@ -1508,8 +1508,8 @@ _quote:
 	WORD $0x8b4c; BYTE $0x11                   // movq         (%rcx), %r10
 	LONG $0x01c0f641                           // testb        $1, %r8b
 	WORD $0x8948; BYTE $0xf0                   // movq         %rsi, %rax
-	LONG $0x580d8d48; WORD $0x00b2; BYTE $0x00 // leaq         $45656(%rip), %rcx  /* __SingleQuoteTab(%rip) */
-	LONG $0x51258d4c; WORD $0x00c2; BYTE $0x00 // leaq         $49745(%rip), %r12  /* __DoubleQuoteTab(%rip) */
+	LONG $0xe80d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50664(%rip), %rcx  /* __SingleQuoteTab(%rip) */
+	LONG $0xe1258d4c; WORD $0x00d5; BYTE $0x00 // leaq         $54753(%rip), %r12  /* __DoubleQuoteTab(%rip) */
 	LONG $0xe1440f4c                           // cmoveq       %rcx, %r12
 	QUAD $0x00000000f50c8d48                   // leaq         (,%rsi,8), %rcx
 	WORD $0x3949; BYTE $0xca                   // cmpq         %rcx, %r10
@@ -1613,7 +1613,7 @@ LBB5_17:
 	LONG $0x74b60f43; WORD $0x000d             // movzbl       (%r13,%r9), %esi
 	WORD $0x8948; BYTE $0xf3                   // movq         %rsi, %rbx
 	LONG $0x04e3c148                           // shlq         $4, %rbx
-	LONG $0xcc158d48; WORD $0x00b0; BYTE $0x00 // leaq         $45260(%rip), %rdx  /* __SingleQuoteTab(%rip) */
+	LONG $0x5c158d48; WORD $0x00c4; BYTE $0x00 // leaq         $50268(%rip), %rdx  /* __SingleQuoteTab(%rip) */
 	LONG $0x133c8348; BYTE $0x00               // cmpq         $0, (%rbx,%rdx)
 	LONG $0x008c850f; WORD $0x0000             // jne          LBB5_27, $140(%rip)
 	LONG $0x0b048d4d                           // leaq         (%r11,%rcx), %r8
@@ -1827,7 +1827,7 @@ LBB5_80:
 	LONG $0x000255e9; BYTE $0x00 // jmp          LBB5_82, $597(%rip)
 
 LBB5_56:
-	LONG $0x490d8d4c; WORD $0x00ce; BYTE $0x00 // leaq         $52809(%rip), %r9  /* __EscTab(%rip) */
+	LONG $0xd90d8d4c; WORD $0x00e1; BYTE $0x00 // leaq         $57817(%rip), %r9  /* __EscTab(%rip) */
 	QUAD $0xfffffb91056ff9c5                   // vmovdqa      $-1135(%rip), %xmm0  /* LCPI5_0(%rip) */
 	QUAD $0xfffffb990d6ff9c5                   // vmovdqa      $-1127(%rip), %xmm1  /* LCPI5_1(%rip) */
 	QUAD $0xfffffba1156ff9c5                   // vmovdqa      $-1119(%rip), %xmm2  /* LCPI5_2(%rip) */
@@ -2126,7 +2126,7 @@ LBB6_15:
 LBB6_17:
 	WORD $0x014c; BYTE $0xf0                   // addq         %r14, %rax
 	LONG $0x5bb60f41; BYTE $0xff               // movzbl       $-1(%r11), %ebx
-	LONG $0x74158d4c; WORD $0x00cb; BYTE $0x00 // leaq         $52084(%rip), %r10  /* __UnquoteTab(%rip) */
+	LONG $0x04158d4c; WORD $0x00df; BYTE $0x00 // leaq         $57092(%rip), %r10  /* __UnquoteTab(%rip) */
 	LONG $0x131c8a42                           // movb         (%rbx,%r10), %bl
 	WORD $0xfb80; BYTE $0xff                   // cmpb         $-1, %bl
 	LONG $0x0017840f; WORD $0x0000             // je           LBB6_20, $23(%rip)
@@ -2910,7 +2910,7 @@ _html_escape:
 	QUAD $0xffffff910d6ff9c5                   // vmovdqa      $-111(%rip), %xmm1  /* LCPI7_1(%rip) */
 	QUAD $0xffffff99156ff9c5                   // vmovdqa      $-103(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD $0xffffffa11d6ff9c5                   // vmovdqa      $-95(%rip), %xmm3  /* LCPI7_3(%rip) */
-	LONG $0xea1d8d4c; WORD $0x00c0; BYTE $0x00 // leaq         $49386(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x7a1d8d4c; WORD $0x00d4; BYTE $0x00 // leaq         $54394(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x8949; BYTE $0xfc                   // movq         %rdi, %r12
 	LONG $0xd0758b4c                           // movq         $-48(%rbp), %r14
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
@@ -3020,7 +3020,7 @@ LBB7_17:
 LBB7_20:
 	WORD $0x2949; BYTE $0xcf                   // subq         %rcx, %r15
 	WORD $0x0148; BYTE $0xcb                   // addq         %rcx, %rbx
-	LONG $0x4c1d8d4c; WORD $0x00bf; BYTE $0x00 // leaq         $48972(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0xdc1d8d4c; WORD $0x00d2; BYTE $0x00 // leaq         $53980(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
 LBB7_21:
@@ -3055,7 +3055,7 @@ LBB7_24:
 LBB7_45:
 	WORD $0x294d; BYTE $0xe7                   // subq         %r12, %r15
 	WORD $0x2949; BYTE $0xc7                   // subq         %rax, %r15
-	LONG $0xd21d8d4c; WORD $0x00be; BYTE $0x00 // leaq         $48850(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x621d8d4c; WORD $0x00d2; BYTE $0x00 // leaq         $53858(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x854d; BYTE $0xff                   // testq        %r15, %r15
 	LONG $0x0109890f; WORD $0x0000             // jns          LBB7_49, $265(%rip)
 	LONG $0x000229e9; BYTE $0x00               // jmp          LBB7_48, $553(%rip)
@@ -3305,7 +3305,7 @@ LBB8_5:
 	WORD $0xd348; BYTE $0xe7                   // shlq         %cl, %rdi
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0x04e1c148                           // shlq         $4, %rcx
-	LONG $0x413d8d4c; WORD $0x0046; BYTE $0x00 // leaq         $17985(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0xd13d8d4c; WORD $0x0059; BYTE $0x00 // leaq         $22993(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	LONG $0x3964f74a; BYTE $0x08               // mulq         $8(%rcx,%r15)
 	WORD $0x8949; BYTE $0xc3                   // movq         %rax, %r11
@@ -3424,7 +3424,7 @@ LBB9_5:
 	LONG $0xd05d8948                           // movq         %rbx, $-48(%rbp)
 	LONG $0x005a8e0f; WORD $0x0000             // jle          LBB9_12, $90(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0x38358d4c; WORD $0x0070; BYTE $0x00 // leaq         $28728(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0xc8358d4c; WORD $0x0083; BYTE $0x00 // leaq         $33736(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_8, $45(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
@@ -3437,7 +3437,7 @@ LBB9_10:
 LBB9_11:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x0042a5e8; BYTE $0x00 // callq        _right_shift, $17061(%rip)
+	LONG $0x005285e8; BYTE $0x00 // callq        _right_shift, $21125(%rip)
 
 LBB9_7:
 	WORD $0x0141; BYTE $0xdc       // addl         %ebx, %r12d
@@ -3454,7 +3454,7 @@ LBB9_8:
 	LONG $0xffffd3e9; BYTE $0xff   // jmp          LBB9_7, $-45(%rip)
 
 LBB9_12:
-	LONG $0xe1358d4c; WORD $0x006f; BYTE $0x00 // leaq         $28641(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x71358d4c; WORD $0x0083; BYTE $0x00 // leaq         $33649(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_14, $45(%rip)
 
 LBB9_18:
@@ -3466,7 +3466,7 @@ LBB9_18:
 LBB9_20:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x004026e8; BYTE $0x00 // callq        _left_shift, $16422(%rip)
+	LONG $0x005006e8; BYTE $0x00 // callq        _left_shift, $20486(%rip)
 	LONG $0x14478b41             // movl         $20(%r15), %eax
 
 LBB9_13:
@@ -3508,7 +3508,7 @@ LBB9_21:
 LBB9_25:
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x00003cbe; BYTE $0x00   // movl         $60, %esi
-	LONG $0x0041b3e8; BYTE $0x00   // callq        _right_shift, $16819(%rip)
+	LONG $0x005193e8; BYTE $0x00   // callq        _right_shift, $20883(%rip)
 	LONG $0x3cc48341               // addl         $60, %r12d
 	LONG $0x88fc8341               // cmpl         $-120, %r12d
 	LONG $0xffe58c0f; WORD $0xffff // jl           LBB9_25, $-27(%rip)
@@ -3534,7 +3534,7 @@ LBB9_31:
 	WORD $0xf741; BYTE $0xdc       // negl         %r12d
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	WORD $0x8944; BYTE $0xe6       // movl         %r12d, %esi
-	LONG $0x00415fe8; BYTE $0x00   // callq        _right_shift, $16735(%rip)
+	LONG $0x00513fe8; BYTE $0x00   // callq        _right_shift, $20799(%rip)
 	LONG $0xfc02be41; WORD $0xffff // movl         $-1022, %r14d
 
 LBB9_32:
@@ -3542,7 +3542,7 @@ LBB9_32:
 	LONG $0x000d840f; WORD $0x0000 // je           LBB9_34, $13(%rip)
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x000035be; BYTE $0x00   // movl         $53, %esi
-	LONG $0x003f21e8; BYTE $0x00   // callq        _left_shift, $16161(%rip)
+	LONG $0x004f01e8; BYTE $0x00   // callq        _left_shift, $20225(%rip)
 
 LBB9_34:
 	LONG $0x14478b41                           // movl         $20(%r15), %eax
@@ -3917,7 +3917,7 @@ LBB11_2:
 	LONG $0xb07d8d48               // leaq         $-80(%rbp), %rdi
 	LONG $0xd0758d48               // leaq         $-48(%rbp), %rsi
 	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
-	LONG $0x001317e8; BYTE $0x00   // callq        _vnumber, $4887(%rip)
+	LONG $0x000fd7e8; BYTE $0x00   // callq        _vnumber, $4055(%rip)
 	LONG $0xd0658b4c               // movq         $-48(%rbp), %r12
 	LONG $0x0002f3e9; BYTE $0x00   // jmp          LBB11_49, $755(%rip)
 
@@ -3939,7 +3939,7 @@ LBB11_4:
 LBB11_7:
 	WORD $0x894c; BYTE $0xe7                   // movq         %r12, %rdi
 	WORD $0x8948; BYTE $0xde                   // movq         %rbx, %rsi
-	LONG $0x002472e8; BYTE $0x00               // callq        _do_skip_number, $9330(%rip)
+	LONG $0x002112e8; BYTE $0x00               // callq        _do_skip_number, $8466(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
 	LONG $0x0293880f; WORD $0x0000             // js           LBB11_45, $659(%rip)
 	WORD $0x0149; BYTE $0xc4                   // addq         %rax, %r12
@@ -4556,6 +4556,11 @@ LCPI14_2:
 
 	// .p2align 4, 0x90
 _advance_string:
+	WORD $0xc1f6; BYTE $0x20       // testb        $32, %cl
+	LONG $0x0005850f; WORD $0x0000 // jne          LBB14_2, $5(%rip)
+	LONG $0x004602e9; BYTE $0x00   // jmp          _advance_string_default, $17922(%rip)
+
+LBB14_2:
 	BYTE $0x55                                 // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
 	WORD $0x5741                               // pushq        %r15
@@ -4564,135 +4569,32 @@ _advance_string:
 	WORD $0x5441                               // pushq        %r12
 	BYTE $0x53                                 // pushq        %rbx
 	LONG $0x18ec8348                           // subq         $24, %rsp
-	LONG $0xc8558948                           // movq         %rdx, $-56(%rbp)
-	WORD $0xc1f6; BYTE $0x20                   // testb        $32, %cl
-	LONG $0x017e850f; WORD $0x0000             // jne          LBB14_12, $382(%rip)
-	LONG $0x087f8b4c                           // movq         $8(%rdi), %r15
-	WORD $0x2949; BYTE $0xf7                   // subq         %rsi, %r15
-	LONG $0x0a58840f; WORD $0x0000             // je           LBB14_111, $2648(%rip)
-	WORD $0x8b4c; BYTE $0x37                   // movq         (%rdi), %r14
-	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
-	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
-	LONG $0x40ff8349                           // cmpq         $64, %r15
-	LONG $0x0879820f; WORD $0x0000             // jb           LBB14_112, $2169(%rip)
-	WORD $0x8948; BYTE $0xf3                   // movq         %rsi, %rbx
-	WORD $0xf748; BYTE $0xd3                   // notq         %rbx
-	QUAD $0xffffffffd045c748                   // movq         $-1, $-48(%rbp)
-	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	QUAD $0xffffff74056ff9c5                   // vmovdqa      $-140(%rip), %xmm0  /* LCPI14_0(%rip) */
-	QUAD $0xffffff7c0d6ff9c5                   // vmovdqa      $-132(%rip), %xmm1  /* LCPI14_1(%rip) */
-	QUAD $0x555555555555ba49; WORD $0x5555     // movabsq      $6148914691236517205, %r10
-	WORD $0x9090                               // .p2align 4, 0x90
-
-LBB14_4:
-	LONG $0x6f7ac1c4; WORD $0x3614             // vmovdqu      (%r14,%rsi), %xmm2
-	LONG $0x6f7ac1c4; WORD $0x365c; BYTE $0x10 // vmovdqu      $16(%r14,%rsi), %xmm3
-	LONG $0x6f7ac1c4; WORD $0x3664; BYTE $0x20 // vmovdqu      $32(%r14,%rsi), %xmm4
-	LONG $0x6f7ac1c4; WORD $0x366c; BYTE $0x30 // vmovdqu      $48(%r14,%rsi), %xmm5
-	LONG $0xf074e9c5                           // vpcmpeqb     %xmm0, %xmm2, %xmm6
-	LONG $0xe6d779c5                           // vpmovmskb    %xmm6, %r12d
-	LONG $0xf074e1c5                           // vpcmpeqb     %xmm0, %xmm3, %xmm6
-	LONG $0xd6d7f9c5                           // vpmovmskb    %xmm6, %edx
-	LONG $0xf074d9c5                           // vpcmpeqb     %xmm0, %xmm4, %xmm6
-	LONG $0xc6d7f9c5                           // vpmovmskb    %xmm6, %eax
-	LONG $0xf074d1c5                           // vpcmpeqb     %xmm0, %xmm5, %xmm6
-	LONG $0xfed7f9c5                           // vpmovmskb    %xmm6, %edi
-	LONG $0xd174e9c5                           // vpcmpeqb     %xmm1, %xmm2, %xmm2
-	LONG $0xead779c5                           // vpmovmskb    %xmm2, %r13d
-	LONG $0xd174e1c5                           // vpcmpeqb     %xmm1, %xmm3, %xmm2
-	LONG $0xcad7f9c5                           // vpmovmskb    %xmm2, %ecx
-	LONG $0xd174d9c5                           // vpcmpeqb     %xmm1, %xmm4, %xmm2
-	LONG $0xc2d779c5                           // vpmovmskb    %xmm2, %r8d
-	LONG $0xd174d1c5                           // vpcmpeqb     %xmm1, %xmm5, %xmm2
-	LONG $0xcad779c5                           // vpmovmskb    %xmm2, %r9d
-	LONG $0x30e7c148                           // shlq         $48, %rdi
-	LONG $0x20e0c148                           // shlq         $32, %rax
-	WORD $0x0948; BYTE $0xf8                   // orq          %rdi, %rax
-	LONG $0x10e2c148                           // shlq         $16, %rdx
-	WORD $0x0948; BYTE $0xc2                   // orq          %rax, %rdx
-	WORD $0x0949; BYTE $0xd4                   // orq          %rdx, %r12
-	LONG $0x30e1c149                           // shlq         $48, %r9
-	LONG $0x20e0c149                           // shlq         $32, %r8
-	WORD $0x094d; BYTE $0xc8                   // orq          %r9, %r8
-	LONG $0x10e1c148                           // shlq         $16, %rcx
-	WORD $0x094c; BYTE $0xc1                   // orq          %r8, %rcx
-	WORD $0x0949; BYTE $0xcd                   // orq          %rcx, %r13
-	LONG $0x0030850f; WORD $0x0000             // jne          LBB14_8, $48(%rip)
-	WORD $0x854d; BYTE $0xdb                   // testq        %r11, %r11
-	LONG $0x0044850f; WORD $0x0000             // jne          LBB14_10, $68(%rip)
-	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
-	LONG $0x0080850f; WORD $0x0000             // jne          LBB14_11, $128(%rip)
-
-LBB14_7:
-	LONG $0xc0c78349               // addq         $-64, %r15
-	LONG $0xc0c38348               // addq         $-64, %rbx
-	LONG $0x40c68348               // addq         $64, %rsi
-	LONG $0x3fff8349               // cmpq         $63, %r15
-	LONG $0xff4a870f; WORD $0xffff // ja           LBB14_4, $-182(%rip)
-	LONG $0x000560e9; BYTE $0x00   // jmp          LBB14_70, $1376(%rip)
-
-LBB14_8:
-	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_10, $18(%rip)
-	LONG $0xcdbc0f49               // bsfq         %r13, %rcx
-	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
-	LONG $0xd04d8948               // movq         %rcx, $-48(%rbp)
-	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
-
-LBB14_10:
-	WORD $0x894c; BYTE $0xd8               // movq         %r11, %rax
-	WORD $0xf748; BYTE $0xd0               // notq         %rax
-	WORD $0x214c; BYTE $0xe8               // andq         %r13, %rax
-	LONG $0x000c8d48                       // leaq         (%rax,%rax), %rcx
-	WORD $0x094c; BYTE $0xd9               // orq          %r11, %rcx
-	WORD $0x8948; BYTE $0xca               // movq         %rcx, %rdx
-	WORD $0xf748; BYTE $0xd2               // notq         %rdx
-	WORD $0x214c; BYTE $0xea               // andq         %r13, %rdx
-	QUAD $0xaaaaaaaaaaaabf48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rdi
-	WORD $0x2148; BYTE $0xfa               // andq         %rdi, %rdx
-	WORD $0x3145; BYTE $0xdb               // xorl         %r11d, %r11d
-	WORD $0x0148; BYTE $0xc2               // addq         %rax, %rdx
-	LONG $0xc3920f41                       // setb         %r11b
-	WORD $0x0148; BYTE $0xd2               // addq         %rdx, %rdx
-	WORD $0x314c; BYTE $0xd2               // xorq         %r10, %rdx
-	WORD $0x2148; BYTE $0xca               // andq         %rcx, %rdx
-	WORD $0xf748; BYTE $0xd2               // notq         %rdx
-	WORD $0x2149; BYTE $0xd4               // andq         %rdx, %r12
-	WORD $0x854d; BYTE $0xe4               // testq        %r12, %r12
-	LONG $0xff80840f; WORD $0xffff         // je           LBB14_7, $-128(%rip)
-
-LBB14_11:
-	LONG $0xc4bc0f49             // bsfq         %r12, %rax
-	WORD $0x2948; BYTE $0xd8     // subq         %rbx, %rax
-	LONG $0x000704e9; BYTE $0x00 // jmp          LBB14_108, $1796(%rip)
-
-LBB14_12:
 	LONG $0x086f8b4c                           // movq         $8(%rdi), %r13
 	WORD $0x2949; BYTE $0xf5                   // subq         %rsi, %r13
-	LONG $0x08da840f; WORD $0x0000             // je           LBB14_111, $2266(%rip)
+	LONG $0x070f840f; WORD $0x0000             // je           LBB14_95, $1807(%rip)
 	WORD $0x8b4c; BYTE $0x37                   // movq         (%rdi), %r14
 	WORD $0x014c; BYTE $0xf6                   // addq         %r14, %rsi
-	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
-	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
+	LONG $0xc8558948                           // movq         %rdx, $-56(%rbp)
+	LONG $0xff02c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rdx)
 	LONG $0xd075894c                           // movq         %r14, $-48(%rbp)
-	WORD $0xf749; BYTE $0xde                   // negq         %r14
+	WORD $0x894c; BYTE $0xf2                   // movq         %r14, %rdx
+	WORD $0xf748; BYTE $0xda                   // negq         %rdx
 	QUAD $0xffffffffc045c748                   // movq         $-1, $-64(%rbp)
-	QUAD $0xfffffdff056f79c5                   // vmovdqa      $-513(%rip), %xmm8  /* LCPI14_0(%rip) */
-	QUAD $0xfffffe070d6f79c5                   // vmovdqa      $-505(%rip), %xmm9  /* LCPI14_1(%rip) */
-	QUAD $0xfffffe0f156ff9c5                   // vmovdqa      $-497(%rip), %xmm2  /* LCPI14_2(%rip) */
+	QUAD $0xffffff79056f79c5                   // vmovdqa      $-135(%rip), %xmm8  /* LCPI14_0(%rip) */
+	QUAD $0xffffff810d6f79c5                   // vmovdqa      $-127(%rip), %xmm9  /* LCPI14_1(%rip) */
+	QUAD $0xffffff89156ff9c5                   // vmovdqa      $-119(%rip), %xmm2  /* LCPI14_2(%rip) */
 	LONG $0xdb76e1c5                           // vpcmpeqd     %xmm3, %xmm3, %xmm3
+	QUAD $0x555555555555be49; WORD $0x5555     // movabsq      $6148914691236517205, %r14
 
-LBB14_14:
+LBB14_4:
 	LONG $0x40fd8349                           // cmpq         $64, %r13
-	LONG $0x03f1820f; WORD $0x0000             // jb           LBB14_63, $1009(%rip)
-	LONG $0x363c8d4d                           // leaq         (%r14,%rsi), %r15
+	LONG $0x03f1820f; WORD $0x0000             // jb           LBB14_53, $1009(%rip)
+	LONG $0x323c8d4c                           // leaq         (%rdx,%rsi), %r15
 	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
 	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_16:
+LBB14_6:
 	LONG $0x6f7aa1c4; WORD $0x1e24             // vmovdqu      (%rsi,%r11), %xmm4
 	LONG $0x6f7aa1c4; WORD $0x1e6c; BYTE $0x10 // vmovdqu      $16(%rsi,%r11), %xmm5
 	LONG $0x6f7aa1c4; WORD $0x1e7c; BYTE $0x20 // vmovdqu      $32(%rsi,%r11), %xmm7
@@ -4750,437 +4652,409 @@ LBB14_16:
 	WORD $0x0948; BYTE $0xc1                   // orq          %rax, %rcx
 	LONG $0xd1d779c5                           // vpmovmskb    %xmm1, %r10d
 	WORD $0x094d; BYTE $0xca                   // orq          %r9, %r10
-	LONG $0x0058850f; WORD $0x0000             // jne          LBB14_23, $88(%rip)
+	LONG $0x0058850f; WORD $0x0000             // jne          LBB14_13, $88(%rip)
 	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
-	LONG $0x006f850f; WORD $0x0000             // jne          LBB14_25, $111(%rip)
+	LONG $0x006f850f; WORD $0x0000             // jne          LBB14_15, $111(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
 
-LBB14_19:
+LBB14_9:
 	LONG $0xc464e9c5               // vpcmpgtb     %xmm4, %xmm2, %xmm0
 	LONG $0xcb64d9c5               // vpcmpgtb     %xmm3, %xmm4, %xmm1
 	LONG $0xc1dbf9c5               // vpand        %xmm1, %xmm0, %xmm0
 	LONG $0xc0d7f9c5               // vpmovmskb    %xmm0, %eax
-	LONG $0xd4d7f9c5               // vpmovmskb    %xmm4, %edx
+	LONG $0xdcd7f9c5               // vpmovmskb    %xmm4, %ebx
 	WORD $0x0948; BYTE $0xc7       // orq          %rax, %rdi
-	WORD $0x0948; BYTE $0xd1       // orq          %rdx, %rcx
+	WORD $0x0948; BYTE $0xd9       // orq          %rbx, %rcx
 	WORD $0x854d; BYTE $0xc0       // testq        %r8, %r8
-	LONG $0x00a6850f; WORD $0x0000 // jne          LBB14_26, $166(%rip)
+	LONG $0x00a6850f; WORD $0x0000 // jne          LBB14_16, $166(%rip)
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x033c850f; WORD $0x0000 // jne          LBB14_68, $828(%rip)
+	LONG $0x033d850f; WORD $0x0000 // jne          LBB14_58, $829(%rip)
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x01ac850f; WORD $0x0000 // jne          LBB14_46, $428(%rip)
+	LONG $0x01ac850f; WORD $0x0000 // jne          LBB14_36, $428(%rip)
 	LONG $0xc0c58349               // addq         $-64, %r13
 	LONG $0x40c38349               // addq         $64, %r11
 	LONG $0x3ffd8349               // cmpq         $63, %r13
-	LONG $0xfec2870f; WORD $0xffff // ja           LBB14_16, $-318(%rip)
-	LONG $0x00019ee9; BYTE $0x00   // jmp          LBB14_47, $414(%rip)
+	LONG $0xfec2870f; WORD $0xffff // ja           LBB14_6, $-318(%rip)
+	LONG $0x00019ee9; BYTE $0x00   // jmp          LBB14_37, $414(%rip)
 
-LBB14_23:
+LBB14_13:
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_25, $21(%rip)
-	LONG $0xd2bc0f49               // bsfq         %r10, %rdx
-	WORD $0x014c; BYTE $0xfa       // addq         %r15, %rdx
-	WORD $0x014c; BYTE $0xda       // addq         %r11, %rdx
-	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
-	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x10       // movq         %rdx, (%rax)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_15, $21(%rip)
+	LONG $0xc2bc0f49               // bsfq         %r10, %rax
+	WORD $0x014c; BYTE $0xf8       // addq         %r15, %rax
+	WORD $0x014c; BYTE $0xd8       // addq         %r11, %rax
+	LONG $0xc0458948               // movq         %rax, $-64(%rbp)
+	LONG $0xc85d8b48               // movq         $-56(%rbp), %rbx
+	WORD $0x8948; BYTE $0x03       // movq         %rax, (%rbx)
 
-LBB14_25:
-	WORD $0x894c; BYTE $0xe0                                             // movq         %r12, %rax
-	WORD $0xf748; BYTE $0xd0                                             // notq         %rax
-	WORD $0x214c; BYTE $0xd0                                             // andq         %r10, %rax
-	LONG $0x000c8d4c                                                     // leaq         (%rax,%rax), %r9
+LBB14_15:
+	WORD $0x894d; BYTE $0xe6                                             // movq         %r12, %r14
+	WORD $0xf749; BYTE $0xd6                                             // notq         %r14
+	WORD $0x214d; BYTE $0xd6                                             // andq         %r10, %r14
+	LONG $0x360c8d4f                                                     // leaq         (%r14,%r14), %r9
 	WORD $0x094d; BYTE $0xe1                                             // orq          %r12, %r9
 	WORD $0x894c; BYTE $0xcb                                             // movq         %r9, %rbx
 	WORD $0xf748; BYTE $0xd3                                             // notq         %rbx
 	WORD $0x214c; BYTE $0xd3                                             // andq         %r10, %rbx
-	QUAD $0xaaaaaaaaaaaaba48; WORD $0xaaaa                               // movabsq      $-6148914691236517206, %rdx
-	WORD $0x2148; BYTE $0xd3                                             // andq         %rdx, %rbx
+	QUAD $0xaaaaaaaaaaaab848; WORD $0xaaaa                               // movabsq      $-6148914691236517206, %rax
+	WORD $0x2148; BYTE $0xc3                                             // andq         %rax, %rbx
 	WORD $0x3145; BYTE $0xe4                                             // xorl         %r12d, %r12d
-	WORD $0x0148; BYTE $0xc3                                             // addq         %rax, %rbx
+	WORD $0x014c; BYTE $0xf3                                             // addq         %r14, %rbx
 	LONG $0xc4920f41                                                     // setb         %r12b
 	WORD $0x0148; BYTE $0xdb                                             // addq         %rbx, %rbx
-	QUAD $0x555555555555b848; WORD $0x5555                               // movabsq      $6148914691236517205, %rax
-	WORD $0x3148; BYTE $0xc3                                             // xorq         %rax, %rbx
+	QUAD $0x555555555555be49; WORD $0x5555                               // movabsq      $6148914691236517205, %r14
+	WORD $0x314c; BYTE $0xf3                                             // xorq         %r14, %rbx
 	WORD $0x214c; BYTE $0xcb                                             // andq         %r9, %rbx
 	WORD $0xf748; BYTE $0xd3                                             // notq         %rbx
 	WORD $0x2149; BYTE $0xd8                                             // andq         %rbx, %r8
-	LONG $0xffff46e9; BYTE $0xff                                         // jmp          LBB14_19, $-186(%rip)
+	LONG $0xffff46e9; BYTE $0xff                                         // jmp          LBB14_9, $-186(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_26:
+LBB14_16:
 	LONG $0x0040bf41; WORD $0x0000 // movl         $64, %r15d
 	LONG $0x0040b941; WORD $0x0000 // movl         $64, %r9d
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_28, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_18, $4(%rip)
 	LONG $0xcfbc0f4c               // bsfq         %rdi, %r9
 
-LBB14_28:
+LBB14_18:
 	LONG $0xc0bc0f49               // bsfq         %r8, %rax
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_30, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_20, $4(%rip)
 	LONG $0xf9bc0f4c               // bsfq         %rcx, %r15
 
-LBB14_30:
+LBB14_20:
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x031a820f; WORD $0x0000 // jb           LBB14_75, $794(%rip)
+	LONG $0x0299820f; WORD $0x0000 // jb           LBB14_60, $665(%rip)
 	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
-	LONG $0x024f830f; WORD $0x0000 // jae          LBB14_67, $591(%rip)
+	LONG $0x0250830f; WORD $0x0000 // jae          LBB14_57, $592(%rip)
 
-LBB14_32:
+LBB14_22:
 	WORD $0x014c; BYTE $0xde // addq         %r11, %rsi
 
-LBB14_33:
+LBB14_23:
 	WORD $0x014c; BYTE $0xfe                           // addq         %r15, %rsi
 	WORD $0x294d; BYTE $0xfd                           // subq         %r15, %r13
 	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_34:
+LBB14_24:
 	LONG $0x04fd8349                                                     // cmpq         $4, %r13
-	LONG $0x0324820f; WORD $0x0000                                       // jb           LBB14_79, $804(%rip)
+	LONG $0x02a3820f; WORD $0x0000                                       // jb           LBB14_64, $675(%rip)
 	WORD $0x068b                                                         // movl         (%rsi), %eax
 	WORD $0xc189                                                         // movl         %eax, %ecx
 	LONG $0xc0f0e181; WORD $0x00c0                                       // andl         $12632304, %ecx
 	LONG $0x80e0f981; WORD $0x0080                                       // cmpl         $8421600, %ecx
-	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_38, $48(%rip)
+	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_28, $48(%rip)
 	WORD $0xc789                                                         // movl         %eax, %edi
 	LONG $0x200fe781; WORD $0x0000                                       // andl         $8207, %edi
 	LONG $0x200dff81; WORD $0x0000                                       // cmpl         $8205, %edi
-	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_38, $28(%rip)
+	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_28, $28(%rip)
 	LONG $0x000003b9; BYTE $0x00                                         // movl         $3, %ecx
 	WORD $0xff85                                                         // testl        %edi, %edi
-	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_44, $109(%rip)
+	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_34, $109(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_38:
+LBB14_28:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0e0e181; WORD $0x0000 // andl         $49376, %ecx
 	LONG $0x80c0f981; WORD $0x0000 // cmpl         $32960, %ecx
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_40, $16(%rip)
-	WORD $0xc289                   // movl         %eax, %edx
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_30, $16(%rip)
+	WORD $0xc789                   // movl         %eax, %edi
 	LONG $0x000002b9; BYTE $0x00   // movl         $2, %ecx
-	WORD $0xe283; BYTE $0x1e       // andl         $30, %edx
-	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_44, $58(%rip)
+	WORD $0xe783; BYTE $0x1e       // andl         $30, %edi
+	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_34, $58(%rip)
 
-LBB14_40:
+LBB14_30:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0f8e181; WORD $0xc0c0 // andl         $-1061109512, %ecx
 	LONG $0x80f0f981; WORD $0x8080 // cmpl         $-2139062032, %ecx
-	LONG $0x03f6850f; WORD $0x0000 // jne          LBB14_106, $1014(%rip)
+	LONG $0x0390850f; WORD $0x0000 // jne          LBB14_91, $912(%rip)
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0x3007e181; WORD $0x0000 // andl         $12295, %ecx
-	LONG $0x03e8840f; WORD $0x0000 // je           LBB14_106, $1000(%rip)
+	LONG $0x0382840f; WORD $0x0000 // je           LBB14_91, $898(%rip)
 	LONG $0x000004b9; BYTE $0x00   // movl         $4, %ecx
 	WORD $0x04a8                   // testb        $4, %al
-	LONG $0x000b840f; WORD $0x0000 // je           LBB14_44, $11(%rip)
+	LONG $0x000b840f; WORD $0x0000 // je           LBB14_34, $11(%rip)
 	LONG $0x00300325; BYTE $0x00   // andl         $12291, %eax
-	LONG $0x03d0850f; WORD $0x0000 // jne          LBB14_106, $976(%rip)
+	LONG $0x036a850f; WORD $0x0000 // jne          LBB14_91, $874(%rip)
 
-LBB14_44:
+LBB14_34:
 	WORD $0x0148; BYTE $0xce       // addq         %rcx, %rsi
 	WORD $0x2949; BYTE $0xcd       // subq         %rcx, %r13
-	LONG $0xfd1b840f; WORD $0xffff // je           LBB14_14, $-741(%rip)
+	LONG $0xfd1b840f; WORD $0xffff // je           LBB14_4, $-741(%rip)
 	WORD $0x3e80; BYTE $0x00       // cmpb         $0, (%rsi)
-	LONG $0xff3d880f; WORD $0xffff // js           LBB14_34, $-195(%rip)
-	LONG $0xfffd0de9; BYTE $0xff   // jmp          LBB14_14, $-755(%rip)
+	LONG $0xff3d880f; WORD $0xffff // js           LBB14_24, $-195(%rip)
+	LONG $0xfffd0de9; BYTE $0xff   // jmp          LBB14_4, $-755(%rip)
 
-LBB14_46:
+LBB14_36:
 	LONG $0xf9bc0f4c             // bsfq         %rcx, %r15
-	LONG $0xffff1be9; BYTE $0xff // jmp          LBB14_32, $-229(%rip)
+	LONG $0xffff1be9; BYTE $0xff // jmp          LBB14_22, $-229(%rip)
 
-LBB14_47:
+LBB14_37:
 	WORD $0x014c; BYTE $0xde       // addq         %r11, %rsi
 	LONG $0x20fd8349               // cmpq         $32, %r13
-	LONG $0x0247820f; WORD $0x0000 // jb           LBB14_78, $583(%rip)
+	LONG $0x01c6820f; WORD $0x0000 // jb           LBB14_63, $454(%rip)
 
-LBB14_48:
+LBB14_38:
 	LONG $0x266ffac5               // vmovdqu      (%rsi), %xmm4
 	LONG $0x6e6ffac5; BYTE $0x10   // vmovdqu      $16(%rsi), %xmm5
 	LONG $0xc474b9c5               // vpcmpeqb     %xmm4, %xmm8, %xmm0
 	LONG $0xc8d779c5               // vpmovmskb    %xmm0, %r9d
 	LONG $0xc574b9c5               // vpcmpeqb     %xmm5, %xmm8, %xmm0
-	LONG $0xd0d7f9c5               // vpmovmskb    %xmm0, %edx
+	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
 	LONG $0xc474b1c5               // vpcmpeqb     %xmm4, %xmm9, %xmm0
 	LONG $0xc8d7f9c5               // vpmovmskb    %xmm0, %ecx
 	LONG $0xc574b1c5               // vpcmpeqb     %xmm5, %xmm9, %xmm0
-	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
 	LONG $0xc5d7f9c5               // vpmovmskb    %xmm5, %eax
-	LONG $0x10e2c148               // shlq         $16, %rdx
-	WORD $0x0949; BYTE $0xd1       // orq          %rdx, %r9
 	LONG $0x10e7c148               // shlq         $16, %rdi
+	WORD $0x0949; BYTE $0xf9       // orq          %rdi, %r9
+	LONG $0x10e3c148               // shlq         $16, %rbx
 	LONG $0x10e0c148               // shlq         $16, %rax
-	WORD $0x0948; BYTE $0xf9       // orq          %rdi, %rcx
-	LONG $0x00bf850f; WORD $0x0000 // jne          LBB14_64, $191(%rip)
+	WORD $0x0948; BYTE $0xd9       // orq          %rbx, %rcx
+	LONG $0x00bf850f; WORD $0x0000 // jne          LBB14_54, $191(%rip)
 	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
-	LONG $0x00da850f; WORD $0x0000 // jne          LBB14_66, $218(%rip)
+	LONG $0x00da850f; WORD $0x0000 // jne          LBB14_56, $218(%rip)
 	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
 
-LBB14_51:
+LBB14_41:
 	LONG $0xc564e9c5               // vpcmpgtb     %xmm5, %xmm2, %xmm0
 	LONG $0xcb64d1c5               // vpcmpgtb     %xmm3, %xmm5, %xmm1
 	LONG $0xc1dbf9c5               // vpand        %xmm1, %xmm0, %xmm0
 	LONG $0xc8d7f9c5               // vpmovmskb    %xmm0, %ecx
 	LONG $0x10e1c148               // shlq         $16, %rcx
-	LONG $0xd4d7f9c5               // vpmovmskb    %xmm4, %edx
-	WORD $0x0948; BYTE $0xd0       // orq          %rdx, %rax
+	LONG $0xfcd7f9c5               // vpmovmskb    %xmm4, %edi
+	WORD $0x0948; BYTE $0xf8       // orq          %rdi, %rax
 	LONG $0x0040bf41; WORD $0x0000 // movl         $64, %r15d
 	LONG $0x000040bf; BYTE $0x00   // movl         $64, %edi
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_53, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_43, $4(%rip)
 	LONG $0xf9bc0f49               // bsfq         %r9, %rdi
 
-LBB14_53:
+LBB14_43:
 	LONG $0xc464e9c5               // vpcmpgtb     %xmm4, %xmm2, %xmm0
 	LONG $0xcb64d9c5               // vpcmpgtb     %xmm3, %xmm4, %xmm1
 	LONG $0xc1dbf9c5               // vpand        %xmm1, %xmm0, %xmm0
-	LONG $0xd0d7f9c5               // vpmovmskb    %xmm0, %edx
-	WORD $0x0948; BYTE $0xd1       // orq          %rdx, %rcx
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	WORD $0x0948; BYTE $0xd9       // orq          %rbx, %rcx
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_55, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_45, $4(%rip)
 	LONG $0xf8bc0f4c               // bsfq         %rax, %r15
 
-LBB14_55:
+LBB14_45:
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x0009840f; WORD $0x0000 // je           LBB14_57, $9(%rip)
+	LONG $0x0009840f; WORD $0x0000 // je           LBB14_47, $9(%rip)
 	LONG $0xd9bc0f48               // bsfq         %rcx, %rbx
-	LONG $0x000005e9; BYTE $0x00   // jmp          LBB14_58, $5(%rip)
+	LONG $0x000005e9; BYTE $0x00   // jmp          LBB14_48, $5(%rip)
 
-LBB14_57:
+LBB14_47:
 	LONG $0x000040bb; BYTE $0x00 // movl         $64, %ebx
 
-LBB14_58:
+LBB14_48:
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0017840f; WORD $0x0000 // je           LBB14_61, $23(%rip)
+	LONG $0x0017840f; WORD $0x0000 // je           LBB14_51, $23(%rip)
 	WORD $0x3948; BYTE $0xfb       // cmpq         %rdi, %rbx
-	LONG $0x031e820f; WORD $0x0000 // jb           LBB14_113, $798(%rip)
+	LONG $0x029e820f; WORD $0x0000 // jb           LBB14_96, $670(%rip)
 	WORD $0x3949; BYTE $0xff       // cmpq         %rdi, %r15
-	LONG $0xfe3b820f; WORD $0xffff // jb           LBB14_33, $-453(%rip)
-	LONG $0x000153e9; BYTE $0x00   // jmp          LBB14_76, $339(%rip)
+	LONG $0xfe3b820f; WORD $0xffff // jb           LBB14_23, $-453(%rip)
+	LONG $0x0000d2e9; BYTE $0x00   // jmp          LBB14_61, $210(%rip)
 
-LBB14_61:
+LBB14_51:
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x0307850f; WORD $0x0000 // jne          LBB14_113, $775(%rip)
+	LONG $0x0287850f; WORD $0x0000 // jne          LBB14_96, $647(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0xfe24850f; WORD $0xffff // jne          LBB14_33, $-476(%rip)
-	LONG $0x00014de9; BYTE $0x00   // jmp          LBB14_77, $333(%rip)
+	LONG $0xfe24850f; WORD $0xffff // jne          LBB14_23, $-476(%rip)
+	LONG $0x0000cce9; BYTE $0x00   // jmp          LBB14_62, $204(%rip)
 
-LBB14_63:
+LBB14_53:
 	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
 	LONG $0x20fd8349               // cmpq         $32, %r13
-	LONG $0xff01830f; WORD $0xffff // jae          LBB14_48, $-255(%rip)
-	LONG $0x000143e9; BYTE $0x00   // jmp          LBB14_78, $323(%rip)
+	LONG $0xff01830f; WORD $0xffff // jae          LBB14_38, $-255(%rip)
+	LONG $0x0000c2e9; BYTE $0x00   // jmp          LBB14_63, $194(%rip)
 
-LBB14_64:
+LBB14_54:
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_66, $25(%rip)
-	WORD $0x8948; BYTE $0xf2       // movq         %rsi, %rdx
-	LONG $0xd0552b48               // subq         $-48(%rbp), %rdx
-	LONG $0xf9bc0f48               // bsfq         %rcx, %rdi
-	WORD $0x0148; BYTE $0xd7       // addq         %rdx, %rdi
-	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
-	LONG $0xc07d8948               // movq         %rdi, $-64(%rbp)
-	WORD $0x8948; BYTE $0x3a       // movq         %rdi, (%rdx)
+	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_56, $25(%rip)
+	WORD $0x8948; BYTE $0xf7       // movq         %rsi, %rdi
+	LONG $0xd07d2b48               // subq         $-48(%rbp), %rdi
+	LONG $0xd9bc0f48               // bsfq         %rcx, %rbx
+	WORD $0x0148; BYTE $0xfb       // addq         %rdi, %rbx
+	LONG $0xc05d8948               // movq         %rbx, $-64(%rbp)
+	LONG $0xc87d8b48               // movq         $-56(%rbp), %rdi
+	WORD $0x8948; BYTE $0x1f       // movq         %rbx, (%rdi)
 
-LBB14_66:
-	WORD $0x8944; BYTE $0xe2       // movl         %r12d, %edx
-	WORD $0xd2f7                   // notl         %edx
-	WORD $0xca21                   // andl         %ecx, %edx
-	LONG $0x543c8d41               // leal         (%r12,%rdx,2), %edi
-	WORD $0x1c8d; BYTE $0x12       // leal         (%rdx,%rdx), %ebx
+LBB14_56:
+	WORD $0x8944; BYTE $0xe7       // movl         %r12d, %edi
+	WORD $0xd7f7                   // notl         %edi
+	WORD $0xcf21                   // andl         %ecx, %edi
+	LONG $0x7c048d45               // leal         (%r12,%rdi,2), %r8d
+	WORD $0x1c8d; BYTE $0x3f       // leal         (%rdi,%rdi), %ebx
 	WORD $0xd3f7                   // notl         %ebx
 	WORD $0xcb21                   // andl         %ecx, %ebx
 	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
 	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
-	WORD $0xd301                   // addl         %edx, %ebx
+	WORD $0xfb01                   // addl         %edi, %ebx
 	LONG $0xc4920f41               // setb         %r12b
 	WORD $0xdb01                   // addl         %ebx, %ebx
 	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
-	WORD $0xfb21                   // andl         %edi, %ebx
+	WORD $0x2144; BYTE $0xc3       // andl         %r8d, %ebx
 	WORD $0xd3f7                   // notl         %ebx
 	WORD $0x2141; BYTE $0xd9       // andl         %ebx, %r9d
-	LONG $0xfffef4e9; BYTE $0xff   // jmp          LBB14_51, $-268(%rip)
+	LONG $0xfffef3e9; BYTE $0xff   // jmp          LBB14_41, $-269(%rip)
 
-LBB14_67:
+LBB14_57:
 	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xc6     // addq         %rax, %rsi
 	LONG $0x33048d49             // leaq         (%r11,%rsi), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000241e9; BYTE $0x00 // jmp          LBB14_108, $577(%rip)
+	LONG $0x0001dae9; BYTE $0x00 // jmp          LBB14_93, $474(%rip)
 
-LBB14_68:
+LBB14_58:
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
 	LONG $0xc07d8348; BYTE $0xff               // cmpq         $-1, $-64(%rbp)
-	LONG $0x022f850f; WORD $0x0000             // jne          LBB14_108, $559(%rip)
+	LONG $0x01c8850f; WORD $0x0000             // jne          LBB14_93, $456(%rip)
 	LONG $0xcfbc0f48                           // bsfq         %rdi, %rcx
 	LONG $0xd0752b48                           // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xce                   // addq         %rcx, %rsi
 	WORD $0x014c; BYTE $0xde                   // addq         %r11, %rsi
 	LONG $0xc84d8b48                           // movq         $-56(%rbp), %rcx
 	WORD $0x8948; BYTE $0x31                   // movq         %rsi, (%rcx)
-	LONG $0x000215e9; BYTE $0x00               // jmp          LBB14_108, $533(%rip)
+	LONG $0x0001aee9; BYTE $0x00               // jmp          LBB14_93, $430(%rip)
 
-LBB14_70:
-	WORD $0x014c; BYTE $0xf6       // addq         %r14, %rsi
-	LONG $0x20ff8349               // cmpq         $32, %r15
-	LONG $0x02b0820f; WORD $0x0000 // jb           LBB14_118, $688(%rip)
-
-LBB14_71:
-	LONG $0x066ffac5               // vmovdqu      (%rsi), %xmm0
-	LONG $0x4e6ffac5; BYTE $0x10   // vmovdqu      $16(%rsi), %xmm1
-	QUAD $0xfffff927156ff9c5       // vmovdqa      $-1753(%rip), %xmm2  /* LCPI14_0(%rip) */
-	QUAD $0xfffff92f1d6ff9c5       // vmovdqa      $-1745(%rip), %xmm3  /* LCPI14_1(%rip) */
-	LONG $0xe274f9c5               // vpcmpeqb     %xmm2, %xmm0, %xmm4
-	LONG $0xc4d7f9c5               // vpmovmskb    %xmm4, %eax
-	LONG $0xd274f1c5               // vpcmpeqb     %xmm2, %xmm1, %xmm2
-	LONG $0xcad7f9c5               // vpmovmskb    %xmm2, %ecx
-	LONG $0xc374f9c5               // vpcmpeqb     %xmm3, %xmm0, %xmm0
-	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
-	LONG $0xc374f1c5               // vpcmpeqb     %xmm3, %xmm1, %xmm0
-	LONG $0xd0d7f9c5               // vpmovmskb    %xmm0, %edx
-	LONG $0x10e1c148               // shlq         $16, %rcx
-	WORD $0x0948; BYTE $0xc8       // orq          %rcx, %rax
-	LONG $0x10e2c148               // shlq         $16, %rdx
-	WORD $0x0948; BYTE $0xd7       // orq          %rdx, %rdi
-	LONG $0x0200850f; WORD $0x0000 // jne          LBB14_114, $512(%rip)
-	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x021a850f; WORD $0x0000 // jne          LBB14_116, $538(%rip)
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0246840f; WORD $0x0000 // je           LBB14_117, $582(%rip)
-
-LBB14_74:
-	LONG $0xc0bc0f48             // bsfq         %rax, %rax
-	WORD $0x294c; BYTE $0xf6     // subq         %r14, %rsi
-	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
-	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000193e9; BYTE $0x00 // jmp          LBB14_108, $403(%rip)
-
-LBB14_75:
+LBB14_60:
 	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x014c; BYTE $0xce     // addq         %r9, %rsi
 	WORD $0x014c; BYTE $0xde     // addq         %r11, %rsi
-	LONG $0x000176e9; BYTE $0x00 // jmp          LBB14_107, $374(%rip)
+	LONG $0x000191e9; BYTE $0x00 // jmp          LBB14_92, $401(%rip)
 
-LBB14_76:
+LBB14_61:
 	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	LONG $0x3e048d48             // leaq         (%rsi,%rdi), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000173e9; BYTE $0x00 // jmp          LBB14_108, $371(%rip)
+	LONG $0x00018ee9; BYTE $0x00 // jmp          LBB14_93, $398(%rip)
 
-LBB14_77:
+LBB14_62:
 	LONG $0x20c68348 // addq         $32, %rsi
 	LONG $0xe0c58349 // addq         $-32, %r13
 
-LBB14_78:
+LBB14_63:
 	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
-	LONG $0x030f850f; WORD $0x0000 // jne          LBB14_139, $783(%rip)
+	LONG $0x01a8850f; WORD $0x0000 // jne          LBB14_97, $424(%rip)
 
-LBB14_79:
+LBB14_64:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x854d; BYTE $0xed                   // testq        %r13, %r13
+	LONG $0x016d840f; WORD $0x0000             // je           LBB14_93, $365(%rip)
 
-LBB14_80:
-	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x0152840f; WORD $0x0000 // je           LBB14_108, $338(%rip)
+LBB14_65:
+	LONG $0xc8558b48 // movq         $-56(%rbp), %rdx
+
+LBB14_66:
 	WORD $0xb60f; BYTE $0x0e       // movzbl       (%rsi), %ecx
 	WORD $0xf983; BYTE $0x22       // cmpl         $34, %ecx
-	LONG $0x0155840f; WORD $0x0000 // je           LBB14_109, $341(%rip)
+	LONG $0x016c840f; WORD $0x0000 // je           LBB14_94, $364(%rip)
 	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
-	LONG $0x00f7840f; WORD $0x0000 // je           LBB14_102, $247(%rip)
+	LONG $0x0109840f; WORD $0x0000 // je           LBB14_87, $265(%rip)
 	WORD $0xf980; BYTE $0x1f       // cmpb         $31, %cl
-	LONG $0x0122860f; WORD $0x0000 // jbe          LBB14_106, $290(%rip)
+	LONG $0x0139860f; WORD $0x0000 // jbe          LBB14_91, $313(%rip)
 	WORD $0xc984                   // testb        %cl, %cl
-	LONG $0x000d880f; WORD $0x0000 // js           LBB14_86, $13(%rip)
+	LONG $0x0016880f; WORD $0x0000 // js           LBB14_71, $22(%rip)
 	LONG $0x01c68348               // addq         $1, %rsi
 	LONG $0xffc58349               // addq         $-1, %r13
-	LONG $0xffffc4e9; BYTE $0xff   // jmp          LBB14_80, $-60(%rip)
+	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
+	LONG $0xffc9850f; WORD $0xffff // jne          LBB14_66, $-55(%rip)
+	LONG $0x00012de9; BYTE $0x00   // jmp          LBB14_93, $301(%rip)
 
-LBB14_86:
+LBB14_71:
 	LONG $0x04fd8349               // cmpq         $4, %r13
-	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_88, $7(%rip)
+	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_73, $7(%rip)
 	WORD $0x0e8b                   // movl         (%rsi), %ecx
-	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_92, $40(%rip)
+	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_77, $40(%rip)
 
-LBB14_88:
+LBB14_73:
 	LONG $0x02fd8349               // cmpq         $2, %r13
-	LONG $0x001b840f; WORD $0x0000 // je           LBB14_91, $27(%rip)
+	LONG $0x001b840f; WORD $0x0000 // je           LBB14_76, $27(%rip)
 	LONG $0x01fd8349               // cmpq         $1, %r13
-	LONG $0x0014840f; WORD $0x0000 // je           LBB14_92, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB14_77, $20(%rip)
 	LONG $0x024eb60f               // movzbl       $2(%rsi), %ecx
-	WORD $0xb70f; BYTE $0x16       // movzwl       (%rsi), %edx
+	WORD $0xb70f; BYTE $0x3e       // movzwl       (%rsi), %edi
 	WORD $0xe1c1; BYTE $0x10       // shll         $16, %ecx
-	WORD $0xd109                   // orl          %edx, %ecx
-	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_92, $3(%rip)
+	WORD $0xf909                   // orl          %edi, %ecx
+	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_77, $3(%rip)
 
-LBB14_91:
+LBB14_76:
 	WORD $0xb70f; BYTE $0x0e // movzwl       (%rsi), %ecx
 
-LBB14_92:
-	WORD $0xca89                   // movl         %ecx, %edx
-	LONG $0xc0f0e281; WORD $0x00c0 // andl         $12632304, %edx
-	LONG $0x80e0fa81; WORD $0x0080 // cmpl         $8421600, %edx
-	LONG $0x0021850f; WORD $0x0000 // jne          LBB14_95, $33(%rip)
+LBB14_77:
+	WORD $0xcf89                   // movl         %ecx, %edi
+	LONG $0xc0f0e781; WORD $0x00c0 // andl         $12632304, %edi
+	LONG $0x80e0ff81; WORD $0x0080 // cmpl         $8421600, %edi
+	LONG $0x0021850f; WORD $0x0000 // jne          LBB14_80, $33(%rip)
 	WORD $0xcb89                   // movl         %ecx, %ebx
 	LONG $0x200fe381; WORD $0x0000 // andl         $8207, %ebx
 	LONG $0x200dfb81; WORD $0x0000 // cmpl         $8205, %ebx
-	LONG $0x000d840f; WORD $0x0000 // je           LBB14_95, $13(%rip)
+	LONG $0x000d840f; WORD $0x0000 // je           LBB14_80, $13(%rip)
 	LONG $0x000003bf; BYTE $0x00   // movl         $3, %edi
 	WORD $0xdb85                   // testl        %ebx, %ebx
-	LONG $0x0060850f; WORD $0x0000 // jne          LBB14_101, $96(%rip)
+	LONG $0x0060850f; WORD $0x0000 // jne          LBB14_86, $96(%rip)
 
-LBB14_95:
-	WORD $0xca89                   // movl         %ecx, %edx
-	LONG $0xc0e0e281; WORD $0x0000 // andl         $49376, %edx
-	LONG $0x80c0fa81; WORD $0x0000 // cmpl         $32960, %edx
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_97, $16(%rip)
-	WORD $0xca89                   // movl         %ecx, %edx
+LBB14_80:
+	WORD $0xcf89                   // movl         %ecx, %edi
+	LONG $0xc0e0e781; WORD $0x0000 // andl         $49376, %edi
+	LONG $0x80c0ff81; WORD $0x0000 // cmpl         $32960, %edi
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_82, $16(%rip)
+	WORD $0xcb89                   // movl         %ecx, %ebx
 	LONG $0x000002bf; BYTE $0x00   // movl         $2, %edi
-	WORD $0xe283; BYTE $0x1e       // andl         $30, %edx
-	LONG $0x003c850f; WORD $0x0000 // jne          LBB14_101, $60(%rip)
+	WORD $0xe383; BYTE $0x1e       // andl         $30, %ebx
+	LONG $0x003c850f; WORD $0x0000 // jne          LBB14_86, $60(%rip)
 
-LBB14_97:
-	WORD $0xca89                   // movl         %ecx, %edx
-	LONG $0xc0f8e281; WORD $0xc0c0 // andl         $-1061109512, %edx
-	LONG $0x80f0fa81; WORD $0x8080 // cmpl         $-2139062032, %edx
-	LONG $0x0067850f; WORD $0x0000 // jne          LBB14_106, $103(%rip)
-	WORD $0xca89                   // movl         %ecx, %edx
-	LONG $0x3007e281; WORD $0x0000 // andl         $12295, %edx
-	LONG $0x0059840f; WORD $0x0000 // je           LBB14_106, $89(%rip)
+LBB14_82:
+	WORD $0xcf89                   // movl         %ecx, %edi
+	LONG $0xc0f8e781; WORD $0xc0c0 // andl         $-1061109512, %edi
+	LONG $0x80f0ff81; WORD $0x8080 // cmpl         $-2139062032, %edi
+	LONG $0x0075850f; WORD $0x0000 // jne          LBB14_91, $117(%rip)
+	WORD $0xcf89                   // movl         %ecx, %edi
+	LONG $0x3007e781; WORD $0x0000 // andl         $12295, %edi
+	LONG $0x0067840f; WORD $0x0000 // je           LBB14_91, $103(%rip)
 	LONG $0x000004bf; BYTE $0x00   // movl         $4, %edi
 	WORD $0xc1f6; BYTE $0x04       // testb        $4, %cl
-	LONG $0x000c840f; WORD $0x0000 // je           LBB14_101, $12(%rip)
+	LONG $0x000c840f; WORD $0x0000 // je           LBB14_86, $12(%rip)
 	LONG $0x3003e181; WORD $0x0000 // andl         $12291, %ecx
-	LONG $0x003f850f; WORD $0x0000 // jne          LBB14_106, $63(%rip)
+	LONG $0x004d850f; WORD $0x0000 // jne          LBB14_91, $77(%rip)
 
-LBB14_101:
-	WORD $0x0148; BYTE $0xfe     // addq         %rdi, %rsi
-	WORD $0x2949; BYTE $0xfd     // subq         %rdi, %r13
-	LONG $0xfffeebe9; BYTE $0xff // jmp          LBB14_80, $-277(%rip)
+LBB14_86:
+	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
+	WORD $0x2949; BYTE $0xfd       // subq         %rdi, %r13
+	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
+	LONG $0xfee7850f; WORD $0xffff // jne          LBB14_66, $-281(%rip)
+	LONG $0x00004be9; BYTE $0x00   // jmp          LBB14_93, $75(%rip)
 
-LBB14_102:
+LBB14_87:
 	LONG $0x01fd8349               // cmpq         $1, %r13
-	LONG $0x003c840f; WORD $0x0000 // je           LBB14_108, $60(%rip)
+	LONG $0x0041840f; WORD $0x0000 // je           LBB14_93, $65(%rip)
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_105, $18(%rip)
-	WORD $0x8948; BYTE $0xf2       // movq         %rsi, %rdx
-	LONG $0xd0552b48               // subq         $-48(%rbp), %rdx
-	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
-	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
+	LONG $0x000e850f; WORD $0x0000 // jne          LBB14_90, $14(%rip)
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	LONG $0xd04d2b48               // subq         $-48(%rbp), %rcx
+	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
+	WORD $0x8948; BYTE $0x0a       // movq         %rcx, (%rdx)
 
-LBB14_105:
-	LONG $0x02c68348             // addq         $2, %rsi
-	LONG $0xfec58349             // addq         $-2, %r13
-	LONG $0xfffeb7e9; BYTE $0xff // jmp          LBB14_80, $-329(%rip)
+LBB14_90:
+	LONG $0x02c68348               // addq         $2, %rsi
+	LONG $0xfec58349               // addq         $-2, %r13
+	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
+	LONG $0xfeae850f; WORD $0xffff // jne          LBB14_66, $-338(%rip)
+	LONG $0x000012e9; BYTE $0x00   // jmp          LBB14_93, $18(%rip)
 
-LBB14_106:
+LBB14_91:
 	LONG $0xd0752b48 // subq         $-48(%rbp), %rsi
 
-LBB14_107:
+LBB14_92:
 	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
 	WORD $0x8948; BYTE $0x30                   // movq         %rsi, (%rax)
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
 
-LBB14_108:
+LBB14_93:
 	LONG $0x18c48348 // addq         $24, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -5190,167 +5064,41 @@ LBB14_108:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB14_109:
+LBB14_94:
 	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	LONG $0x01c68348             // addq         $1, %rsi
-	LONG $0x000133e9; BYTE $0x00 // jmp          LBB14_131, $307(%rip)
+	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
+	LONG $0xffffe1e9; BYTE $0xff // jmp          LBB14_93, $-31(%rip)
 
-LBB14_112:
-	WORD $0x014c; BYTE $0xf6       // addq         %r14, %rsi
-	QUAD $0xffffffffd045c748       // movq         $-1, $-48(%rbp)
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	LONG $0x20ff8349               // cmpq         $32, %r15
-	LONG $0xfdc4830f; WORD $0xffff // jae          LBB14_71, $-572(%rip)
-	LONG $0x00006fe9; BYTE $0x00   // jmp          LBB14_118, $111(%rip)
-
-LBB14_113:
+LBB14_96:
 	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xde     // addq         %rbx, %rsi
-	LONG $0xffffade9; BYTE $0xff // jmp          LBB14_107, $-83(%rip)
+	LONG $0xffffc7e9; BYTE $0xff // jmp          LBB14_92, $-57(%rip)
 
-LBB14_114:
-	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
-	LONG $0x0018850f; WORD $0x0000 // jne          LBB14_116, $24(%rip)
-	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
-	WORD $0x294c; BYTE $0xf1       // subq         %r14, %rcx
-	LONG $0xd7bc0f48               // bsfq         %rdi, %rdx
-	WORD $0x0148; BYTE $0xca       // addq         %rcx, %rdx
-	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
-	LONG $0xd0558948               // movq         %rdx, $-48(%rbp)
-	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
-
-LBB14_116:
-	WORD $0x8944; BYTE $0xd9       // movl         %r11d, %ecx
-	WORD $0xd1f7                   // notl         %ecx
-	WORD $0xf921                   // andl         %edi, %ecx
-	LONG $0x4b148d41               // leal         (%r11,%rcx,2), %edx
-	WORD $0x1c8d; BYTE $0x09       // leal         (%rcx,%rcx), %ebx
-	WORD $0xd3f7                   // notl         %ebx
-	WORD $0xfb21                   // andl         %edi, %ebx
-	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	WORD $0xcb01                   // addl         %ecx, %ebx
-	LONG $0xc3920f41               // setb         %r11b
-	WORD $0xdb01                   // addl         %ebx, %ebx
-	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
-	WORD $0xd321                   // andl         %edx, %ebx
-	WORD $0xd3f7                   // notl         %ebx
-	WORD $0xd821                   // andl         %ebx, %eax
-	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0xfdba850f; WORD $0xffff // jne          LBB14_74, $-582(%rip)
-
-LBB14_117:
-	LONG $0x20c68348 // addq         $32, %rsi
-	LONG $0xe0c78349 // addq         $-32, %r15
-
-LBB14_118:
-	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x00be850f; WORD $0x0000 // jne          LBB14_134, $190(%rip)
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0092840f; WORD $0x0000 // je           LBB14_130, $146(%rip)
-
-LBB14_120:
-	WORD $0x894c; BYTE $0xf7                   // movq         %r14, %rdi
-	WORD $0xf748; BYTE $0xd7                   // notq         %rdi
-	LONG $0x01c78348                           // addq         $1, %rdi
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-
-LBB14_121:
-	WORD $0xdb31 // xorl         %ebx, %ebx
-
-LBB14_122:
-	LONG $0x1e0cb60f               // movzbl       (%rsi,%rbx), %ecx
-	WORD $0xf980; BYTE $0x22       // cmpb         $34, %cl
-	LONG $0x006b840f; WORD $0x0000 // je           LBB14_129, $107(%rip)
-	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
-	LONG $0x0012840f; WORD $0x0000 // je           LBB14_125, $18(%rip)
-	LONG $0x01c38348               // addq         $1, %rbx
-	WORD $0x3949; BYTE $0xdf       // cmpq         %rbx, %r15
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB14_122, $-35(%rip)
-	LONG $0x000062e9; BYTE $0x00   // jmp          LBB14_132, $98(%rip)
-
-LBB14_125:
-	LONG $0xff4f8d49               // leaq         $-1(%r15), %rcx
-	WORD $0x3948; BYTE $0xd9       // cmpq         %rbx, %rcx
-	LONG $0xfefe840f; WORD $0xffff // je           LBB14_108, $-258(%rip)
-	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_128, $18(%rip)
-	LONG $0x37148d48               // leaq         (%rdi,%rsi), %rdx
-	WORD $0x0148; BYTE $0xda       // addq         %rbx, %rdx
-	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
-	LONG $0xd0558948               // movq         %rdx, $-48(%rbp)
-	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
-
-LBB14_128:
-	WORD $0x0148; BYTE $0xde       // addq         %rbx, %rsi
-	LONG $0x02c68348               // addq         $2, %rsi
-	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
-	WORD $0x2948; BYTE $0xd9       // subq         %rbx, %rcx
-	LONG $0xfec18348               // addq         $-2, %rcx
-	LONG $0xfec78349               // addq         $-2, %r15
-	WORD $0x3949; BYTE $0xdf       // cmpq         %rbx, %r15
-	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
-	LONG $0xff8b850f; WORD $0xffff // jne          LBB14_121, $-117(%rip)
-	LONG $0xfffebbe9; BYTE $0xff   // jmp          LBB14_108, $-325(%rip)
-
-LBB14_129:
-	WORD $0x0148; BYTE $0xde // addq         %rbx, %rsi
-	LONG $0x01c68348         // addq         $1, %rsi
-
-LBB14_130:
-	WORD $0x294c; BYTE $0xf6 // subq         %r14, %rsi
-
-LBB14_131:
-	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
-	LONG $0xfffea9e9; BYTE $0xff // jmp          LBB14_108, $-343(%rip)
-
-LBB14_132:
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	WORD $0xf980; BYTE $0x22                   // cmpb         $34, %cl
-	LONG $0xfe99850f; WORD $0xffff             // jne          LBB14_108, $-359(%rip)
-	WORD $0x014c; BYTE $0xfe                   // addq         %r15, %rsi
-	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB14_130, $-35(%rip)
-
-LBB14_134:
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x006b840f; WORD $0x0000 // je           LBB14_111, $107(%rip)
-	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
-	LONG $0x0014850f; WORD $0x0000 // jne          LBB14_137, $20(%rip)
-	WORD $0x894c; BYTE $0xf1       // movq         %r14, %rcx
-	WORD $0xf748; BYTE $0xd1       // notq         %rcx
-	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
-	LONG $0xd04d8948               // movq         %rcx, $-48(%rbp)
-	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
-
-LBB14_137:
-	LONG $0x01c68348               // addq         $1, %rsi
-	LONG $0xffc78349               // addq         $-1, %r15
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0xff12850f; WORD $0xffff // jne          LBB14_120, $-238(%rip)
-	LONG $0xffff9fe9; BYTE $0xff   // jmp          LBB14_130, $-97(%rip)
-
-LBB14_139:
+LBB14_97:
 	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x002d840f; WORD $0x0000 // je           LBB14_111, $45(%rip)
+	LONG $0x003d840f; WORD $0x0000 // je           LBB14_95, $61(%rip)
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_142, $21(%rip)
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	WORD $0xf748; BYTE $0xd1       // notq         %rcx
-	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
-	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_100, $21(%rip)
+	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
+	WORD $0xf748; BYTE $0xd0       // notq         %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xc0458948               // movq         %rax, $-64(%rbp)
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	WORD $0x8948; BYTE $0x01       // movq         %rax, (%rcx)
 
-LBB14_142:
-	LONG $0x01c68348             // addq         $1, %rsi
-	LONG $0xffc58349             // addq         $-1, %r13
-	LONG $0xfffcbbe9; BYTE $0xff // jmp          LBB14_79, $-837(%rip)
-
-LBB14_111:
+LBB14_100:
+	LONG $0x01c68348                           // addq         $1, %rsi
+	LONG $0xffc58349                           // addq         $-1, %r13
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0xfffe11e9; BYTE $0xff               // jmp          LBB14_108, $-495(%rip)
-	BYTE $0x00                                 // .p2align 4, 0x00
+	WORD $0x854d; BYTE $0xed                   // testq        %r13, %r13
+	LONG $0xfe27850f; WORD $0xffff             // jne          LBB14_65, $-473(%rip)
+	LONG $0xffff8fe9; BYTE $0xff               // jmp          LBB14_93, $-113(%rip)
+
+LBB14_95:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xffff83e9; BYTE $0xff               // jmp          LBB14_93, $-125(%rip)
+	QUAD $0x0000000000000000; BYTE $0x00       // .p2align 4, 0x00
 
 LCPI15_0:
 	LONG $0x43300000 // .long 1127219200
@@ -5733,7 +5481,7 @@ LBB15_61:
 	WORD $0xfe83; BYTE $0x17                   // cmpl         $23, %esi
 	LONG $0x003f8c0f; WORD $0x0000             // jl           LBB15_70, $63(%rip)
 	WORD $0x468d; BYTE $0xea                   // leal         $-22(%rsi), %eax
-	LONG $0x160d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50454(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0xe60d8d48; WORD $0x00db; BYTE $0x00 // leaq         $56294(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x000016b8; BYTE $0x00               // movl         $22, %eax
@@ -5743,7 +5491,7 @@ LBB15_67:
 	WORD $0xfe83; BYTE $0xea                   // cmpl         $-22, %esi
 	LONG $0x0052820f; WORD $0x0000             // jb           LBB15_74, $82(%rip)
 	WORD $0xdef7                               // negl         %esi
-	LONG $0xf0058d48; WORD $0x00c4; BYTE $0x00 // leaq         $50416(%rip), %rax  /* _P10_TAB(%rip) */
+	LONG $0xc0058d48; WORD $0x00db; BYTE $0x00 // leaq         $56256(%rip), %rax  /* _P10_TAB(%rip) */
 	LONG $0x045efbc5; BYTE $0xf0               // vdivsd       (%rax,%rsi,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x00009de9; BYTE $0x00               // jmp          LBB15_78, $157(%rip)
@@ -5758,7 +5506,7 @@ LBB15_71:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	LONG $0x0018870f; WORD $0x0000             // ja           LBB15_74, $24(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xb60d8d48; WORD $0x00c4; BYTE $0x00 // leaq         $50358(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x860d8d48; WORD $0x00db; BYTE $0x00 // leaq         $56198(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x000063e9; BYTE $0x00               // jmp          LBB15_78, $99(%rip)
@@ -5769,7 +5517,7 @@ LBB15_74:
 	LONG $0xc04d8d48               // leaq         $-64(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	LONG $0xa8758948               // movq         %rsi, $-88(%rbp)
-	LONG $0xffdf7fe8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8321(%rip)
+	LONG $0xffe2bfe8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-7489(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x004d840f; WORD $0x0000 // je           LBB15_80, $77(%rip)
 	LONG $0xa8758b48               // movq         $-88(%rbp), %rsi
@@ -5779,7 +5527,7 @@ LBB15_74:
 	LONG $0xb04d8d48               // leaq         $-80(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	WORD $0x558b; BYTE $0xd4       // movl         $-44(%rbp), %edx
-	LONG $0xffdf56e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8362(%rip)
+	LONG $0xffe296e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-7530(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x0024840f; WORD $0x0000 // je           LBB15_80, $36(%rip)
 	LONG $0x4d10fbc5; BYTE $0xb0   // vmovsd       $-80(%rbp), %xmm1
@@ -5800,7 +5548,7 @@ LBB15_80:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	LONG $0xc8558b48             // movq         $-56(%rbp), %rdx
 	LONG $0xa04d8b48             // movq         $-96(%rbp), %rcx
-	LONG $0xffe45ee8; BYTE $0xff // callq        _atof_native, $-7074(%rip)
+	LONG $0xffe79ee8; BYTE $0xff // callq        _atof_native, $-6242(%rip)
 	LONG $0x4511fbc5; BYTE $0xc0 // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x7ef9e1c4; BYTE $0xc0 // vmovq        %xmm0, %rax
 	LONG $0x000009e9; BYTE $0x00 // jmp          LBB15_83, $9(%rip)
@@ -6075,17 +5823,18 @@ LBB17_9:
 	BYTE $0xc3               // retq
 	WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-_skip_one:
-	BYTE $0x55                                 // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
-	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
-	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
-	BYTE $0x5d                                 // popq         %rbp
-	LONG $0x000003e9; BYTE $0x00               // jmp          _fsm_exec, $3(%rip)
-	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
+_skip_array:
+	BYTE $0x55                                             // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
+	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
+	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
+	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
+	BYTE $0x5d                                             // popq         %rbp
+	LONG $0x00000de9; BYTE $0x00                           // jmp          _fsm_exec, $13(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _fsm_exec:
 	BYTE $0x55                                 // pushq        %rbp
@@ -6126,7 +5875,7 @@ LBB19_4:
 	LONG $0x007d8b49               // movq         (%r13), %rdi
 	LONG $0x08758b49               // movq         $8(%r13), %rsi
 	WORD $0x894c; BYTE $0xe2       // movq         %r12, %rdx
-	LONG $0xffe8d1e8; BYTE $0xff   // callq        _advance_ns, $-5935(%rip)
+	LONG $0xffec01e8; BYTE $0xff   // callq        _advance_ns, $-5119(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x03a7840f; WORD $0x0000 // je           LBB19_57, $935(%rip)
 	WORD $0x6349; BYTE $0x17       // movslq       (%r15), %rdx
@@ -6186,7 +5935,7 @@ LBB19_18:
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
-	LONG $0xffeb1be8; BYTE $0xff   // callq        _advance_string, $-5349(%rip)
+	LONG $0xffee4be8; BYTE $0xff   // callq        _advance_string, $-4533(%rip)
 	WORD $0x8949; BYTE $0xc5       // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0xfef7880f; WORD $0xffff // js           LBB19_2, $-265(%rip)
@@ -6243,7 +5992,7 @@ LBB19_29:
 	WORD $0x014c; BYTE $0xef                   // addq         %r13, %rdi
 	LONG $0x08708b48                           // movq         $8(%rax), %rsi
 	WORD $0x294c; BYTE $0xee                   // subq         %r13, %rsi
-	LONG $0x0006c0e8; BYTE $0x00               // callq        _do_skip_number, $1728(%rip)
+	LONG $0x000690e8; BYTE $0x00               // callq        _do_skip_number, $1680(%rip)
 	LONG $0xff488d48                           // leaq         $-1(%rax), %rcx
 	LONG $0xfec2c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rdx
 	WORD $0x2948; BYTE $0xc2                   // subq         %rax, %rdx
@@ -6281,7 +6030,7 @@ LBB19_34:
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
-	LONG $0xffe9c8e8; BYTE $0xff   // callq        _advance_string, $-5688(%rip)
+	LONG $0xffecf8e8; BYTE $0xff   // callq        _advance_string, $-4872(%rip)
 	WORD $0x8949; BYTE $0xc5       // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0009890f; WORD $0x0000 // jns          LBB19_36, $9(%rip)
@@ -6318,7 +6067,7 @@ LBB19_41:
 	WORD $0x014c; BYTE $0xef       // addq         %r13, %rdi
 	LONG $0x08708b48               // movq         $8(%rax), %rsi
 	WORD $0x294c; BYTE $0xee       // subq         %r13, %rsi
-	LONG $0x0005aee8; BYTE $0x00   // callq        _do_skip_number, $1454(%rip)
+	LONG $0x00057ee8; BYTE $0x00   // callq        _do_skip_number, $1406(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0148880f; WORD $0x0000 // js           LBB19_62, $328(%rip)
 	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
@@ -6636,19 +6385,6 @@ LJTI19_1:
 	LONG $0xfffffec7                           // .long L19_1_set_53
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
-_skip_array:
-	BYTE $0x55                                             // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
-	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
-	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
-	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
-	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff8ade9; BYTE $0xff                           // jmp          _fsm_exec, $-1875(%rip)
-	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
-
 _skip_object:
 	BYTE $0x55                                             // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
@@ -6659,7 +6395,7 @@ _skip_object:
 	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
 	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
 	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff87de9; BYTE $0xff                           // jmp          _fsm_exec, $-1923(%rip)
+	LONG $0xfff8ade9; BYTE $0xff                           // jmp          _fsm_exec, $-1875(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _skip_string:
@@ -6673,18 +6409,18 @@ _skip_string:
 	WORD $0x8b48; BYTE $0x1e       // movq         (%rsi), %rbx
 	LONG $0xe8558d48               // leaq         $-24(%rbp), %rdx
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
-	LONG $0xffe4a0e8; BYTE $0xff   // callq        _advance_string, $-7008(%rip)
+	LONG $0xffe800e8; BYTE $0xff   // callq        _advance_string, $-6144(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0009890f; WORD $0x0000 // jns          LBB22_1, $9(%rip)
+	LONG $0x0009890f; WORD $0x0000 // jns          LBB21_1, $9(%rip)
 	LONG $0xe84d8b48               // movq         $-24(%rbp), %rcx
-	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB22_3, $10(%rip)
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB21_3, $10(%rip)
 
-LBB22_1:
+LBB21_1:
 	LONG $0xffc38348         // addq         $-1, %rbx
 	WORD $0x8948; BYTE $0xc1 // movq         %rax, %rcx
 	WORD $0x8948; BYTE $0xd8 // movq         %rbx, %rax
 
-LBB22_3:
+LBB21_3:
 	WORD $0x8949; BYTE $0x0e // movq         %rcx, (%r14)
 	LONG $0x10c48348         // addq         $16, %rsp
 	BYTE $0x5b               // popq         %rbx
@@ -6707,19 +6443,19 @@ _skip_negative:
 	WORD $0x8948; BYTE $0xc7       // movq         %rax, %rdi
 	LONG $0x0000aee8; BYTE $0x00   // callq        _do_skip_number, $174(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x000f880f; WORD $0x0000 // js           LBB23_1, $15(%rip)
+	LONG $0x000f880f; WORD $0x0000 // js           LBB22_1, $15(%rip)
 	WORD $0x0148; BYTE $0xd8       // addq         %rbx, %rax
 	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
 	LONG $0xffc38348               // addq         $-1, %rbx
-	LONG $0x000010e9; BYTE $0x00   // jmp          LBB23_3, $16(%rip)
+	LONG $0x000010e9; BYTE $0x00   // jmp          LBB22_3, $16(%rip)
 
-LBB23_1:
+LBB22_1:
 	WORD $0xf748; BYTE $0xd0                   // notq         %rax
 	WORD $0x0148; BYTE $0xc3                   // addq         %rax, %rbx
 	WORD $0x8949; BYTE $0x1e                   // movq         %rbx, (%r14)
 	LONG $0xfec3c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rbx
 
-LBB23_3:
+LBB22_3:
 	WORD $0x8948; BYTE $0xd8                                 // movq         %rbx, %rax
 	BYTE $0x5b                                               // popq         %rbx
 	WORD $0x5e41                                             // popq         %r14
@@ -6727,25 +6463,25 @@ LBB23_3:
 	BYTE $0xc3                                               // retq
 	QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 4, 0x00
 
-LCPI24_0:
+LCPI23_0:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI24_1:
+LCPI23_1:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI24_2:
+LCPI23_2:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI24_3:
+LCPI23_3:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI24_4:
+LCPI23_4:
 	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
 
-LCPI24_5:
+LCPI23_5:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI24_6:
+LCPI23_6:
 	QUAD $0x4545454545454545; QUAD $0x4545454545454545 // .space 16, 'EEEEEEEEEEEEEEEE'
 
 	// .p2align 4, 0x90
@@ -6756,39 +6492,39 @@ _do_skip_number:
 	WORD $0x5641                           // pushq        %r14
 	BYTE $0x53                             // pushq        %rbx
 	WORD $0x8548; BYTE $0xf6               // testq        %rsi, %rsi
-	LONG $0x0236840f; WORD $0x0000         // je           LBB24_1, $566(%rip)
+	LONG $0x0236840f; WORD $0x0000         // je           LBB23_1, $566(%rip)
 	WORD $0x3f80; BYTE $0x30               // cmpb         $48, (%rdi)
-	LONG $0x0035850f; WORD $0x0000         // jne          LBB24_6, $53(%rip)
+	LONG $0x0035850f; WORD $0x0000         // jne          LBB23_6, $53(%rip)
 	LONG $0x000001b8; BYTE $0x00           // movl         $1, %eax
 	LONG $0x01fe8348                       // cmpq         $1, %rsi
-	LONG $0x02b9840f; WORD $0x0000         // je           LBB24_55, $697(%rip)
+	LONG $0x02b9840f; WORD $0x0000         // je           LBB23_55, $697(%rip)
 	WORD $0x4f8a; BYTE $0x01               // movb         $1(%rdi), %cl
 	WORD $0xc180; BYTE $0xd2               // addb         $-46, %cl
 	WORD $0xf980; BYTE $0x37               // cmpb         $55, %cl
-	LONG $0x02aa870f; WORD $0x0000         // ja           LBB24_55, $682(%rip)
+	LONG $0x02aa870f; WORD $0x0000         // ja           LBB23_55, $682(%rip)
 	WORD $0xb60f; BYTE $0xc9               // movzbl       %cl, %ecx
 	QUAD $0x000000800001ba48; WORD $0x0080 // movabsq      $36028797027352577, %rdx
 	LONG $0xcaa30f48                       // btq          %rcx, %rdx
-	LONG $0x0293830f; WORD $0x0000         // jae          LBB24_55, $659(%rip)
+	LONG $0x0293830f; WORD $0x0000         // jae          LBB23_55, $659(%rip)
 
-LBB24_6:
+LBB23_6:
 	LONG $0x10fe8348                           // cmpq         $16, %rsi
-	LONG $0x02f2820f; WORD $0x0000             // jb           LBB24_7, $754(%rip)
+	LONG $0x02f2820f; WORD $0x0000             // jb           LBB23_7, $754(%rip)
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
 	WORD $0xc031                               // xorl         %eax, %eax
-	QUAD $0xffffff25056f79c5                   // vmovdqa      $-219(%rip), %xmm8  /* LCPI24_0(%rip) */
-	QUAD $0xffffff2d0d6f79c5                   // vmovdqa      $-211(%rip), %xmm9  /* LCPI24_1(%rip) */
-	QUAD $0xffffff35156f79c5                   // vmovdqa      $-203(%rip), %xmm10  /* LCPI24_2(%rip) */
-	QUAD $0xffffff3d1d6f79c5                   // vmovdqa      $-195(%rip), %xmm11  /* LCPI24_3(%rip) */
-	QUAD $0xffffff45256ff9c5                   // vmovdqa      $-187(%rip), %xmm4  /* LCPI24_4(%rip) */
-	QUAD $0xffffff4d2d6ff9c5                   // vmovdqa      $-179(%rip), %xmm5  /* LCPI24_5(%rip) */
-	QUAD $0xffffff55356ff9c5                   // vmovdqa      $-171(%rip), %xmm6  /* LCPI24_6(%rip) */
+	QUAD $0xffffff25056f79c5                   // vmovdqa      $-219(%rip), %xmm8  /* LCPI23_0(%rip) */
+	QUAD $0xffffff2d0d6f79c5                   // vmovdqa      $-211(%rip), %xmm9  /* LCPI23_1(%rip) */
+	QUAD $0xffffff35156f79c5                   // vmovdqa      $-203(%rip), %xmm10  /* LCPI23_2(%rip) */
+	QUAD $0xffffff3d1d6f79c5                   // vmovdqa      $-195(%rip), %xmm11  /* LCPI23_3(%rip) */
+	QUAD $0xffffff45256ff9c5                   // vmovdqa      $-187(%rip), %xmm4  /* LCPI23_4(%rip) */
+	QUAD $0xffffff4d2d6ff9c5                   // vmovdqa      $-179(%rip), %xmm5  /* LCPI23_5(%rip) */
+	QUAD $0xffffff55356ff9c5                   // vmovdqa      $-171(%rip), %xmm6  /* LCPI23_6(%rip) */
 	LONG $0xffc1c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r9
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
 	LONG $0x90909090                           // .p2align 4, 0x90
 
-LBB24_9:
+LBB23_9:
 	LONG $0x3c6ffac5; BYTE $0x07   // vmovdqu      (%rdi,%rax), %xmm7
 	LONG $0x6441c1c4; BYTE $0xc0   // vpcmpgtb     %xmm8, %xmm7, %xmm0
 	LONG $0xcf64b1c5               // vpcmpgtb     %xmm7, %xmm9, %xmm1
@@ -6809,7 +6545,7 @@ LBB24_9:
 	WORD $0xd1f7                   // notl         %ecx
 	WORD $0xbc0f; BYTE $0xc9       // bsfl         %ecx, %ecx
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_11, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_11, $20(%rip)
 	LONG $0xffffffbb; BYTE $0xff   // movl         $-1, %ebx
 	WORD $0xe3d3                   // shll         %cl, %ebx
 	WORD $0xd3f7                   // notl         %ebx
@@ -6818,168 +6554,168 @@ LBB24_9:
 	WORD $0x2144; BYTE $0xdb       // andl         %r11d, %ebx
 	WORD $0x8941; BYTE $0xdb       // movl         %ebx, %r11d
 
-LBB24_11:
+LBB23_11:
 	WORD $0x5a8d; BYTE $0xff       // leal         $-1(%rdx), %ebx
 	WORD $0xd321                   // andl         %edx, %ebx
-	LONG $0x0206850f; WORD $0x0000 // jne          LBB24_12, $518(%rip)
+	LONG $0x0206850f; WORD $0x0000 // jne          LBB23_12, $518(%rip)
 	LONG $0xff5f8d41               // leal         $-1(%r15), %ebx
 	WORD $0x2144; BYTE $0xfb       // andl         %r15d, %ebx
-	LONG $0x01f9850f; WORD $0x0000 // jne          LBB24_12, $505(%rip)
+	LONG $0x01f9850f; WORD $0x0000 // jne          LBB23_12, $505(%rip)
 	LONG $0xff5b8d41               // leal         $-1(%r11), %ebx
 	WORD $0x2144; BYTE $0xdb       // andl         %r11d, %ebx
-	LONG $0x01ec850f; WORD $0x0000 // jne          LBB24_12, $492(%rip)
+	LONG $0x01ec850f; WORD $0x0000 // jne          LBB23_12, $492(%rip)
 	WORD $0xd285                   // testl        %edx, %edx
-	LONG $0x0013840f; WORD $0x0000 // je           LBB24_19, $19(%rip)
+	LONG $0x0013840f; WORD $0x0000 // je           LBB23_19, $19(%rip)
 	WORD $0xbc0f; BYTE $0xd2       // bsfl         %edx, %edx
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x01ed850f; WORD $0x0000 // jne          LBB24_56, $493(%rip)
+	LONG $0x01ed850f; WORD $0x0000 // jne          LBB23_56, $493(%rip)
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd0       // movq         %rdx, %r8
 
-LBB24_19:
+LBB23_19:
 	WORD $0x8545; BYTE $0xff       // testl        %r15d, %r15d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_22, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_22, $20(%rip)
 	LONG $0xd7bc0f41               // bsfl         %r15d, %edx
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x01d0850f; WORD $0x0000 // jne          LBB24_56, $464(%rip)
+	LONG $0x01d0850f; WORD $0x0000 // jne          LBB23_56, $464(%rip)
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd1       // movq         %rdx, %r9
 
-LBB24_22:
+LBB23_22:
 	WORD $0x8545; BYTE $0xdb       // testl        %r11d, %r11d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_25, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_25, $20(%rip)
 	LONG $0xd3bc0f41               // bsfl         %r11d, %edx
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x01b3850f; WORD $0x0000 // jne          LBB24_56, $435(%rip)
+	LONG $0x01b3850f; WORD $0x0000 // jne          LBB23_56, $435(%rip)
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd2       // movq         %rdx, %r10
 
-LBB24_25:
+LBB23_25:
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x00b9850f; WORD $0x0000 // jne          LBB24_57, $185(%rip)
+	LONG $0x00b9850f; WORD $0x0000 // jne          LBB23_57, $185(%rip)
 	LONG $0xf0c68349               // addq         $-16, %r14
 	LONG $0x10c08348               // addq         $16, %rax
 	LONG $0x0ffe8349               // cmpq         $15, %r14
-	LONG $0xff03870f; WORD $0xffff // ja           LBB24_9, $-253(%rip)
+	LONG $0xff03870f; WORD $0xffff // ja           LBB23_9, $-253(%rip)
 	LONG $0x070c8d48               // leaq         (%rdi,%rax), %rcx
 	WORD $0x8949; BYTE $0xcb       // movq         %rcx, %r11
 	WORD $0x3948; BYTE $0xf0       // cmpq         %rsi, %rax
-	LONG $0x00a0840f; WORD $0x0000 // je           LBB24_41, $160(%rip)
+	LONG $0x00a0840f; WORD $0x0000 // je           LBB23_41, $160(%rip)
 
-LBB24_28:
+LBB23_28:
 	LONG $0x311c8d4e                           // leaq         (%rcx,%r14), %r11
 	WORD $0x8948; BYTE $0xce                   // movq         %rcx, %rsi
 	WORD $0x2948; BYTE $0xfe                   // subq         %rdi, %rsi
 	WORD $0xc031                               // xorl         %eax, %eax
-	LONG $0x9c3d8d4c; WORD $0x0001; BYTE $0x00 // leaq         $412(%rip), %r15  /* LJTI24_0(%rip) */
-	LONG $0x000028e9; BYTE $0x00               // jmp          LBB24_29, $40(%rip)
+	LONG $0x9c3d8d4c; WORD $0x0001; BYTE $0x00 // leaq         $412(%rip), %r15  /* LJTI23_0(%rip) */
+	LONG $0x000028e9; BYTE $0x00               // jmp          LBB23_29, $40(%rip)
 
-LBB24_31:
+LBB23_31:
 	WORD $0xfa83; BYTE $0x65       // cmpl         $101, %edx
-	LONG $0x0094850f; WORD $0x0000 // jne          LBB24_40, $148(%rip)
+	LONG $0x0094850f; WORD $0x0000 // jne          LBB23_40, $148(%rip)
 
-LBB24_32:
+LBB23_32:
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x0149850f; WORD $0x0000 // jne          LBB24_58, $329(%rip)
+	LONG $0x0149850f; WORD $0x0000 // jne          LBB23_58, $329(%rip)
 	LONG $0x060c8d4c               // leaq         (%rsi,%rax), %r9
 	LONG $0x90909090               // .p2align 4, 0x90
 
-LBB24_39:
+LBB23_39:
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x3949; BYTE $0xc6       // cmpq         %rax, %r14
-	LONG $0x0060840f; WORD $0x0000 // je           LBB24_41, $96(%rip)
+	LONG $0x0060840f; WORD $0x0000 // je           LBB23_41, $96(%rip)
 
-LBB24_29:
+LBB23_29:
 	LONG $0x0114be0f               // movsbl       (%rcx,%rax), %edx
 	WORD $0x5a8d; BYTE $0xd0       // leal         $-48(%rdx), %ebx
 	WORD $0xfb83; BYTE $0x0a       // cmpl         $10, %ebx
-	LONG $0xffe3820f; WORD $0xffff // jb           LBB24_39, $-29(%rip)
+	LONG $0xffe3820f; WORD $0xffff // jb           LBB23_39, $-29(%rip)
 	WORD $0x5a8d; BYTE $0xd5       // leal         $-43(%rdx), %ebx
 	WORD $0xfb83; BYTE $0x1a       // cmpl         $26, %ebx
-	LONG $0xffbc870f; WORD $0xffff // ja           LBB24_31, $-68(%rip)
+	LONG $0xffbc870f; WORD $0xffff // ja           LBB23_31, $-68(%rip)
 	LONG $0x9f146349               // movslq       (%r15,%rbx,4), %rdx
 	WORD $0x014c; BYTE $0xfa       // addq         %r15, %rdx
 	JMP  DX
 
-LBB24_37:
+LBB23_37:
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x0105850f; WORD $0x0000 // jne          LBB24_58, $261(%rip)
+	LONG $0x0105850f; WORD $0x0000 // jne          LBB23_58, $261(%rip)
 	LONG $0x06148d4c               // leaq         (%rsi,%rax), %r10
-	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB24_39, $-69(%rip)
+	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB23_39, $-69(%rip)
 
-LBB24_35:
+LBB23_35:
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x00f2850f; WORD $0x0000 // jne          LBB24_58, $242(%rip)
+	LONG $0x00f2850f; WORD $0x0000 // jne          LBB23_58, $242(%rip)
 	LONG $0x06048d4c               // leaq         (%rsi,%rax), %r8
-	LONG $0xffffa8e9; BYTE $0xff   // jmp          LBB24_39, $-88(%rip)
+	LONG $0xffffa8e9; BYTE $0xff   // jmp          LBB23_39, $-88(%rip)
 
-LBB24_1:
+LBB23_1:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0x00008fe9; BYTE $0x00               // jmp          LBB24_55, $143(%rip)
+	LONG $0x00008fe9; BYTE $0x00               // jmp          LBB23_55, $143(%rip)
 
-LBB24_57:
+LBB23_57:
 	WORD $0x8941; BYTE $0xcb // movl         %ecx, %r11d
 	WORD $0x0149; BYTE $0xfb // addq         %rdi, %r11
 	WORD $0x0149; BYTE $0xc3 // addq         %rax, %r11
 
-LBB24_41:
+LBB23_41:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xc0                   // testq        %r8, %r8
-	LONG $0x001b850f; WORD $0x0000             // jne          LBB24_42, $27(%rip)
-	LONG $0x000071e9; BYTE $0x00               // jmp          LBB24_55, $113(%rip)
+	LONG $0x001b850f; WORD $0x0000             // jne          LBB23_42, $27(%rip)
+	LONG $0x000071e9; BYTE $0x00               // jmp          LBB23_55, $113(%rip)
 
-LBB24_40:
+LBB23_40:
 	WORD $0x0148; BYTE $0xc1                   // addq         %rax, %rcx
 	WORD $0x8949; BYTE $0xcb                   // movq         %rcx, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xc0                   // testq        %r8, %r8
-	LONG $0x005b840f; WORD $0x0000             // je           LBB24_55, $91(%rip)
+	LONG $0x005b840f; WORD $0x0000             // je           LBB23_55, $91(%rip)
 
-LBB24_42:
+LBB23_42:
 	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
-	LONG $0x0052840f; WORD $0x0000 // je           LBB24_55, $82(%rip)
+	LONG $0x0052840f; WORD $0x0000 // je           LBB23_55, $82(%rip)
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0049840f; WORD $0x0000 // je           LBB24_55, $73(%rip)
+	LONG $0x0049840f; WORD $0x0000 // je           LBB23_55, $73(%rip)
 	WORD $0x2949; BYTE $0xfb       // subq         %rdi, %r11
 	LONG $0xff438d49               // leaq         $-1(%r11), %rax
 	WORD $0x3949; BYTE $0xc0       // cmpq         %rax, %r8
-	LONG $0x0033840f; WORD $0x0000 // je           LBB24_47, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000 // je           LBB23_47, $51(%rip)
 	WORD $0x3949; BYTE $0xc2       // cmpq         %rax, %r10
-	LONG $0x002a840f; WORD $0x0000 // je           LBB24_47, $42(%rip)
+	LONG $0x002a840f; WORD $0x0000 // je           LBB23_47, $42(%rip)
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x0021840f; WORD $0x0000 // je           LBB24_47, $33(%rip)
+	LONG $0x0021840f; WORD $0x0000 // je           LBB23_47, $33(%rip)
 	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
-	LONG $0x00258e0f; WORD $0x0000 // jle          LBB24_51, $37(%rip)
+	LONG $0x00258e0f; WORD $0x0000 // jle          LBB23_51, $37(%rip)
 	LONG $0xff428d49               // leaq         $-1(%r10), %rax
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x0018840f; WORD $0x0000 // je           LBB24_51, $24(%rip)
+	LONG $0x0018840f; WORD $0x0000 // je           LBB23_51, $24(%rip)
 	WORD $0xf749; BYTE $0xd2       // notq         %r10
 	WORD $0x894c; BYTE $0xd0       // movq         %r10, %rax
-	LONG $0x000006e9; BYTE $0x00   // jmp          LBB24_55, $6(%rip)
+	LONG $0x000006e9; BYTE $0x00   // jmp          LBB23_55, $6(%rip)
 
-LBB24_47:
+LBB23_47:
 	WORD $0xf749; BYTE $0xdb // negq         %r11
 	WORD $0x894c; BYTE $0xd8 // movq         %r11, %rax
 
-LBB24_55:
+LBB23_55:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	BYTE $0xc3   // retq
 
-LBB24_51:
+LBB23_51:
 	WORD $0x894c; BYTE $0xc0       // movq         %r8, %rax
 	WORD $0x094c; BYTE $0xc8       // orq          %r9, %rax
 	WORD $0x990f; BYTE $0xc0       // setns        %al
-	LONG $0x0014880f; WORD $0x0000 // js           LBB24_54, $20(%rip)
+	LONG $0x0014880f; WORD $0x0000 // js           LBB23_54, $20(%rip)
 	WORD $0x394d; BYTE $0xc8       // cmpq         %r9, %r8
-	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB24_54, $11(%rip)
+	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB23_54, $11(%rip)
 	WORD $0xf749; BYTE $0xd0       // notq         %r8
 	WORD $0x894c; BYTE $0xc0       // movq         %r8, %rax
-	LONG $0xffffd6e9; BYTE $0xff   // jmp          LBB24_55, $-42(%rip)
+	LONG $0xffffd6e9; BYTE $0xff   // jmp          LBB23_55, $-42(%rip)
 
-LBB24_54:
+LBB23_54:
 	LONG $0xff498d49             // leaq         $-1(%r9), %rcx
 	WORD $0x3949; BYTE $0xc8     // cmpq         %rcx, %r8
 	WORD $0xf749; BYTE $0xd1     // notq         %r9
@@ -6987,67 +6723,67 @@ LBB24_54:
 	WORD $0xc084                 // testb        %al, %al
 	LONG $0xcb440f4d             // cmoveq       %r11, %r9
 	WORD $0x894c; BYTE $0xc8     // movq         %r9, %rax
-	LONG $0xffffbae9; BYTE $0xff // jmp          LBB24_55, $-70(%rip)
+	LONG $0xffffbae9; BYTE $0xff // jmp          LBB23_55, $-70(%rip)
 
-LBB24_12:
+LBB23_12:
 	WORD $0xbc0f; BYTE $0xcb     // bsfl         %ebx, %ecx
-	LONG $0x000010e9; BYTE $0x00 // jmp          LBB24_13, $16(%rip)
+	LONG $0x000010e9; BYTE $0x00 // jmp          LBB23_13, $16(%rip)
 
-LBB24_58:
+LBB23_58:
 	WORD $0x2948; BYTE $0xcf     // subq         %rcx, %rdi
 	WORD $0xf748; BYTE $0xd0     // notq         %rax
 	WORD $0x0148; BYTE $0xf8     // addq         %rdi, %rax
-	LONG $0xffffa4e9; BYTE $0xff // jmp          LBB24_55, $-92(%rip)
+	LONG $0xffffa4e9; BYTE $0xff // jmp          LBB23_55, $-92(%rip)
 
-LBB24_56:
+LBB23_56:
 	WORD $0xd189 // movl         %edx, %ecx
 
-LBB24_13:
+LBB23_13:
 	WORD $0xf748; BYTE $0xd0     // notq         %rax
 	WORD $0x2948; BYTE $0xc8     // subq         %rcx, %rax
-	LONG $0xffff97e9; BYTE $0xff // jmp          LBB24_55, $-105(%rip)
+	LONG $0xffff97e9; BYTE $0xff // jmp          LBB23_55, $-105(%rip)
 
-LBB24_7:
+LBB23_7:
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	WORD $0x8948; BYTE $0xf9                   // movq         %rdi, %rcx
 	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
 	LONG $0xffc1c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r9
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
-	LONG $0xfffe51e9; BYTE $0xff               // jmp          LBB24_28, $-431(%rip)
+	LONG $0xfffe51e9; BYTE $0xff               // jmp          LBB23_28, $-431(%rip)
 
 	// .p2align 2, 0x90
-	// .set L24_0_set_37, LBB24_37-LJTI24_0
-	// .set L24_0_set_40, LBB24_40-LJTI24_0
-	// .set L24_0_set_35, LBB24_35-LJTI24_0
-	// .set L24_0_set_32, LBB24_32-LJTI24_0
-LJTI24_0:
-	LONG $0xfffffeb6         // .long L24_0_set_37
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xfffffeb6         // .long L24_0_set_37
-	LONG $0xfffffec9         // .long L24_0_set_35
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xfffffe72         // .long L24_0_set_32
+	// .set L23_0_set_37, LBB23_37-LJTI23_0
+	// .set L23_0_set_40, LBB23_40-LJTI23_0
+	// .set L23_0_set_35, LBB23_35-LJTI23_0
+	// .set L23_0_set_32, LBB23_32-LJTI23_0
+LJTI23_0:
+	LONG $0xfffffeb6         // .long L23_0_set_37
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xfffffeb6         // .long L23_0_set_37
+	LONG $0xfffffec9         // .long L23_0_set_35
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xfffffe72         // .long L23_0_set_32
 	QUAD $0x9090909090909090 // .p2align 4, 0x90
 
 _skip_positive:
@@ -7101,22 +6837,22 @@ _skip_number:
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x2948; BYTE $0xc6       // subq         %rax, %rsi
-	LONG $0x003b840f; WORD $0x0000 // je           LBB26_6, $59(%rip)
+	LONG $0x003b840f; WORD $0x0000 // je           LBB25_6, $59(%rip)
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0x000c830f; WORD $0x0000 // jae          LBB26_3, $12(%rip)
+	LONG $0x000c830f; WORD $0x0000 // jae          LBB25_3, $12(%rip)
 	WORD $0x038a                   // movb         (%rbx), %al
 	WORD $0xd004                   // addb         $-48, %al
 	WORD $0x093c                   // cmpb         $9, %al
-	LONG $0x0038870f; WORD $0x0000 // ja           LBB26_8, $56(%rip)
+	LONG $0x0038870f; WORD $0x0000 // ja           LBB25_8, $56(%rip)
 
-LBB26_3:
+LBB25_3:
 	WORD $0x8948; BYTE $0xdf       // movq         %rbx, %rdi
 	LONG $0xfffb71e8; BYTE $0xff   // callq        _do_skip_number, $-1167(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0021880f; WORD $0x0000 // js           LBB26_7, $33(%rip)
+	LONG $0x0021880f; WORD $0x0000 // js           LBB25_7, $33(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 
-LBB26_5:
+LBB25_5:
 	WORD $0x294c; BYTE $0xe3 // subq         %r12, %rbx
 	WORD $0x8949; BYTE $0x1e // movq         %rbx, (%r14)
 	WORD $0x894c; BYTE $0xf8 // movq         %r15, %rax
@@ -7127,38 +6863,1444 @@ LBB26_5:
 	BYTE $0x5d               // popq         %rbp
 	BYTE $0xc3               // retq
 
-LBB26_6:
+LBB25_6:
 	LONG $0xffc7c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r15
-	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB26_5, $-30(%rip)
+	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB25_5, $-30(%rip)
 
-LBB26_7:
+LBB25_7:
 	WORD $0xf748; BYTE $0xd0 // notq         %rax
 	WORD $0x0148; BYTE $0xc3 // addq         %rax, %rbx
 
-LBB26_8:
+LBB25_8:
 	LONG $0xfec7c749; WORD $0xffff; BYTE $0xff // movq         $-2, %r15
-	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB26_5, $-48(%rip)
+	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB25_5, $-48(%rip)
 	LONG $0x90909090; BYTE $0x90               // .p2align 4, 0x90
 
+_skip_one:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
+	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
+	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
+	BYTE $0x5d                                 // popq         %rbp
+	LONG $0xfff293e9; BYTE $0xff               // jmp          _fsm_exec, $-3437(%rip)
+	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
+
 _validate_one:
-	BYTE $0x55                                                                                                   // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                                                                                     // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                                                                                     // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                                                                                     // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                                                                                     // movq         %rdi, %rsi
-	LONG $0x0100c748; WORD $0x0000; BYTE $0x00                                                                   // movq         $1, (%rax)
-	LONG $0x000020b9; BYTE $0x00                                                                                 // movl         $32, %ecx
-	WORD $0x8948; BYTE $0xc7                                                                                     // movq         %rax, %rdi
-	BYTE $0x5d                                                                                                   // popq         %rbp
-	LONG $0xfff25ee9; BYTE $0xff                                                                                 // jmp          _fsm_exec, $-3490(%rip)
-	QUAD $0x0000000000000000; QUAD $0x0000000000000000; QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 5, 0x00
+	BYTE $0x55                                               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                                 // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                                 // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                                 // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                                 // movq         %rdi, %rsi
+	LONG $0x0100c748; WORD $0x0000; BYTE $0x00               // movq         $1, (%rax)
+	LONG $0x000020b9; BYTE $0x00                             // movl         $32, %ecx
+	WORD $0x8948; BYTE $0xc7                                 // movq         %rax, %rdi
+	BYTE $0x5d                                               // popq         %rbp
+	LONG $0xfff26ee9; BYTE $0xff                             // jmp          _fsm_exec, $-3474(%rip)
+	QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 4, 0x00
 
 LCPI28_0:
+	QUAD $0x2c2c2c2c2c2c2c2c; QUAD $0x2c2c2c2c2c2c2c2c // .space 16, ',,,,,,,,,,,,,,,,'
+
+LCPI28_1:
+	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
+
+LCPI28_2:
+	QUAD $0x5d5d5d5d5d5d5d5d; QUAD $0x5d5d5d5d5d5d5d5d // .space 16, ']]]]]]]]]]]]]]]]'
+
+LCPI28_3:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI28_4:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+LCPI28_5:
+	QUAD $0x7b7b7b7b7b7b7b7b; QUAD $0x7b7b7b7b7b7b7b7b // .space 16, '{{{{{{{{{{{{{{{{'
+
+LCPI28_6:
+	QUAD $0x7d7d7d7d7d7d7d7d; QUAD $0x7d7d7d7d7d7d7d7d // .space 16, '}}}}}}}}}}}}}}}}'
+
+LCPI28_7:
+	QUAD $0x5b5b5b5b5b5b5b5b; QUAD $0x5b5b5b5b5b5b5b5b // .space 16, '[[[[[[[[[[[[[[[['
+
+	// .p2align 4, 0x90
+_skip_one_fast:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x5741                               // pushq        %r15
+	WORD $0x5641                               // pushq        %r14
+	WORD $0x5541                               // pushq        %r13
+	WORD $0x5441                               // pushq        %r12
+	BYTE $0x53                                 // pushq        %rbx
+	LONG $0xe0e48348                           // andq         $-32, %rsp
+	LONG $0x80ec8148; WORD $0x0000; BYTE $0x00 // subq         $128, %rsp
+	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xfc                   // movq         %rdi, %r12
+	WORD $0x8b48; BYTE $0x3f                   // movq         (%rdi), %rdi
+	LONG $0x24748b49; BYTE $0x08               // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                   // movq         %r14, %rdx
+	LONG $0xffde22e8; BYTE $0xff               // callq        _advance_ns, $-8670(%rip)
+	WORD $0x8b49; BYTE $0x16                   // movq         (%r14), %rdx
+	LONG $0xff428d4c                           // leaq         $-1(%rdx), %r8
+	WORD $0xbe0f; BYTE $0xc8                   // movsbl       %al, %ecx
+	WORD $0xf983; BYTE $0x7b                   // cmpl         $123, %ecx
+	LONG $0x0112870f; WORD $0x0000             // ja           LBB28_19, $274(%rip)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0x85358d48; WORD $0x0009; BYTE $0x00 // leaq         $2437(%rip), %rsi  /* LJTI28_0(%rip) */
+	LONG $0x8e0c6348                           // movslq       (%rsi,%rcx,4), %rcx
+	WORD $0x0148; BYTE $0xf1                   // addq         %rsi, %rcx
+	JMP  CX
+
+LBB28_2:
+	LONG $0x24048b49               // movq         (%r12), %rax
+	LONG $0x24748b49; BYTE $0x08   // movq         $8(%r12), %rsi
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	WORD $0x2948; BYTE $0xd1       // subq         %rdx, %rcx
+	LONG $0x10f98348               // cmpq         $16, %rcx
+	LONG $0x08b6820f; WORD $0x0000 // jb           LBB28_80, $2230(%rip)
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	WORD $0xf748; BYTE $0xd9       // negq         %rcx
+	QUAD $0xffffff01056ff9c5       // vmovdqa      $-255(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xffffff090d6ff9c5       // vmovdqa      $-247(%rip), %xmm1  /* LCPI28_1(%rip) */
+	QUAD $0xffffff11156ff9c5       // vmovdqa      $-239(%rip), %xmm2  /* LCPI28_2(%rip) */
+	BYTE $0x90                     // .p2align 4, 0x90
+
+LBB28_4:
+	LONG $0x1c6ffac5; BYTE $0x10   // vmovdqu      (%rax,%rdx), %xmm3
+	LONG $0xe074e1c5               // vpcmpeqb     %xmm0, %xmm3, %xmm4
+	LONG $0xd9dbe1c5               // vpand        %xmm1, %xmm3, %xmm3
+	LONG $0xda74e1c5               // vpcmpeqb     %xmm2, %xmm3, %xmm3
+	LONG $0xdcebe1c5               // vpor         %xmm4, %xmm3, %xmm3
+	LONG $0xfbd7f9c5               // vpmovmskb    %xmm3, %edi
+	WORD $0xff85                   // testl        %edi, %edi
+	LONG $0x006c850f; WORD $0x0000 // jne          LBB28_14, $108(%rip)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x0e3c8d48               // leaq         (%rsi,%rcx), %rdi
+	LONG $0xf0c78348               // addq         $-16, %rdi
+	LONG $0xf0c18348               // addq         $-16, %rcx
+	LONG $0x0fff8348               // cmpq         $15, %rdi
+	LONG $0xffc5870f; WORD $0xffff // ja           LBB28_4, $-59(%rip)
+	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
+	WORD $0x2948; BYTE $0xca       // subq         %rcx, %rdx
+	WORD $0x0148; BYTE $0xce       // addq         %rcx, %rsi
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x0035840f; WORD $0x0000 // je           LBB28_13, $53(%rip)
+
+LBB28_7:
+	LONG $0x0a3c8d48 // leaq         (%rdx,%rcx), %rdi
+	WORD $0xf631     // xorl         %esi, %esi
+
+LBB28_8:
+	LONG $0x321cb60f               // movzbl       (%rdx,%rsi), %ebx
+	WORD $0xfb80; BYTE $0x2c       // cmpb         $44, %bl
+	LONG $0x0809840f; WORD $0x0000 // je           LBB28_78, $2057(%rip)
+	WORD $0xfb80; BYTE $0x7d       // cmpb         $125, %bl
+	LONG $0x0800840f; WORD $0x0000 // je           LBB28_78, $2048(%rip)
+	WORD $0xfb80; BYTE $0x5d       // cmpb         $93, %bl
+	LONG $0x07f7840f; WORD $0x0000 // je           LBB28_78, $2039(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x3948; BYTE $0xf1       // cmpq         %rsi, %rcx
+	LONG $0xffd4850f; WORD $0xffff // jne          LBB28_8, $-44(%rip)
+	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
+
+LBB28_13:
+	WORD $0x2948; BYTE $0xc2     // subq         %rax, %rdx
+	LONG $0x0007e5e9; BYTE $0x00 // jmp          LBB28_79, $2021(%rip)
+
+LBB28_14:
+	LONG $0xc7bc0f66         // bsfw         %di, %ax
+	WORD $0xb70f; BYTE $0xc0 // movzwl       %ax, %eax
+	WORD $0x2948; BYTE $0xc8 // subq         %rcx, %rax
+
+LBB28_15:
+	WORD $0x8949; BYTE $0x06 // movq         %rax, (%r14)
+
+LBB28_16:
+	WORD $0x894c; BYTE $0xc0 // movq         %r8, %rax
+
+LBB28_17:
+	LONG $0xd8658d48         // leaq         $-40(%rbp), %rsp
+	BYTE $0x5b               // popq         %rbx
+	WORD $0x5c41             // popq         %r12
+	WORD $0x5d41             // popq         %r13
+	WORD $0x5e41             // popq         %r14
+	WORD $0x5f41             // popq         %r15
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	BYTE $0xc3               // retq
+
+LBB28_18:
+	LONG $0x03c28348               // addq         $3, %rdx
+	LONG $0x24543b49; BYTE $0x08   // cmpq         $8(%r12), %rdx
+	LONG $0xffdf830f; WORD $0xffff // jae          LBB28_17, $-33(%rip)
+	LONG $0x0007afe9; BYTE $0x00   // jmp          LBB28_79, $1967(%rip)
+
+LBB28_19:
+	WORD $0x894d; BYTE $0x06                   // movq         %r8, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xffffcbe9; BYTE $0xff               // jmp          LBB28_17, $-53(%rip)
+
+LBB28_20:
+	LONG $0x240c8b49               // movq         (%r12), %rcx
+	LONG $0x244c8b4d; BYTE $0x08   // movq         $8(%r12), %r9
+	LONG $0x244c8948; BYTE $0x10   // movq         %rcx, $16(%rsp)
+	LONG $0x11148d4c               // leaq         (%rcx,%rdx), %r10
+	WORD $0x2949; BYTE $0xd1       // subq         %rdx, %r9
+	LONG $0x20f98349               // cmpq         $32, %r9
+	LONG $0x0798820f; WORD $0x0000 // jb           LBB28_28, $1944(%rip)
+	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
+	QUAD $0xfffffe24056ff9c5       // vmovdqa      $-476(%rip), %xmm0  /* LCPI28_3(%rip) */
+	QUAD $0xfffffe2c0d6ff9c5       // vmovdqa      $-468(%rip), %xmm1  /* LCPI28_4(%rip) */
+	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
+	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
+	LONG $0x000027e9; BYTE $0x00   // jmp          LBB28_22, $39(%rip)
+	BYTE $0x90                     // .p2align 4, 0x90
+
+LBB28_24:
+	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x009d850f; WORD $0x0000 // jne          LBB28_77, $157(%rip)
+
+LBB28_25:
+	LONG $0x20c58349               // addq         $32, %r13
+	LONG $0x390c8d4b               // leaq         (%r9,%r15), %rcx
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0xe0c78349               // addq         $-32, %r15
+	LONG $0x1ff98348               // cmpq         $31, %rcx
+	LONG $0x0744860f; WORD $0x0000 // jbe          LBB28_26, $1860(%rip)
+
+LBB28_22:
+	LONG $0x6f7a81c4; WORD $0x2a14             // vmovdqu      (%r10,%r13), %xmm2
+	LONG $0x6f7a81c4; WORD $0x2a5c; BYTE $0x10 // vmovdqu      $16(%r10,%r13), %xmm3
+	LONG $0xe074e9c5                           // vpcmpeqb     %xmm0, %xmm2, %xmm4
+	LONG $0xfcd7f9c5                           // vpmovmskb    %xmm4, %edi
+	LONG $0xe074e1c5                           // vpcmpeqb     %xmm0, %xmm3, %xmm4
+	LONG $0xccd7f9c5                           // vpmovmskb    %xmm4, %ecx
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf9                   // orq          %rdi, %rcx
+	LONG $0xd174e9c5                           // vpcmpeqb     %xmm1, %xmm2, %xmm2
+	LONG $0xf2d7f9c5                           // vpmovmskb    %xmm2, %esi
+	LONG $0xd174e1c5                           // vpcmpeqb     %xmm1, %xmm3, %xmm2
+	LONG $0xfad7f9c5                           // vpmovmskb    %xmm2, %edi
+	LONG $0x10e7c148                           // shlq         $16, %rdi
+	WORD $0x0948; BYTE $0xf7                   // orq          %rsi, %rdi
+	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
+	WORD $0x094c; BYTE $0xde                   // orq          %r11, %rsi
+	LONG $0xff93840f; WORD $0xffff             // je           LBB28_24, $-109(%rip)
+	WORD $0x8944; BYTE $0xde                   // movl         %r11d, %esi
+	WORD $0xd6f7                               // notl         %esi
+	WORD $0xfe21                               // andl         %edi, %esi
+	LONG $0x36248d44                           // leal         (%rsi,%rsi), %r12d
+	WORD $0x0945; BYTE $0xdc                   // orl          %r11d, %r12d
+	WORD $0x8944; BYTE $0xe3                   // movl         %r12d, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	WORD $0xfb21                               // andl         %edi, %ebx
+	LONG $0xaaaae381; WORD $0xaaaa             // andl         $-1431655766, %ebx
+	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
+	WORD $0xf301                               // addl         %esi, %ebx
+	LONG $0xc3920f41                           // setb         %r11b
+	WORD $0xdb01                               // addl         %ebx, %ebx
+	LONG $0x5555f381; WORD $0x5555             // xorl         $1431655765, %ebx
+	WORD $0x2144; BYTE $0xe3                   // andl         %r12d, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	WORD $0xd921                               // andl         %ebx, %ecx
+	WORD $0x8548; BYTE $0xc9                   // testq        %rcx, %rcx
+	LONG $0xff63840f; WORD $0xffff             // je           LBB28_25, $-157(%rip)
+
+LBB28_77:
+	WORD $0xbc0f; BYTE $0xc1     // bsfl         %ecx, %eax
+	WORD $0x0148; BYTE $0xd0     // addq         %rdx, %rax
+	WORD $0x014c; BYTE $0xe8     // addq         %r13, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xfffecce9; BYTE $0xff // jmp          LBB28_15, $-308(%rip)
+
+LBB28_29:
+	LONG $0x2444894c; BYTE $0x18   // movq         %r8, $24(%rsp)
+	LONG $0x244c8b49; BYTE $0x08   // movq         $8(%r12), %rcx
+	WORD $0x2948; BYTE $0xd1       // subq         %rdx, %rcx
+	LONG $0x24140349               // addq         (%r12), %rdx
+	WORD $0x3145; BYTE $0xc0       // xorl         %r8d, %r8d
+	QUAD $0xfffffd49156f79c5       // vmovdqa      $-695(%rip), %xmm10  /* LCPI28_4(%rip) */
+	QUAD $0xfffffd310d6ff9c5       // vmovdqa      $-719(%rip), %xmm1  /* LCPI28_3(%rip) */
+	LONG $0x763141c4; BYTE $0xc9   // vpcmpeqd     %xmm9, %xmm9, %xmm9
+	QUAD $0xfffffd641d6ff9c5       // vmovdqa      $-668(%rip), %xmm3  /* LCPI28_7(%rip) */
+	QUAD $0xfffffd0c256ff9c5       // vmovdqa      $-756(%rip), %xmm4  /* LCPI28_2(%rip) */
+	LONG $0x573841c4; BYTE $0xc0   // vxorps       %xmm8, %xmm8, %xmm8
+	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
+	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
+	WORD $0xf631                   // xorl         %esi, %esi
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x10   // movq         %rcx, $16(%rsp)
+	LONG $0x01c38c0f; WORD $0x0000 // jl           LBB28_38, $451(%rip)
+
+LBB28_32:
+	LONG $0x126ffac5                           // vmovdqu      (%rdx), %xmm2
+	LONG $0x6a6ffac5; BYTE $0x10               // vmovdqu      $16(%rdx), %xmm5
+	LONG $0x7a6ffac5; BYTE $0x20               // vmovdqu      $32(%rdx), %xmm7
+	LONG $0x726ffac5; BYTE $0x30               // vmovdqu      $48(%rdx), %xmm6
+	LONG $0xc274a9c5                           // vpcmpeqb     %xmm2, %xmm10, %xmm0
+	LONG $0xc8d7f9c5                           // vpmovmskb    %xmm0, %ecx
+	LONG $0xc574a9c5                           // vpcmpeqb     %xmm5, %xmm10, %xmm0
+	LONG $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
+	LONG $0xc774a9c5                           // vpcmpeqb     %xmm7, %xmm10, %xmm0
+	LONG $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
+	LONG $0xc674a9c5                           // vpcmpeqb     %xmm6, %xmm10, %xmm0
+	LONG $0xd0d779c5                           // vpmovmskb    %xmm0, %r10d
+	LONG $0x30e2c149                           // shlq         $48, %r10
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x094c; BYTE $0xd7                   // orq          %r10, %rdi
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xfb                   // orq          %rdi, %rbx
+	WORD $0x0948; BYTE $0xd9                   // orq          %rbx, %rcx
+	WORD $0x8948; BYTE $0xcf                   // movq         %rcx, %rdi
+	WORD $0x094c; BYTE $0xef                   // orq          %r13, %rdi
+	LONG $0x000f850f; WORD $0x0000             // jne          LBB28_34, $15(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	WORD $0x3145; BYTE $0xed                   // xorl         %r13d, %r13d
+	LONG $0x000046e9; BYTE $0x00               // jmp          LBB28_35, $70(%rip)
+
+LBB28_34:
+	WORD $0x894c; BYTE $0xef               // movq         %r13, %rdi
+	WORD $0xf748; BYTE $0xd7               // notq         %rdi
+	WORD $0x2148; BYTE $0xcf               // andq         %rcx, %rdi
+	LONG $0x3f148d4c                       // leaq         (%rdi,%rdi), %r10
+	WORD $0x094d; BYTE $0xea               // orq          %r13, %r10
+	WORD $0x894d; BYTE $0xd3               // movq         %r10, %r11
+	WORD $0xf749; BYTE $0xd3               // notq         %r11
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2148; BYTE $0xd9               // andq         %rbx, %rcx
+	WORD $0x214c; BYTE $0xd9               // andq         %r11, %rcx
+	WORD $0x3145; BYTE $0xed               // xorl         %r13d, %r13d
+	WORD $0x0148; BYTE $0xf9               // addq         %rdi, %rcx
+	LONG $0xc5920f41                       // setb         %r13b
+	WORD $0x0148; BYTE $0xc9               // addq         %rcx, %rcx
+	QUAD $0x555555555555bf48; WORD $0x5555 // movabsq      $6148914691236517205, %rdi
+	WORD $0x3148; BYTE $0xf9               // xorq         %rdi, %rcx
+	WORD $0x214c; BYTE $0xd1               // andq         %r10, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+
+LBB28_35:
+	LONG $0xc174c9c5               // vpcmpeqb     %xmm1, %xmm6, %xmm0
+	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
+	LONG $0x30e7c148               // shlq         $48, %rdi
+	LONG $0xc174c1c5               // vpcmpeqb     %xmm1, %xmm7, %xmm0
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	LONG $0x20e3c148               // shlq         $32, %rbx
+	WORD $0x0948; BYTE $0xfb       // orq          %rdi, %rbx
+	LONG $0xc174d1c5               // vpcmpeqb     %xmm1, %xmm5, %xmm0
+	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
+	LONG $0x10e7c148               // shlq         $16, %rdi
+	WORD $0x0948; BYTE $0xdf       // orq          %rbx, %rdi
+	LONG $0xc174e9c5               // vpcmpeqb     %xmm1, %xmm2, %xmm0
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	WORD $0x0948; BYTE $0xfb       // orq          %rdi, %rbx
+	WORD $0x2148; BYTE $0xcb       // andq         %rcx, %rbx
+	LONG $0x6ef9e1c4; BYTE $0xc3   // vmovq        %rbx, %xmm0
+	LONG $0x4479c3c4; WORD $0x00c1 // vpclmulqdq   $0, %xmm9, %xmm0, %xmm0
+	LONG $0x7ef9c1c4; BYTE $0xc2   // vmovq        %xmm0, %r10
+	WORD $0x314d; BYTE $0xc2       // xorq         %r8, %r10
+	LONG $0xc374e9c5               // vpcmpeqb     %xmm3, %xmm2, %xmm0
+	LONG $0xf8d7f9c5               // vpmovmskb    %xmm0, %edi
+	LONG $0xc374d1c5               // vpcmpeqb     %xmm3, %xmm5, %xmm0
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	LONG $0xc374c1c5               // vpcmpeqb     %xmm3, %xmm7, %xmm0
+	LONG $0xc8d7f9c5               // vpmovmskb    %xmm0, %ecx
+	LONG $0xc374c9c5               // vpcmpeqb     %xmm3, %xmm6, %xmm0
+	LONG $0xc0d779c5               // vpmovmskb    %xmm0, %r8d
+	LONG $0x30e0c149               // shlq         $48, %r8
+	LONG $0x20e1c148               // shlq         $32, %rcx
+	WORD $0x094c; BYTE $0xc1       // orq          %r8, %rcx
+	LONG $0x10e3c148               // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xcb       // orq          %rcx, %rbx
+	WORD $0x0948; BYTE $0xdf       // orq          %rbx, %rdi
+	WORD $0x894d; BYTE $0xd0       // movq         %r10, %r8
+	WORD $0xf749; BYTE $0xd0       // notq         %r8
+	WORD $0x214c; BYTE $0xc7       // andq         %r8, %rdi
+	LONG $0xc474e9c5               // vpcmpeqb     %xmm4, %xmm2, %xmm0
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	LONG $0xc474d1c5               // vpcmpeqb     %xmm4, %xmm5, %xmm0
+	LONG $0xc8d7f9c5               // vpmovmskb    %xmm0, %ecx
+	LONG $0xc474c1c5               // vpcmpeqb     %xmm4, %xmm7, %xmm0
+	LONG $0xd8d779c5               // vpmovmskb    %xmm0, %r11d
+	LONG $0xc474c9c5               // vpcmpeqb     %xmm4, %xmm6, %xmm0
+	LONG $0xf8d779c5               // vpmovmskb    %xmm0, %r15d
+	LONG $0x30e7c149               // shlq         $48, %r15
+	LONG $0x20e3c149               // shlq         $32, %r11
+	WORD $0x094d; BYTE $0xfb       // orq          %r15, %r11
+	LONG $0x10e1c148               // shlq         $16, %rcx
+	WORD $0x094c; BYTE $0xd9       // orq          %r11, %rcx
+	WORD $0x0948; BYTE $0xcb       // orq          %rcx, %rbx
+	WORD $0x214c; BYTE $0xc3       // andq         %r8, %rbx
+	LONG $0x0028840f; WORD $0x0000 // je           LBB28_30, $40(%rip)
+
+	// .p2align 4, 0x90
+LBB28_36:
+	LONG $0xff438d4c               // leaq         $-1(%rbx), %r8
+	WORD $0x894c; BYTE $0xc1       // movq         %r8, %rcx
+	WORD $0x2148; BYTE $0xf9       // andq         %rdi, %rcx
+	LONG $0xb80f48f3; BYTE $0xc9   // popcntq      %rcx, %rcx
+	WORD $0x014c; BYTE $0xc9       // addq         %r9, %rcx
+	WORD $0x3948; BYTE $0xf1       // cmpq         %rsi, %rcx
+	LONG $0x0482860f; WORD $0x0000 // jbe          LBB28_76, $1154(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x214c; BYTE $0xc3       // andq         %r8, %rbx
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_36, $-40(%rip)
+
+LBB28_30:
+	LONG $0x3ffac149               // sarq         $63, %r10
+	LONG $0xb80f48f3; BYTE $0xcf   // popcntq      %rdi, %rcx
+	WORD $0x0149; BYTE $0xc9       // addq         %rcx, %r9
+	LONG $0x40c28348               // addq         $64, %rdx
+	LONG $0x244c8b48; BYTE $0x10   // movq         $16(%rsp), %rcx
+	LONG $0xc0c18348               // addq         $-64, %rcx
+	WORD $0x894d; BYTE $0xd0       // movq         %r10, %r8
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x10   // movq         %rcx, $16(%rsp)
+	LONG $0xfe3d8d0f; WORD $0xffff // jge          LBB28_32, $-451(%rip)
+
+LBB28_38:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x04bc8e0f; WORD $0x0000 // jle          LBB28_81, $1212(%rip)
+	LONG $0x44297cc5; WORD $0x4024 // vmovaps      %ymm8, $64(%rsp)
+	LONG $0x44297cc5; WORD $0x2024 // vmovaps      %ymm8, $32(%rsp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0xfe14820f; WORD $0xffff // jb           LBB28_32, $-492(%rip)
+	LONG $0x247c8348; WORD $0x1010 // cmpq         $16, $16(%rsp)
+	LONG $0x00308c0f; WORD $0x0000 // jl           LBB28_43, $48(%rip)
+	LONG $0x245c8b48; BYTE $0x10   // movq         $16(%rsp), %rbx
+	LONG $0x244c8d48; BYTE $0x20   // leaq         $32(%rsp), %rcx
+
+LBB28_42:
+	LONG $0x026ffac5               // vmovdqu      (%rdx), %xmm0
+	LONG $0x017ffac5               // vmovdqu      %xmm0, (%rcx)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c18348               // addq         $16, %rcx
+	LONG $0xf0538d4c               // leaq         $-16(%rbx), %r10
+	LONG $0x1ffb8348               // cmpq         $31, %rbx
+	WORD $0x894c; BYTE $0xd3       // movq         %r10, %rbx
+	LONG $0xffdf8f0f; WORD $0xffff // jg           LBB28_42, $-33(%rip)
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB28_44, $10(%rip)
+
+LBB28_43:
+	LONG $0x244c8d48; BYTE $0x20 // leaq         $32(%rsp), %rcx
+	LONG $0x24548b4c; BYTE $0x10 // movq         $16(%rsp), %r10
+
+LBB28_44:
+	LONG $0x08fa8349               // cmpq         $8, %r10
+	LONG $0x004e8c0f; WORD $0x0000 // jl           LBB28_45, $78(%rip)
+	WORD $0x8b48; BYTE $0x3a       // movq         (%rdx), %rdi
+	WORD $0x8948; BYTE $0x39       // movq         %rdi, (%rcx)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c18348               // addq         $8, %rcx
+	LONG $0xf8c28349               // addq         $-8, %r10
+	LONG $0x04fa8349               // cmpq         $4, %r10
+	LONG $0x003c8d0f; WORD $0x0000 // jge          LBB28_49, $60(%rip)
+
+LBB28_46:
+	LONG $0x02fa8349               // cmpq         $2, %r10
+	LONG $0x004c8c0f; WORD $0x0000 // jl           LBB28_47, $76(%rip)
+
+LBB28_50:
+	WORD $0xb70f; BYTE $0x3a       // movzwl       (%rdx), %edi
+	WORD $0x8966; BYTE $0x39       // movw         %di, (%rcx)
+	LONG $0x02c28348               // addq         $2, %rdx
+	LONG $0x02c18348               // addq         $2, %rcx
+	LONG $0xfec28349               // addq         $-2, %r10
+	WORD $0x8948; BYTE $0xd3       // movq         %rdx, %rbx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0x003a8f0f; WORD $0x0000 // jg           LBB28_51, $58(%rip)
+	LONG $0xfffd76e9; BYTE $0xff   // jmp          LBB28_32, $-650(%rip)
+
+LBB28_45:
+	LONG $0x04fa8349               // cmpq         $4, %r10
+	LONG $0xffc48c0f; WORD $0xffff // jl           LBB28_46, $-60(%rip)
+
+LBB28_49:
+	WORD $0x3a8b                   // movl         (%rdx), %edi
+	WORD $0x3989                   // movl         %edi, (%rcx)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c18348               // addq         $4, %rcx
+	LONG $0xfcc28349               // addq         $-4, %r10
+	LONG $0x02fa8349               // cmpq         $2, %r10
+	LONG $0xffb48d0f; WORD $0xffff // jge          LBB28_50, $-76(%rip)
+
+LBB28_47:
+	WORD $0x8948; BYTE $0xd3       // movq         %rdx, %rbx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0xfd418e0f; WORD $0xffff // jle          LBB28_32, $-703(%rip)
+
+LBB28_51:
+	WORD $0x138a                 // movb         (%rbx), %dl
+	WORD $0x1188                 // movb         %dl, (%rcx)
+	LONG $0x24548d48; BYTE $0x20 // leaq         $32(%rsp), %rdx
+	LONG $0xfffd33e9; BYTE $0xff // jmp          LBB28_32, $-717(%rip)
+
+LBB28_52:
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x24543b49; BYTE $0x08   // cmpq         $8(%r12), %rdx
+	LONG $0xfba1830f; WORD $0xffff // jae          LBB28_17, $-1119(%rip)
+	LONG $0x000371e9; BYTE $0x00   // jmp          LBB28_79, $881(%rip)
+
+LBB28_53:
+	LONG $0x2444894c; BYTE $0x18   // movq         %r8, $24(%rsp)
+	LONG $0x244c8b49; BYTE $0x08   // movq         $8(%r12), %rcx
+	WORD $0x2948; BYTE $0xd1       // subq         %rdx, %rcx
+	LONG $0x24140349               // addq         (%r12), %rdx
+	WORD $0x3145; BYTE $0xc0       // xorl         %r8d, %r8d
+	QUAD $0xfffffa13156f79c5       // vmovdqa      $-1517(%rip), %xmm10  /* LCPI28_4(%rip) */
+	QUAD $0xfffff9fb0d6ff9c5       // vmovdqa      $-1541(%rip), %xmm1  /* LCPI28_3(%rip) */
+	LONG $0x763141c4; BYTE $0xc9   // vpcmpeqd     %xmm9, %xmm9, %xmm9
+	QUAD $0xfffffa0e1d6ff9c5       // vmovdqa      $-1522(%rip), %xmm3  /* LCPI28_5(%rip) */
+	QUAD $0xfffffa16256ff9c5       // vmovdqa      $-1514(%rip), %xmm4  /* LCPI28_6(%rip) */
+	LONG $0x573841c4; BYTE $0xc0   // vxorps       %xmm8, %xmm8, %xmm8
+	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
+	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
+	WORD $0xf631                   // xorl         %esi, %esi
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x10   // movq         %rcx, $16(%rsp)
+	LONG $0x01cd8c0f; WORD $0x0000 // jl           LBB28_62, $461(%rip)
+
+LBB28_56:
+	LONG $0x126ffac5                           // vmovdqu      (%rdx), %xmm2
+	LONG $0x6a6ffac5; BYTE $0x10               // vmovdqu      $16(%rdx), %xmm5
+	LONG $0x7a6ffac5; BYTE $0x20               // vmovdqu      $32(%rdx), %xmm7
+	LONG $0x726ffac5; BYTE $0x30               // vmovdqu      $48(%rdx), %xmm6
+	LONG $0xc274a9c5                           // vpcmpeqb     %xmm2, %xmm10, %xmm0
+	LONG $0xf8d779c5                           // vpmovmskb    %xmm0, %r15d
+	LONG $0xc574a9c5                           // vpcmpeqb     %xmm5, %xmm10, %xmm0
+	LONG $0xd8d7f9c5                           // vpmovmskb    %xmm0, %ebx
+	LONG $0xc774a9c5                           // vpcmpeqb     %xmm7, %xmm10, %xmm0
+	LONG $0xf8d7f9c5                           // vpmovmskb    %xmm0, %edi
+	LONG $0xc674a9c5                           // vpcmpeqb     %xmm6, %xmm10, %xmm0
+	LONG $0xc8d7f9c5                           // vpmovmskb    %xmm0, %ecx
+	LONG $0x30e1c148                           // shlq         $48, %rcx
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xcf                   // orq          %rcx, %rdi
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xfb                   // orq          %rdi, %rbx
+	WORD $0x0949; BYTE $0xdf                   // orq          %rbx, %r15
+	WORD $0x894c; BYTE $0xf9                   // movq         %r15, %rcx
+	WORD $0x094c; BYTE $0xe9                   // orq          %r13, %rcx
+	LONG $0x000f850f; WORD $0x0000             // jne          LBB28_58, $15(%rip)
+	LONG $0xffc7c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r15
+	WORD $0x3145; BYTE $0xed                   // xorl         %r13d, %r13d
+	LONG $0x000046e9; BYTE $0x00               // jmp          LBB28_59, $70(%rip)
+
+LBB28_58:
+	WORD $0x894c; BYTE $0xe9               // movq         %r13, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x214c; BYTE $0xf9               // andq         %r15, %rcx
+	LONG $0x09148d4c                       // leaq         (%rcx,%rcx), %r10
+	WORD $0x094d; BYTE $0xea               // orq          %r13, %r10
+	WORD $0x894c; BYTE $0xd3               // movq         %r10, %rbx
+	WORD $0xf748; BYTE $0xd3               // notq         %rbx
+	QUAD $0xaaaaaaaaaaaabf48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rdi
+	WORD $0x2149; BYTE $0xff               // andq         %rdi, %r15
+	WORD $0x2149; BYTE $0xdf               // andq         %rbx, %r15
+	WORD $0x3145; BYTE $0xed               // xorl         %r13d, %r13d
+	WORD $0x0149; BYTE $0xcf               // addq         %rcx, %r15
+	LONG $0xc5920f41                       // setb         %r13b
+	WORD $0x014d; BYTE $0xff               // addq         %r15, %r15
+	QUAD $0x555555555555b948; WORD $0x5555 // movabsq      $6148914691236517205, %rcx
+	WORD $0x3149; BYTE $0xcf               // xorq         %rcx, %r15
+	WORD $0x214d; BYTE $0xd7               // andq         %r10, %r15
+	WORD $0xf749; BYTE $0xd7               // notq         %r15
+
+LBB28_59:
+	LONG $0xc174c9c5                       // vpcmpeqb     %xmm1, %xmm6, %xmm0
+	LONG $0xc8d7f9c5                       // vpmovmskb    %xmm0, %ecx
+	LONG $0x30e1c148                       // shlq         $48, %rcx
+	LONG $0xc174c1c5                       // vpcmpeqb     %xmm1, %xmm7, %xmm0
+	LONG $0xf8d7f9c5                       // vpmovmskb    %xmm0, %edi
+	LONG $0x20e7c148                       // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xcf               // orq          %rcx, %rdi
+	LONG $0xc174d1c5                       // vpcmpeqb     %xmm1, %xmm5, %xmm0
+	LONG $0xc8d7f9c5                       // vpmovmskb    %xmm0, %ecx
+	LONG $0x10e1c148                       // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf9               // orq          %rdi, %rcx
+	LONG $0xc174e9c5                       // vpcmpeqb     %xmm1, %xmm2, %xmm0
+	LONG $0xf8d7f9c5                       // vpmovmskb    %xmm0, %edi
+	WORD $0x0948; BYTE $0xcf               // orq          %rcx, %rdi
+	WORD $0x214c; BYTE $0xff               // andq         %r15, %rdi
+	LONG $0x6ef9e1c4; BYTE $0xc7           // vmovq        %rdi, %xmm0
+	LONG $0x4479c3c4; WORD $0x00c1         // vpclmulqdq   $0, %xmm9, %xmm0, %xmm0
+	LONG $0x7ef9c1c4; BYTE $0xc7           // vmovq        %xmm0, %r15
+	WORD $0x314d; BYTE $0xc7               // xorq         %r8, %r15
+	LONG $0xc374e9c5                       // vpcmpeqb     %xmm3, %xmm2, %xmm0
+	LONG $0xf8d7f9c5                       // vpmovmskb    %xmm0, %edi
+	LONG $0xc374d1c5                       // vpcmpeqb     %xmm3, %xmm5, %xmm0
+	LONG $0xd8d7f9c5                       // vpmovmskb    %xmm0, %ebx
+	LONG $0xc374c1c5                       // vpcmpeqb     %xmm3, %xmm7, %xmm0
+	LONG $0xc8d7f9c5                       // vpmovmskb    %xmm0, %ecx
+	LONG $0xc374c9c5                       // vpcmpeqb     %xmm3, %xmm6, %xmm0
+	LONG $0xc0d779c5                       // vpmovmskb    %xmm0, %r8d
+	LONG $0x30e0c149                       // shlq         $48, %r8
+	LONG $0x20e1c148                       // shlq         $32, %rcx
+	WORD $0x094c; BYTE $0xc1               // orq          %r8, %rcx
+	LONG $0x10e3c148                       // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xcb               // orq          %rcx, %rbx
+	WORD $0x0948; BYTE $0xdf               // orq          %rbx, %rdi
+	WORD $0x894d; BYTE $0xf8               // movq         %r15, %r8
+	WORD $0xf749; BYTE $0xd0               // notq         %r8
+	WORD $0x214c; BYTE $0xc7               // andq         %r8, %rdi
+	LONG $0xc474e9c5                       // vpcmpeqb     %xmm4, %xmm2, %xmm0
+	LONG $0xd8d7f9c5                       // vpmovmskb    %xmm0, %ebx
+	LONG $0xc474d1c5                       // vpcmpeqb     %xmm4, %xmm5, %xmm0
+	LONG $0xc8d7f9c5                       // vpmovmskb    %xmm0, %ecx
+	LONG $0xc474c1c5                       // vpcmpeqb     %xmm4, %xmm7, %xmm0
+	LONG $0xd0d779c5                       // vpmovmskb    %xmm0, %r10d
+	LONG $0xc474c9c5                       // vpcmpeqb     %xmm4, %xmm6, %xmm0
+	LONG $0xd8d779c5                       // vpmovmskb    %xmm0, %r11d
+	LONG $0x30e3c149                       // shlq         $48, %r11
+	LONG $0x20e2c149                       // shlq         $32, %r10
+	WORD $0x094d; BYTE $0xda               // orq          %r11, %r10
+	LONG $0x10e1c148                       // shlq         $16, %rcx
+	WORD $0x094c; BYTE $0xd1               // orq          %r10, %rcx
+	WORD $0x0948; BYTE $0xcb               // orq          %rcx, %rbx
+	WORD $0x214c; BYTE $0xc3               // andq         %r8, %rbx
+	LONG $0x0032840f; WORD $0x0000         // je           LBB28_54, $50(%rip)
+	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB28_60:
+	LONG $0xff438d4c               // leaq         $-1(%rbx), %r8
+	WORD $0x894c; BYTE $0xc1       // movq         %r8, %rcx
+	WORD $0x2148; BYTE $0xf9       // andq         %rdi, %rcx
+	LONG $0xb80f48f3; BYTE $0xc9   // popcntq      %rcx, %rcx
+	WORD $0x014c; BYTE $0xc9       // addq         %r9, %rcx
+	WORD $0x3948; BYTE $0xf1       // cmpq         %rsi, %rcx
+	LONG $0x0142860f; WORD $0x0000 // jbe          LBB28_76, $322(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x214c; BYTE $0xc3       // andq         %r8, %rbx
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_60, $-40(%rip)
+
+LBB28_54:
+	LONG $0x3fffc149               // sarq         $63, %r15
+	LONG $0xb80f48f3; BYTE $0xcf   // popcntq      %rdi, %rcx
+	WORD $0x0149; BYTE $0xc9       // addq         %rcx, %r9
+	LONG $0x40c28348               // addq         $64, %rdx
+	LONG $0x244c8b48; BYTE $0x10   // movq         $16(%rsp), %rcx
+	LONG $0xc0c18348               // addq         $-64, %rcx
+	WORD $0x894d; BYTE $0xf8       // movq         %r15, %r8
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x10   // movq         %rcx, $16(%rsp)
+	LONG $0xfe338d0f; WORD $0xffff // jge          LBB28_56, $-461(%rip)
+
+LBB28_62:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x017c8e0f; WORD $0x0000 // jle          LBB28_81, $380(%rip)
+	LONG $0x44297cc5; WORD $0x4024 // vmovaps      %ymm8, $64(%rsp)
+	LONG $0x44297cc5; WORD $0x2024 // vmovaps      %ymm8, $32(%rsp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0xfe0a820f; WORD $0xffff // jb           LBB28_56, $-502(%rip)
+	LONG $0x247c8348; WORD $0x1010 // cmpq         $16, $16(%rsp)
+	LONG $0x00308c0f; WORD $0x0000 // jl           LBB28_67, $48(%rip)
+	LONG $0x245c8b48; BYTE $0x10   // movq         $16(%rsp), %rbx
+	LONG $0x244c8d48; BYTE $0x20   // leaq         $32(%rsp), %rcx
+
+LBB28_66:
+	LONG $0x026ffac5               // vmovdqu      (%rdx), %xmm0
+	LONG $0x017ffac5               // vmovdqu      %xmm0, (%rcx)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c18348               // addq         $16, %rcx
+	LONG $0xf0538d4c               // leaq         $-16(%rbx), %r10
+	LONG $0x1ffb8348               // cmpq         $31, %rbx
+	WORD $0x894c; BYTE $0xd3       // movq         %r10, %rbx
+	LONG $0xffdf8f0f; WORD $0xffff // jg           LBB28_66, $-33(%rip)
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB28_68, $10(%rip)
+
+LBB28_67:
+	LONG $0x244c8d48; BYTE $0x20 // leaq         $32(%rsp), %rcx
+	LONG $0x24548b4c; BYTE $0x10 // movq         $16(%rsp), %r10
+
+LBB28_68:
+	LONG $0x08fa8349               // cmpq         $8, %r10
+	LONG $0x004e8c0f; WORD $0x0000 // jl           LBB28_69, $78(%rip)
+	WORD $0x8b48; BYTE $0x3a       // movq         (%rdx), %rdi
+	WORD $0x8948; BYTE $0x39       // movq         %rdi, (%rcx)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c18348               // addq         $8, %rcx
+	LONG $0xf8c28349               // addq         $-8, %r10
+	LONG $0x04fa8349               // cmpq         $4, %r10
+	LONG $0x003c8d0f; WORD $0x0000 // jge          LBB28_73, $60(%rip)
+
+LBB28_70:
+	LONG $0x02fa8349               // cmpq         $2, %r10
+	LONG $0x004c8c0f; WORD $0x0000 // jl           LBB28_71, $76(%rip)
+
+LBB28_74:
+	WORD $0xb70f; BYTE $0x3a       // movzwl       (%rdx), %edi
+	WORD $0x8966; BYTE $0x39       // movw         %di, (%rcx)
+	LONG $0x02c28348               // addq         $2, %rdx
+	LONG $0x02c18348               // addq         $2, %rcx
+	LONG $0xfec28349               // addq         $-2, %r10
+	WORD $0x8948; BYTE $0xd3       // movq         %rdx, %rbx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0x003a8f0f; WORD $0x0000 // jg           LBB28_75, $58(%rip)
+	LONG $0xfffd6ce9; BYTE $0xff   // jmp          LBB28_56, $-660(%rip)
+
+LBB28_69:
+	LONG $0x04fa8349               // cmpq         $4, %r10
+	LONG $0xffc48c0f; WORD $0xffff // jl           LBB28_70, $-60(%rip)
+
+LBB28_73:
+	WORD $0x3a8b                   // movl         (%rdx), %edi
+	WORD $0x3989                   // movl         %edi, (%rcx)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c18348               // addq         $4, %rcx
+	LONG $0xfcc28349               // addq         $-4, %r10
+	LONG $0x02fa8349               // cmpq         $2, %r10
+	LONG $0xffb48d0f; WORD $0xffff // jge          LBB28_74, $-76(%rip)
+
+LBB28_71:
+	WORD $0x8948; BYTE $0xd3       // movq         %rdx, %rbx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0xfd378e0f; WORD $0xffff // jle          LBB28_56, $-713(%rip)
+
+LBB28_75:
+	WORD $0x138a                 // movb         (%rbx), %dl
+	WORD $0x1188                 // movb         %dl, (%rcx)
+	LONG $0x24548d48; BYTE $0x20 // leaq         $32(%rsp), %rdx
+	LONG $0xfffd29e9; BYTE $0xff // jmp          LBB28_56, $-727(%rip)
+
+LBB28_76:
+	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
+	LONG $0xcbbc0f48                           // bsfq         %rbx, %rcx
+	LONG $0x244c2b48; BYTE $0x10               // subq         $16(%rsp), %rcx
+	WORD $0x0148; BYTE $0xc8                   // addq         %rcx, %rax
+	LONG $0x01c08348                           // addq         $1, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0x244c8b49; BYTE $0x08               // movq         $8(%r12), %rcx
+	WORD $0x3948; BYTE $0xc8                   // cmpq         %rcx, %rax
+	LONG $0xc1470f48                           // cmovaq       %rcx, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0x244c8b48; BYTE $0x18               // movq         $24(%rsp), %rcx
+	LONG $0xc8470f48                           // cmovaq       %rax, %rcx
+	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
+	LONG $0xfff831e9; BYTE $0xff               // jmp          LBB28_17, $-1999(%rip)
+
+LBB28_78:
+	WORD $0x2948; BYTE $0xc2 // subq         %rax, %rdx
+	WORD $0x0148; BYTE $0xf2 // addq         %rsi, %rdx
+
+LBB28_79:
+	WORD $0x8949; BYTE $0x16     // movq         %rdx, (%r14)
+	LONG $0xfff820e9; BYTE $0xff // jmp          LBB28_16, $-2016(%rip)
+
+LBB28_26:
+	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
+	LONG $0x0032850f; WORD $0x0000 // jne          LBB28_82, $50(%rip)
+	WORD $0x014d; BYTE $0xea       // addq         %r13, %r10
+	WORD $0x014d; BYTE $0xf9       // addq         %r15, %r9
+
+LBB28_28:
+	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
+	LONG $0x0066850f; WORD $0x0000 // jne          LBB28_86, $102(%rip)
+	LONG $0xfff806e9; BYTE $0xff   // jmp          LBB28_17, $-2042(%rip)
+
+LBB28_80:
+	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0xf7ad850f; WORD $0xffff // jne          LBB28_7, $-2131(%rip)
+	LONG $0xfff7dde9; BYTE $0xff   // jmp          LBB28_13, $-2083(%rip)
+
+LBB28_81:
+	LONG $0x244c8b49; BYTE $0x08 // movq         $8(%r12), %rcx
+	WORD $0x8949; BYTE $0x0e     // movq         %rcx, (%r14)
+	LONG $0xfff7e8e9; BYTE $0xff // jmp          LBB28_17, $-2072(%rip)
+
+LBB28_82:
+	WORD $0x394d; BYTE $0xe9       // cmpq         %r13, %r9
+	LONG $0xf7df840f; WORD $0xffff // je           LBB28_17, $-2081(%rip)
+	WORD $0x014d; BYTE $0xea       // addq         %r13, %r10
+	LONG $0x01c28349               // addq         $1, %r10
+	WORD $0xf749; BYTE $0xd5       // notq         %r13
+	WORD $0x014d; BYTE $0xe9       // addq         %r13, %r9
+	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
+	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_86, $36(%rip)
+	LONG $0xfff7c4e9; BYTE $0xff   // jmp          LBB28_17, $-2108(%rip)
+
+LBB28_84:
+	LONG $0xfec1c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rcx
+	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
+	WORD $0x0149; BYTE $0xc2                   // addq         %rax, %r10
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
+	LONG $0xf7a5840f; WORD $0xffff             // je           LBB28_17, $-2139(%rip)
+
+LBB28_86:
+	LONG $0x02b60f41                           // movzbl       (%r10), %eax
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0xffd5840f; WORD $0xffff             // je           LBB28_84, $-43(%rip)
+	WORD $0x223c                               // cmpb         $34, %al
+	LONG $0x0024840f; WORD $0x0000             // je           LBB28_89, $36(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
+	WORD $0x0149; BYTE $0xc2                   // addq         %rax, %r10
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
+	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_86, $-51(%rip)
+	LONG $0xfff76de9; BYTE $0xff               // jmp          LBB28_17, $-2195(%rip)
+
+LBB28_89:
+	LONG $0x24542b4c; BYTE $0x10 // subq         $16(%rsp), %r10
+	LONG $0x01c28349             // addq         $1, %r10
+	WORD $0x894d; BYTE $0x16     // movq         %r10, (%r14)
+	LONG $0xfff759e9; BYTE $0xff // jmp          LBB28_16, $-2215(%rip)
+	WORD $0x9090; BYTE $0x90     // .p2align 2, 0x90
+
+	// .set L28_0_set_17, LBB28_17-LJTI28_0
+	// .set L28_0_set_19, LBB28_19-LJTI28_0
+	// .set L28_0_set_20, LBB28_20-LJTI28_0
+	// .set L28_0_set_2, LBB28_2-LJTI28_0
+	// .set L28_0_set_29, LBB28_29-LJTI28_0
+	// .set L28_0_set_52, LBB28_52-LJTI28_0
+	// .set L28_0_set_18, LBB28_18-LJTI28_0
+	// .set L28_0_set_53, LBB28_53-LJTI28_0
+LJTI28_0:
+	LONG $0xfffff759                           // .long L28_0_set_17
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff78e                           // .long L28_0_set_20
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff684                           // .long L28_0_set_2
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff887                           // .long L28_0_set_29
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffffba9                           // .long L28_0_set_52
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff76b                           // .long L28_0_set_18
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff76b                           // .long L28_0_set_18
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffff77f                           // .long L28_0_set_19
+	LONG $0xfffffbbd                           // .long L28_0_set_53
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
+
+_get_by_path:
+	BYTE $0x55                     // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5       // movq         %rsp, %rbp
+	WORD $0x5741                   // pushq        %r15
+	WORD $0x5641                   // pushq        %r14
+	WORD $0x5541                   // pushq        %r13
+	WORD $0x5441                   // pushq        %r12
+	BYTE $0x53                     // pushq        %rbx
+	LONG $0x28ec8348               // subq         $40, %rsp
+	WORD $0x8949; BYTE $0xf6       // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
+	LONG $0x08428b48               // movq         $8(%rdx), %rax
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x063d840f; WORD $0x0000 // je           LBB29_78, $1597(%rip)
+	WORD $0x8b4c; BYTE $0x3a       // movq         (%rdx), %r15
+	LONG $0x04e0c148               // shlq         $4, %rax
+	WORD $0x014c; BYTE $0xf8       // addq         %r15, %rax
+	LONG $0xb0458948               // movq         %rax, $-80(%rbp)
+
+LBB29_2:
+	LONG $0x243c8b49                                                     // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08                                         // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                                             // movq         %r14, %rdx
+	LONG $0xffd23de8; BYTE $0xff                                         // callq        _advance_ns, $-11715(%rip)
+	WORD $0x8b49; BYTE $0x0f                                             // movq         (%r15), %rcx
+	WORD $0x498a; BYTE $0x17                                             // movb         $23(%rcx), %cl
+	WORD $0xe180; BYTE $0x1f                                             // andb         $31, %cl
+	WORD $0xf980; BYTE $0x18                                             // cmpb         $24, %cl
+	LONG $0x059b850f; WORD $0x0000                                       // jne          LBB29_72, $1435(%rip)
+	WORD $0x7b3c                                                         // cmpb         $123, %al
+	LONG $0xc87d894c                                                     // movq         %r15, $-56(%rbp)
+	LONG $0x0610850f; WORD $0x0000                                       // jne          LBB29_79, $1552(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_4:
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08   // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2       // movq         %r14, %rdx
+	LONG $0xffd1ffe8; BYTE $0xff   // callq        _advance_ns, $-11777(%rip)
+	WORD $0x223c                   // cmpb         $34, %al
+	LONG $0x05e8850f; WORD $0x0000 // jne          LBB29_79, $1512(%rip)
+	LONG $0x08478b49               // movq         $8(%r15), %rax
+	WORD $0x8b4c; BYTE $0x28       // movq         (%rax), %r13
+	LONG $0x08788b4c               // movq         $8(%rax), %r15
+	QUAD $0xffffffffb845c748       // movq         $-1, $-72(%rbp)
+	WORD $0x8b49; BYTE $0x1e       // movq         (%r14), %rbx
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
+	LONG $0xb8558d48               // leaq         $-72(%rbp), %rdx
+	LONG $0x001af2e8; BYTE $0x00   // callq        _advance_string_default, $6898(%rip)
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x05d4880f; WORD $0x0000 // js           LBB29_81, $1492(%rip)
+	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
+	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
+	LONG $0xfff98348               // cmpq         $-1, %rcx
+	LONG $0x0009840f; WORD $0x0000 // je           LBB29_8, $9(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x014a8e0f; WORD $0x0000 // jle          LBB29_25, $330(%rip)
+
+LBB29_8:
+	WORD $0x8948; BYTE $0xd9       // movq         %rbx, %rcx
+	WORD $0xf748; BYTE $0xd1       // notq         %rcx
+	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	WORD $0x394c; BYTE $0xf8       // cmpq         %r15, %rax
+	LONG $0x003f850f; WORD $0x0000 // jne          LBB29_12, $63(%rip)
+	WORD $0x0148; BYTE $0xfb       // addq         %rdi, %rbx
+	WORD $0x894c; BYTE $0xe9       // movq         %r13, %rcx
+	WORD $0x8948; BYTE $0xd8       // movq         %rbx, %rax
+
+	// .p2align 4, 0x90
+LBB29_10:
+	LONG $0x10ff8349               // cmpq         $16, %r15
+	LONG $0x0086820f; WORD $0x0000 // jb           LBB29_16, $134(%rip)
+	LONG $0x006ffac5               // vmovdqu      (%rax), %xmm0
+	LONG $0x7479c1c4; WORD $0x0045 // vpcmpeqb     (%r13), %xmm0, %xmm0
+	LONG $0xd0d7f9c5               // vpmovmskb    %xmm0, %edx
+	LONG $0x10c08348               // addq         $16, %rax
+	LONG $0x10c58349               // addq         $16, %r13
+	LONG $0xf0c78349               // addq         $-16, %r15
+	LONG $0x10c18348               // addq         $16, %rcx
+	LONG $0x10c38348               // addq         $16, %rbx
+	LONG $0xfffa8366               // cmpw         $-1, %dx
+	LONG $0xffca840f; WORD $0xffff // je           LBB29_10, $-54(%rip)
+
+LBB29_12:
+	WORD $0xdb31 // xorl         %ebx, %ebx
+
+LBB29_13:
+	LONG $0xc87d8b4c                                       // movq         $-56(%rbp), %r15
+	LONG $0x24748b49; BYTE $0x08                           // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                               // movq         %r14, %rdx
+	LONG $0xffd147e8; BYTE $0xff                           // callq        _advance_ns, $-11961(%rip)
+	WORD $0x3a3c                                           // cmpb         $58, %al
+	LONG $0x0530850f; WORD $0x0000                         // jne          LBB29_79, $1328(%rip)
+	WORD $0x8548; BYTE $0xdb                               // testq        %rbx, %rbx
+	LONG $0x0506850f; WORD $0x0000                         // jne          LBB29_77, $1286(%rip)
+	WORD $0x894c; BYTE $0xe7                               // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6                               // movq         %r14, %rsi
+	LONG $0xfff2dbe8; BYTE $0xff                           // callq        _skip_one_fast, $-3365(%rip)
+	LONG $0x243c8b49                                       // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08                           // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                               // movq         %r14, %rdx
+	LONG $0xffd11ae8; BYTE $0xff                           // callq        _advance_ns, $-12006(%rip)
+	WORD $0x2c3c                                           // cmpb         $44, %al
+	LONG $0xff02840f; WORD $0xffff                         // je           LBB29_4, $-254(%rip)
+	LONG $0x0004fee9; BYTE $0x00                           // jmp          LBB29_79, $1278(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_16:
+	LONG $0x0fffe381; WORD $0x0000 // andl         $4095, %ebx
+	LONG $0x0ff0fb81; WORD $0x0000 // cmpl         $4080, %ebx
+	LONG $0x0040870f; WORD $0x0000 // ja           LBB29_20, $64(%rip)
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0ff1f981; WORD $0x0000 // cmpl         $4081, %ecx
+	LONG $0x002e830f; WORD $0x0000 // jae          LBB29_20, $46(%rip)
+	LONG $0x006ffac5               // vmovdqu      (%rax), %xmm0
+	LONG $0x7479c1c4; WORD $0x0045 // vpcmpeqb     (%r13), %xmm0, %xmm0
+	LONG $0xc0d7f9c5               // vpmovmskb    %xmm0, %eax
+	LONG $0xfff88366               // cmpw         $-1, %ax
+	LONG $0x0055840f; WORD $0x0000 // je           LBB29_24, $85(%rip)
+	WORD $0xd0f7                   // notl         %eax
+	LONG $0xc0bc0f66               // bsfw         %ax, %ax
+	WORD $0xb70f; BYTE $0xc0       // movzwl       %ax, %eax
+	WORD $0xdb31                   // xorl         %ebx, %ebx
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	WORD $0x960f; BYTE $0xc3       // setbe        %bl
+	LONG $0xffff56e9; BYTE $0xff   // jmp          LBB29_13, $-170(%rip)
+
+LBB29_20:
+	LONG $0x000001bb; BYTE $0x00                             // movl         $1, %ebx
+	WORD $0x854d; BYTE $0xff                                 // testq        %r15, %r15
+	LONG $0xff48840f; WORD $0xffff                           // je           LBB29_13, $-184(%rip)
+	WORD $0xc931                                             // xorl         %ecx, %ecx
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB29_22:
+	LONG $0x0814b60f               // movzbl       (%rax,%rcx), %edx
+	LONG $0x0d543a41; BYTE $0x00   // cmpb         (%r13,%rcx), %dl
+	LONG $0xff27850f; WORD $0xffff // jne          LBB29_12, $-217(%rip)
+	LONG $0x01c18348               // addq         $1, %rcx
+	WORD $0x3949; BYTE $0xcf       // cmpq         %rcx, %r15
+	LONG $0xffe4850f; WORD $0xffff // jne          LBB29_22, $-28(%rip)
+	LONG $0xffff17e9; BYTE $0xff   // jmp          LBB29_13, $-233(%rip)
+
+LBB29_24:
+	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
+	LONG $0xffff0de9; BYTE $0xff // jmp          LBB29_13, $-243(%rip)
+
+LBB29_25:
+	QUAD $0x00000000d045c748       // movq         $0, $-48(%rbp)
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	LONG $0x1f1c8d4c               // leaq         (%rdi,%rbx), %r11
+	LONG $0x07048d4c               // leaq         (%rdi,%rax), %r8
+	LONG $0xffc08349               // addq         $-1, %r8
+	LONG $0xffc08348               // addq         $-1, %rax
+	LONG $0x2f148d4f               // leaq         (%r15,%r13), %r10
+	WORD $0x3948; BYTE $0xc3       // cmpq         %rax, %rbx
+	LONG $0x03928d0f; WORD $0x0000 // jge          LBB29_69, $914(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x03898e0f; WORD $0x0000 // jle          LBB29_69, $905(%rip)
+	LONG $0xc045894c               // movq         %r8, $-64(%rbp)
+
+LBB29_28:
+	WORD $0x8a41; BYTE $0x03                   // movb         (%r11), %al
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0x005c850f; WORD $0x0000             // jne          LBB29_33, $92(%rip)
+	WORD $0x894c; BYTE $0xc2                   // movq         %r8, %rdx
+	WORD $0x294c; BYTE $0xda                   // subq         %r11, %rdx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x8548; BYTE $0xd2                   // testq        %rdx, %rdx
+	LONG $0x044d8e0f; WORD $0x0000             // jle          LBB29_84, $1101(%rip)
+	LONG $0x4bb60f41; BYTE $0x01               // movzbl       $1(%r11), %ecx
+	LONG $0x62358d48; WORD $0x0091; BYTE $0x00 // leaq         $37218(%rip), %rsi  /* __UnquoteTab(%rip) */
+	WORD $0x1c8a; BYTE $0x31                   // movb         (%rcx,%rsi), %bl
+	WORD $0xfb80; BYTE $0xff                   // cmpb         $-1, %bl
+	LONG $0x0045840f; WORD $0x0000             // je           LBB29_35, $69(%rip)
+	WORD $0xdb84                               // testb        %bl, %bl
+	LONG $0x0419840f; WORD $0x0000             // je           LBB29_82, $1049(%rip)
+	WORD $0x5d88; BYTE $0xd0                   // movb         %bl, $-48(%rbp)
+	LONG $0x02c38349                           // addq         $2, %r11
+	LONG $0x000001ba; BYTE $0x00               // movl         $1, %edx
+	LONG $0x2a048d48                           // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xd04d8d48                           // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
+	LONG $0x013b820f; WORD $0x0000             // jb           LBB29_46, $315(%rip)
+	LONG $0x00018ae9; BYTE $0x00               // jmp          LBB29_54, $394(%rip)
+
+LBB29_33:
+	LONG $0x00453a41               // cmpb         (%r13), %al
+	LONG $0xfe64850f; WORD $0xffff // jne          LBB29_12, $-412(%rip)
+	LONG $0x01c38349               // addq         $1, %r11
+	LONG $0x01c58349               // addq         $1, %r13
+	LONG $0x00017ce9; BYTE $0x00   // jmp          LBB29_55, $380(%rip)
+
+LBB29_35:
+	LONG $0x04fa8348                           // cmpq         $4, %rdx
+	LONG $0x03e28c0f; WORD $0x0000             // jl           LBB29_83, $994(%rip)
+	LONG $0x024b8d4d                           // leaq         $2(%r11), %r9
+	LONG $0x02738b41                           // movl         $2(%r11), %esi
+	WORD $0xf389                               // movl         %esi, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	LONG $0xcfd08e8d; WORD $0xcfcf             // leal         $-808464432(%rsi), %ecx
+	LONG $0x8080e381; WORD $0x8080             // andl         $-2139062144, %ebx
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	WORD $0xcb85                               // testl        %ecx, %ebx
+	LONG $0x039f850f; WORD $0x0000             // jne          LBB29_86, $927(%rip)
+	LONG $0x19198e8d; WORD $0x1919             // leal         $421075225(%rsi), %ecx
+	WORD $0xf109                               // orl          %esi, %ecx
+	LONG $0x8080c1f7; WORD $0x8080             // testl        $-2139062144, %ecx
+	LONG $0x038b850f; WORD $0x0000             // jne          LBB29_86, $907(%rip)
+	WORD $0xf189                               // movl         %esi, %ecx
+	LONG $0x7f7fe181; WORD $0x7f7f             // andl         $2139062143, %ecx
+	LONG $0xc0c0bf41; WORD $0xc0c0             // movl         $-1061109568, %r15d
+	WORD $0x2941; BYTE $0xcf                   // subl         %ecx, %r15d
+	LONG $0x46818d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rcx), %r8d
+	WORD $0x2141; BYTE $0xdf                   // andl         %ebx, %r15d
+	WORD $0x8545; BYTE $0xc7                   // testl        %r8d, %r15d
+	LONG $0x0367850f; WORD $0x0000             // jne          LBB29_86, $871(%rip)
+	LONG $0xe0e0b841; WORD $0xe0e0             // movl         $-522133280, %r8d
+	WORD $0x2941; BYTE $0xc8                   // subl         %ecx, %r8d
+	LONG $0x3939c181; WORD $0x3939             // addl         $960051513, %ecx
+	WORD $0x2144; BYTE $0xc3                   // andl         %r8d, %ebx
+	WORD $0xcb85                               // testl        %ecx, %ebx
+	LONG $0x0370850f; WORD $0x0000             // jne          LBB29_85, $880(%rip)
+	WORD $0xce0f                               // bswapl       %esi
+	WORD $0xf089                               // movl         %esi, %eax
+	WORD $0xe8c1; BYTE $0x04                   // shrl         $4, %eax
+	WORD $0xd0f7                               // notl         %eax
+	LONG $0x01010125; BYTE $0x01               // andl         $16843009, %eax
+	WORD $0x048d; BYTE $0xc0                   // leal         (%rax,%rax,8), %eax
+	LONG $0x0f0fe681; WORD $0x0f0f             // andl         $252645135, %esi
+	WORD $0xc601                               // addl         %eax, %esi
+	WORD $0xf389                               // movl         %esi, %ebx
+	WORD $0xebc1; BYTE $0x04                   // shrl         $4, %ebx
+	WORD $0xf309                               // orl          %esi, %ebx
+	WORD $0xd889                               // movl         %ebx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xcb                   // movzbl       %bl, %ecx
+	WORD $0xc109                               // orl          %eax, %ecx
+	LONG $0x064b8d4d                           // leaq         $6(%r11), %r9
+	WORD $0xf983; BYTE $0x7f                   // cmpl         $127, %ecx
+	LONG $0xc0458b4c                           // movq         $-64(%rbp), %r8
+	LONG $0x00d0860f; WORD $0x0000             // jbe          LBB29_57, $208(%rip)
+	LONG $0x07fff981; WORD $0x0000             // cmpl         $2047, %ecx
+	LONG $0x00d1860f; WORD $0x0000             // jbe          LBB29_58, $209(%rip)
+	WORD $0xde89                               // movl         %ebx, %esi
+	LONG $0x0000e681; WORD $0x00f8             // andl         $16252928, %esi
+	LONG $0x0000fe81; WORD $0x00d8             // cmpl         $14155776, %esi
+	LONG $0x00db840f; WORD $0x0000             // je           LBB29_59, $219(%rip)
+	WORD $0xe8c1; BYTE $0x0c                   // shrl         $12, %eax
+	WORD $0xe00c                               // orb          $-32, %al
+	WORD $0x4588; BYTE $0xd0                   // movb         %al, $-48(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd1                   // movb         %cl, $-47(%rbp)
+	WORD $0xe380; BYTE $0x3f                   // andb         $63, %bl
+	WORD $0xcb80; BYTE $0x80                   // orb          $-128, %bl
+	WORD $0x5d88; BYTE $0xd2                   // movb         %bl, $-46(%rbp)
+	LONG $0x000003ba; BYTE $0x00               // movl         $3, %edx
+	WORD $0xc389                               // movl         %eax, %ebx
+
+LBB29_44:
+	WORD $0x894d; BYTE $0xcb       // movq         %r9, %r11
+	LONG $0x2a048d48               // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348               // addq         $-48, %rax
+	LONG $0xd04d8d48               // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5       // cmpq         %r10, %r13
+	LONG $0x0054830f; WORD $0x0000 // jae          LBB29_54, $84(%rip)
+
+LBB29_46:
+	WORD $0x3948; BYTE $0xc8       // cmpq         %rcx, %rax
+	LONG $0x0047860f; WORD $0x0000 // jbe          LBB29_53, $71(%rip)
+	LONG $0x005d3841               // cmpb         %bl, (%r13)
+	LONG $0x003d850f; WORD $0x0000 // jne          LBB29_53, $61(%rip)
+	LONG $0x01c58349               // addq         $1, %r13
+	LONG $0xd1558d48               // leaq         $-47(%rbp), %rdx
+	WORD $0x894c; BYTE $0xee       // movq         %r13, %rsi
+
+LBB29_49:
+	WORD $0x8949; BYTE $0xf5       // movq         %rsi, %r13
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	WORD $0x394c; BYTE $0xd6       // cmpq         %r10, %rsi
+	LONG $0x0027830f; WORD $0x0000 // jae          LBB29_54, $39(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x001e830f; WORD $0x0000 // jae          LBB29_54, $30(%rip)
+	LONG $0x5db60f41; BYTE $0x00   // movzbl       (%r13), %ebx
+	LONG $0x01758d49               // leaq         $1(%r13), %rsi
+	LONG $0x01518d48               // leaq         $1(%rcx), %rdx
+	WORD $0x193a                   // cmpb         (%rcx), %bl
+	LONG $0xffd3840f; WORD $0xffff // je           LBB29_49, $-45(%rip)
+	LONG $0x000004e9; BYTE $0x00   // jmp          LBB29_54, $4(%rip)
+
+LBB29_53:
+	LONG $0xd04d8d48 // leaq         $-48(%rbp), %rcx
+
+LBB29_54:
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0xfcdb850f; WORD $0xffff // jne          LBB29_12, $-805(%rip)
+
+LBB29_55:
+	WORD $0x394d; BYTE $0xc3       // cmpq         %r8, %r11
+	LONG $0x0182830f; WORD $0x0000 // jae          LBB29_69, $386(%rip)
+	WORD $0x394d; BYTE $0xd5       // cmpq         %r10, %r13
+	LONG $0xfdf4820f; WORD $0xffff // jb           LBB29_28, $-524(%rip)
+	LONG $0x000174e9; BYTE $0x00   // jmp          LBB29_69, $372(%rip)
+
+LBB29_57:
+	WORD $0x5d88; BYTE $0xd0     // movb         %bl, $-48(%rbp)
+	LONG $0x000001ba; BYTE $0x00 // movl         $1, %edx
+	LONG $0xffff67e9; BYTE $0xff // jmp          LBB29_44, $-153(%rip)
+
+LBB29_58:
+	WORD $0xe9c1; BYTE $0x06     // shrl         $6, %ecx
+	WORD $0xc980; BYTE $0xc0     // orb          $-64, %cl
+	WORD $0x4d88; BYTE $0xd0     // movb         %cl, $-48(%rbp)
+	WORD $0xe380; BYTE $0x3f     // andb         $63, %bl
+	WORD $0xcb80; BYTE $0x80     // orb          $-128, %bl
+	WORD $0x5d88; BYTE $0xd1     // movb         %bl, $-47(%rbp)
+	LONG $0x000002ba; BYTE $0x00 // movl         $2, %edx
+	WORD $0xcb89                 // movl         %ecx, %ebx
+	LONG $0xffff49e9; BYTE $0xff // jmp          LBB29_44, $-183(%rip)
+
+LBB29_59:
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0x06fa8348                           // cmpq         $6, %rdx
+	LONG $0x02248c0f; WORD $0x0000             // jl           LBB29_85, $548(%rip)
+	LONG $0xdbfff981; WORD $0x0000             // cmpl         $56319, %ecx
+	LONG $0x0218870f; WORD $0x0000             // ja           LBB29_85, $536(%rip)
+	LONG $0x5c398041                           // cmpb         $92, (%r9)
+	LONG $0x020e850f; WORD $0x0000             // jne          LBB29_85, $526(%rip)
+	LONG $0x077b8041; BYTE $0x75               // cmpb         $117, $7(%r11)
+	LONG $0x0203850f; WORD $0x0000             // jne          LBB29_85, $515(%rip)
+	LONG $0x084b8d4d                           // leaq         $8(%r11), %r9
+	LONG $0x08538b41                           // movl         $8(%r11), %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	LONG $0xcfd0b28d; WORD $0xcfcf             // leal         $-808464432(%rdx), %esi
+	LONG $0x8080e381; WORD $0x8080             // andl         $-2139062144, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x01c0850f; WORD $0x0000             // jne          LBB29_86, $448(%rip)
+	LONG $0x1919b28d; WORD $0x1919             // leal         $421075225(%rdx), %esi
+	WORD $0xd609                               // orl          %edx, %esi
+	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
+	LONG $0x01ac850f; WORD $0x0000             // jne          LBB29_86, $428(%rip)
+	WORD $0xd689                               // movl         %edx, %esi
+	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
+	LONG $0xc0c0b841; WORD $0xc0c0             // movl         $-1061109568, %r8d
+	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
+	LONG $0x46be8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r15d
+	WORD $0x2141; BYTE $0xd8                   // andl         %ebx, %r8d
+	WORD $0x8545; BYTE $0xf8                   // testl        %r15d, %r8d
+	LONG $0x0188850f; WORD $0x0000             // jne          LBB29_86, $392(%rip)
+	LONG $0xe0e0b841; WORD $0xe0e0             // movl         $-522133280, %r8d
+	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
+	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
+	WORD $0x2144; BYTE $0xc3                   // andl         %r8d, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x016e850f; WORD $0x0000             // jne          LBB29_86, $366(%rip)
+	WORD $0xca0f                               // bswapl       %edx
+	WORD $0xd689                               // movl         %edx, %esi
+	WORD $0xeec1; BYTE $0x04                   // shrl         $4, %esi
+	WORD $0xd6f7                               // notl         %esi
+	LONG $0x0101e681; WORD $0x0101             // andl         $16843009, %esi
+	WORD $0x348d; BYTE $0xf6                   // leal         (%rsi,%rsi,8), %esi
+	LONG $0x0f0fe281; WORD $0x0f0f             // andl         $252645135, %edx
+	WORD $0xf201                               // addl         %esi, %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xebc1; BYTE $0x04                   // shrl         $4, %ebx
+	WORD $0xd309                               // orl          %edx, %ebx
+	WORD $0xda89                               // movl         %ebx, %edx
+	LONG $0x0000e281; WORD $0x00fc             // andl         $16515072, %edx
+	LONG $0x0000fa81; WORD $0x00dc             // cmpl         $14417920, %edx
+	LONG $0x015c850f; WORD $0x0000             // jne          LBB29_85, $348(%rip)
+	WORD $0xd889                               // movl         %ebx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xd3                   // movzbl       %bl, %edx
+	WORD $0xc209                               // orl          %eax, %edx
+	WORD $0xe1c1; BYTE $0x0a                   // shll         $10, %ecx
+	WORD $0x048d; BYTE $0x0a                   // leal         (%rdx,%rcx), %eax
+	WORD $0xd101                               // addl         %edx, %ecx
+	LONG $0x2400c181; WORD $0xfca0             // addl         $-56613888, %ecx
+	WORD $0xcb89                               // movl         %ecx, %ebx
+	WORD $0xebc1; BYTE $0x12                   // shrl         $18, %ebx
+	WORD $0xcb80; BYTE $0xf0                   // orb          $-16, %bl
+	WORD $0x5d88; BYTE $0xd0                   // movb         %bl, $-48(%rbp)
+	WORD $0xca89                               // movl         %ecx, %edx
+	WORD $0xeac1; BYTE $0x0c                   // shrl         $12, %edx
+	WORD $0xe280; BYTE $0x3f                   // andb         $63, %dl
+	WORD $0xca80; BYTE $0x80                   // orb          $-128, %dl
+	WORD $0x5588; BYTE $0xd1                   // movb         %dl, $-47(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd2                   // movb         %cl, $-46(%rbp)
+	WORD $0x3f24                               // andb         $63, %al
+	WORD $0x800c                               // orb          $-128, %al
+	WORD $0x4588; BYTE $0xd3                   // movb         %al, $-45(%rbp)
+	LONG $0x0cc38349                           // addq         $12, %r11
+	LONG $0x000004ba; BYTE $0x00               // movl         $4, %edx
+	LONG $0xc0458b4c                           // movq         $-64(%rbp), %r8
+	LONG $0x2a048d48                           // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xd04d8d48                           // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
+	LONG $0xfe1d820f; WORD $0xffff             // jb           LBB29_46, $-483(%rip)
+	LONG $0xfffe6ce9; BYTE $0xff               // jmp          LBB29_54, $-404(%rip)
+
+LBB29_69:
+	WORD $0x314d; BYTE $0xc3                   // xorq         %r8, %r11
+	WORD $0x314d; BYTE $0xd5                   // xorq         %r10, %r13
+	WORD $0xdb31                               // xorl         %ebx, %ebx
+	WORD $0x094d; BYTE $0xdd                   // orq          %r11, %r13
+	WORD $0x940f; BYTE $0xc3                   // sete         %bl
+	LONG $0xfffb3fe9; BYTE $0xff               // jmp          LBB29_13, $-1217(%rip)
+	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_72:
+	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
+	LONG $0x0078850f; WORD $0x0000 // jne          LBB29_79, $120(%rip)
+	WORD $0x5b3c                   // cmpb         $91, %al
+	LONG $0x0070850f; WORD $0x0000 // jne          LBB29_79, $112(%rip)
+	LONG $0x08478b49               // movq         $8(%r15), %rax
+	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
+	LONG $0x01c38348               // addq         $1, %rbx
+	LONG $0x90909090               // .p2align 4, 0x90
+
+LBB29_75:
+	LONG $0xffc38348                       // addq         $-1, %rbx
+	WORD $0x8548; BYTE $0xdb               // testq        %rbx, %rbx
+	LONG $0x00338e0f; WORD $0x0000         // jle          LBB29_77, $51(%rip)
+	WORD $0x894c; BYTE $0xe7               // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6               // movq         %r14, %rsi
+	LONG $0xffee08e8; BYTE $0xff           // callq        _skip_one_fast, $-4600(%rip)
+	LONG $0x243c8b49                       // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08           // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2               // movq         %r14, %rdx
+	LONG $0xffcc47e8; BYTE $0xff           // callq        _advance_ns, $-13241(%rip)
+	WORD $0x2c3c                           // cmpb         $44, %al
+	LONG $0xffcf840f; WORD $0xffff         // je           LBB29_75, $-49(%rip)
+	LONG $0x00002be9; BYTE $0x00           // jmp          LBB29_79, $43(%rip)
+	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB29_77:
+	LONG $0x10c78349               // addq         $16, %r15
+	LONG $0xb0458b48               // movq         $-80(%rbp), %rax
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	LONG $0xf9d1850f; WORD $0xffff // jne          LBB29_2, $-1583(%rip)
+
+LBB29_78:
+	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6     // movq         %r14, %rsi
+	LONG $0xffedc4e8; BYTE $0xff // callq        _skip_one_fast, $-4668(%rip)
+	LONG $0x00000be9; BYTE $0x00 // jmp          LBB29_80, $11(%rip)
+
+LBB29_79:
+	LONG $0xff068349                           // addq         $-1, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_80:
+	LONG $0x28c48348 // addq         $40, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB29_81:
+	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB29_80, $-35(%rip)
+
+LBB29_86:
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000017e9; BYTE $0x00               // jmp          LBB29_85, $23(%rip)
+
+LBB29_82:
+	LONG $0x01c38349                           // addq         $1, %r11
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB29_84, $4(%rip)
+
+LBB29_83:
+	LONG $0x01c38349 // addq         $1, %r11
+
+LBB29_84:
+	WORD $0x894d; BYTE $0xd9 // movq         %r11, %r9
+
+LBB29_85:
+	WORD $0x2949; BYTE $0xf9                                                     // subq         %rdi, %r9
+	WORD $0x894d; BYTE $0x0e                                                     // movq         %r9, (%r14)
+	LONG $0xffffafe9; BYTE $0xff                                                 // jmp          LBB29_80, $-81(%rip)
+	QUAD $0x0000000000000000; QUAD $0x0000000000000000; WORD $0x0000; BYTE $0x00 // .p2align 5, 0x00
+
+LCPI30_0:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 
 	// .p2align 4, 0x00
-LCPI28_1:
+LCPI30_1:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 
 	// .p2align 4, 0x90
@@ -7176,34 +8318,34 @@ _f32toa:
 	WORD $0xe9c1; BYTE $0x17                   // shrl         $23, %ecx
 	WORD $0xb60f; BYTE $0xd1                   // movzbl       %cl, %edx
 	LONG $0x00fffa81; WORD $0x0000             // cmpl         $255, %edx
-	LONG $0x0e3f840f; WORD $0x0000             // je           LBB28_1, $3647(%rip)
+	LONG $0x0e3f840f; WORD $0x0000             // je           LBB30_1, $3647(%rip)
 	WORD $0x07c6; BYTE $0x2d                   // movb         $45, (%rdi)
 	WORD $0x8941; BYTE $0xc2                   // movl         %eax, %r10d
 	LONG $0x1feac141                           // shrl         $31, %r10d
 	LONG $0x170c8d4e                           // leaq         (%rdi,%r10), %r9
 	LONG $0xffffffa9; BYTE $0x7f               // testl        $2147483647, %eax
-	LONG $0x01a9840f; WORD $0x0000             // je           LBB28_3, $425(%rip)
+	LONG $0x01a9840f; WORD $0x0000             // je           LBB30_3, $425(%rip)
 	LONG $0x7fffff25; BYTE $0x00               // andl         $8388607, %eax
 	WORD $0xd285                               // testl        %edx, %edx
-	LONG $0x0e20840f; WORD $0x0000             // je           LBB28_5, $3616(%rip)
+	LONG $0x0e20840f; WORD $0x0000             // je           LBB30_5, $3616(%rip)
 	LONG $0x00988d44; WORD $0x8000; BYTE $0x00 // leal         $8388608(%rax), %r11d
 	LONG $0x6a828d44; WORD $0xffff; BYTE $0xff // leal         $-150(%rdx), %r8d
 	WORD $0x4a8d; BYTE $0x81                   // leal         $-127(%rdx), %ecx
 	WORD $0xf983; BYTE $0x17                   // cmpl         $23, %ecx
-	LONG $0x001c870f; WORD $0x0000             // ja           LBB28_10, $28(%rip)
+	LONG $0x001c870f; WORD $0x0000             // ja           LBB30_10, $28(%rip)
 	LONG $0x000096b9; BYTE $0x00               // movl         $150, %ecx
 	WORD $0xd129                               // subl         %edx, %ecx
 	LONG $0xffc6c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rsi
 	WORD $0xd348; BYTE $0xe6                   // shlq         %cl, %rsi
 	WORD $0xd6f7                               // notl         %esi
 	WORD $0x8544; BYTE $0xde                   // testl        %r11d, %esi
-	LONG $0x0326840f; WORD $0x0000             // je           LBB28_12, $806(%rip)
+	LONG $0x0326840f; WORD $0x0000             // je           LBB30_12, $806(%rip)
 
-LBB28_10:
+LBB30_10:
 	LONG $0xc84d894c // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948 // movq         %rdi, $-48(%rbp)
 
-LBB28_6:
+LBB30_6:
 	WORD $0x8945; BYTE $0xdf                   // movl         %r11d, %r15d
 	LONG $0x01e78341                           // andl         $1, %r15d
 	WORD $0xc085                               // testl        %eax, %eax
@@ -7228,7 +8370,7 @@ LBB28_6:
 	WORD $0x2944; BYTE $0xf2                   // subl         %r14d, %edx
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xe0d3                               // shll         %cl, %eax
-	LONG $0xc5358d48; WORD $0x00b2; BYTE $0x00 // leaq         $45765(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
+	LONG $0x75358d48; WORD $0x00b6; BYTE $0x00 // leaq         $46709(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
 	LONG $0xd62c8b4c                           // movq         (%rsi,%rdx,8), %r13
 	WORD $0xf749; BYTE $0xe5                   // mulq         %r13
 	WORD $0x8949; BYTE $0xd0                   // movq         %rdx, %r8
@@ -7258,7 +8400,7 @@ LBB28_6:
 	WORD $0x0145; BYTE $0xfc                   // addl         %r15d, %r12d
 	WORD $0x2944; BYTE $0xf9                   // subl         %r15d, %ecx
 	WORD $0xfb83; BYTE $0x28                   // cmpl         $40, %ebx
-	LONG $0x0042820f; WORD $0x0000             // jb           LBB28_31, $66(%rip)
+	LONG $0x0042820f; WORD $0x0000             // jb           LBB30_31, $66(%rip)
 	WORD $0x8944; BYTE $0xc8                   // movl         %r9d, %eax
 	LONG $0xcccccdba; BYTE $0xcc               // movl         $3435973837, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -7275,9 +8417,9 @@ LBB28_6:
 	WORD $0x3948; BYTE $0xfe                   // cmpq         %rdi, %rsi
 	LONG $0xc0960f41                           // setbe        %r8b
 	WORD $0x3845; BYTE $0xc3                   // cmpb         %r8b, %r11b
-	LONG $0x00b7840f; WORD $0x0000             // je           LBB28_8, $183(%rip)
+	LONG $0x00b7840f; WORD $0x0000             // je           LBB30_8, $183(%rip)
 
-LBB28_31:
+LBB30_31:
 	WORD $0x894d; BYTE $0xc8       // movq         %r9, %r8
 	LONG $0x02e8c149               // shrq         $2, %r8
 	WORD $0x8944; BYTE $0xca       // movl         %r9d, %edx
@@ -7288,84 +8430,84 @@ LBB28_31:
 	WORD $0xcf39                   // cmpl         %ecx, %edi
 	WORD $0x960f; BYTE $0xc0       // setbe        %al
 	WORD $0x3040; BYTE $0xf0       // xorb         %sil, %al
-	LONG $0x0048840f; WORD $0x0000 // je           LBB28_32, $72(%rip)
+	LONG $0x0048840f; WORD $0x0000 // je           LBB30_32, $72(%rip)
 	WORD $0xca83; BYTE $0x02       // orl          $2, %edx
 	LONG $0x000001b8; BYTE $0x00   // movl         $1, %eax
 	WORD $0xd339                   // cmpl         %edx, %ebx
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
-	LONG $0x000e870f; WORD $0x0000 // ja           LBB28_35, $14(%rip)
+	LONG $0x000e870f; WORD $0x0000 // ja           LBB30_35, $14(%rip)
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	LONG $0x02e9c041               // shrb         $2, %r9b
 	WORD $0x2041; BYTE $0xc1       // andb         %al, %r9b
 	LONG $0xc1b60f41               // movzbl       %r9b, %eax
 
-LBB28_35:
+LBB30_35:
 	WORD $0x0144; BYTE $0xc0       // addl         %r8d, %eax
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x0030830f; WORD $0x0000 // jae          LBB28_37, $48(%rip)
-	LONG $0x000075e9; BYTE $0x00   // jmp          LBB28_40, $117(%rip)
+	LONG $0x0030830f; WORD $0x0000 // jae          LBB30_37, $48(%rip)
+	LONG $0x000075e9; BYTE $0x00   // jmp          LBB30_40, $117(%rip)
 
-LBB28_3:
+LBB30_3:
 	LONG $0x3001c641             // movb         $48, (%r9)
 	WORD $0x2941; BYTE $0xf9     // subl         %edi, %r9d
 	LONG $0x01c18341             // addl         $1, %r9d
 	WORD $0x8944; BYTE $0xc8     // movl         %r9d, %eax
-	LONG $0x000748e9; BYTE $0x00 // jmp          LBB28_153, $1864(%rip)
+	LONG $0x000748e9; BYTE $0x00 // jmp          LBB30_153, $1864(%rip)
 
-LBB28_32:
+LBB30_32:
 	WORD $0xf939                   // cmpl         %edi, %ecx
 	LONG $0xffd88341               // sbbl         $-1, %r8d
 	WORD $0x8944; BYTE $0xc0       // movl         %r8d, %eax
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x004a820f; WORD $0x0000 // jb           LBB28_40, $74(%rip)
+	LONG $0x004a820f; WORD $0x0000 // jb           LBB30_40, $74(%rip)
 
-LBB28_37:
+LBB30_37:
 	LONG $0x0006bd41; WORD $0x0000 // movl         $6, %r13d
 	LONG $0x0f42403d; BYTE $0x00   // cmpl         $1000000, %eax
-	LONG $0x0077820f; WORD $0x0000 // jb           LBB28_45, $119(%rip)
+	LONG $0x0077820f; WORD $0x0000 // jb           LBB30_45, $119(%rip)
 	LONG $0x0007bd41; WORD $0x0000 // movl         $7, %r13d
 	LONG $0x9896803d; BYTE $0x00   // cmpl         $10000000, %eax
-	LONG $0x0066820f; WORD $0x0000 // jb           LBB28_45, $102(%rip)
+	LONG $0x0066820f; WORD $0x0000 // jb           LBB30_45, $102(%rip)
 	LONG $0xf5e1003d; BYTE $0x05   // cmpl         $100000000, %eax
 	LONG $0x0009bd41; WORD $0x0000 // movl         $9, %r13d
-	LONG $0x000052e9; BYTE $0x00   // jmp          LBB28_44, $82(%rip)
+	LONG $0x000052e9; BYTE $0x00   // jmp          LBB30_44, $82(%rip)
 
-LBB28_8:
+LBB30_8:
 	WORD $0x8844; BYTE $0xc0       // movb         %r8b, %al
 	WORD $0xd001                   // addl         %edx, %eax
 	LONG $0x01c68341               // addl         $1, %r14d
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0xffb6830f; WORD $0xffff // jae          LBB28_37, $-74(%rip)
+	LONG $0xffb6830f; WORD $0xffff // jae          LBB30_37, $-74(%rip)
 
-LBB28_40:
+LBB30_40:
 	LONG $0x0001bd41; WORD $0x0000 // movl         $1, %r13d
 	WORD $0xf883; BYTE $0x0a       // cmpl         $10, %eax
-	LONG $0x002f820f; WORD $0x0000 // jb           LBB28_45, $47(%rip)
+	LONG $0x002f820f; WORD $0x0000 // jb           LBB30_45, $47(%rip)
 	LONG $0x0002bd41; WORD $0x0000 // movl         $2, %r13d
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0x0020820f; WORD $0x0000 // jb           LBB28_45, $32(%rip)
+	LONG $0x0020820f; WORD $0x0000 // jb           LBB30_45, $32(%rip)
 	LONG $0x0003bd41; WORD $0x0000 // movl         $3, %r13d
 	LONG $0x0003e83d; BYTE $0x00   // cmpl         $1000, %eax
-	LONG $0x000f820f; WORD $0x0000 // jb           LBB28_45, $15(%rip)
+	LONG $0x000f820f; WORD $0x0000 // jb           LBB30_45, $15(%rip)
 	LONG $0x0027103d; BYTE $0x00   // cmpl         $10000, %eax
 	LONG $0x0005bd41; WORD $0x0000 // movl         $5, %r13d
 
-LBB28_44:
+LBB30_44:
 	LONG $0x00dd8341 // sbbl         $0, %r13d
 
-LBB28_45:
+LBB30_45:
 	LONG $0x2e0c8d47                           // leal         (%r14,%r13), %r9d
 	LONG $0x2e0c8d43                           // leal         (%r14,%r13), %ecx
 	WORD $0xc183; BYTE $0x05                   // addl         $5, %ecx
 	WORD $0xf983; BYTE $0x1b                   // cmpl         $27, %ecx
-	LONG $0x006d820f; WORD $0x0000             // jb           LBB28_70, $109(%rip)
+	LONG $0x006d820f; WORD $0x0000             // jb           LBB30_70, $109(%rip)
 	WORD $0x8944; BYTE $0xea                   // movl         %r13d, %edx
 	LONG $0x140c8d49                           // leaq         (%r12,%rdx), %rcx
 	LONG $0x01c18348                           // addq         $1, %rcx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x00ca820f; WORD $0x0000             // jb           LBB28_47, $202(%rip)
+	LONG $0x00ca820f; WORD $0x0000             // jb           LBB30_47, $202(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdeaf0f48                           // imulq        %rsi, %rbx
@@ -7373,27 +8515,27 @@ LBB28_45:
 	LONG $0xf0c36944; WORD $0xffd8; BYTE $0xff // imull        $-10000, %ebx, %r8d
 	WORD $0x0141; BYTE $0xc0                   // addl         %eax, %r8d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0x0348840f; WORD $0x0000             // je           LBB28_49, $840(%rip)
+	LONG $0x0348840f; WORD $0x0000             // je           LBB30_49, $840(%rip)
 	WORD $0x8944; BYTE $0xc0                   // movl         %r8d, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
-	LONG $0x2a358d48; WORD $0x003d; BYTE $0x00 // leaq         $15658(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xda358d48; WORD $0x0040; BYTE $0x00 // leaq         $16602(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x3cb70f42; BYTE $0x46               // movzwl       (%rsi,%r8,2), %edi
 	LONG $0xfe798966                           // movw         %di, $-2(%rcx)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0xfc418966                           // movw         %ax, $-4(%rcx)
 	WORD $0x3145; BYTE $0xc0                   // xorl         %r8d, %r8d
-	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB28_51, $794(%rip)
+	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB30_51, $794(%rip)
 
-LBB28_70:
+LBB30_70:
 	WORD $0x8945; BYTE $0xe8                   // movl         %r13d, %r8d
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
-	LONG $0x0120880f; WORD $0x0000             // js           LBB28_71, $288(%rip)
+	LONG $0x0120880f; WORD $0x0000             // js           LBB30_71, $288(%rip)
 	LONG $0x04148d4b                           // leaq         (%r12,%r8), %rdx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x017b820f; WORD $0x0000             // jb           LBB28_124, $379(%rip)
+	LONG $0x017b820f; WORD $0x0000             // jb           LBB30_124, $379(%rip)
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0xb71759be; BYTE $0xd1               // movl         $3518437209, %esi
 	LONG $0xf1af0f48                           // imulq        %rcx, %rsi
@@ -7404,7 +8546,7 @@ LBB28_70:
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf86b; BYTE $0x64                   // imull        $100, %eax, %edi
 	WORD $0xf929                               // subl         %edi, %ecx
-	LONG $0xc83d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15560(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0x783d8d48; WORD $0x0040; BYTE $0x00 // leaq         $16504(%rip), %rdi  /* _Digits(%rip) */
 	LONG $0x4f0cb70f                           // movzwl       (%rdi,%rcx,2), %ecx
 	LONG $0xfe4a8966                           // movw         %cx, $-2(%rdx)
 	LONG $0xfc4a8d48                           // leaq         $-4(%rdx), %rcx
@@ -7413,41 +8555,41 @@ LBB28_70:
 	WORD $0xf089                               // movl         %esi, %eax
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64                   // cmpl         $100, %eax
-	LONG $0x013a830f; WORD $0x0000             // jae          LBB28_128, $314(%rip)
+	LONG $0x013a830f; WORD $0x0000             // jae          LBB30_128, $314(%rip)
 
-LBB28_127:
+LBB30_127:
 	WORD $0xc389                 // movl         %eax, %ebx
-	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB28_130, $364(%rip)
+	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB30_130, $364(%rip)
 
-LBB28_47:
+LBB30_47:
 	WORD $0x3145; BYTE $0xc0       // xorl         %r8d, %r8d
 	WORD $0xc389                   // movl         %eax, %ebx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x02a2830f; WORD $0x0000 // jae          LBB28_54, $674(%rip)
+	LONG $0x02a2830f; WORD $0x0000 // jae          LBB30_54, $674(%rip)
 
-LBB28_53:
+LBB30_53:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB28_56, $740(%rip)
+	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB30_56, $740(%rip)
 
-LBB28_12:
+LBB30_12:
 	WORD $0xd341; BYTE $0xeb                   // shrl         %cl, %r11d
 	LONG $0xa0fb8141; WORD $0x0186; BYTE $0x00 // cmpl         $100000, %r11d
-	LONG $0x01c0820f; WORD $0x0000             // jb           LBB28_18, $448(%rip)
+	LONG $0x01c0820f; WORD $0x0000             // jb           LBB30_18, $448(%rip)
 	LONG $0x000006b9; BYTE $0x00               // movl         $6, %ecx
 	LONG $0x40fb8141; WORD $0x0f42; BYTE $0x00 // cmpl         $1000000, %r11d
-	LONG $0x0022820f; WORD $0x0000             // jb           LBB28_16, $34(%rip)
+	LONG $0x0022820f; WORD $0x0000             // jb           LBB30_16, $34(%rip)
 	LONG $0x000007b9; BYTE $0x00               // movl         $7, %ecx
 	LONG $0x80fb8141; WORD $0x9896; BYTE $0x00 // cmpl         $10000000, %r11d
-	LONG $0x0010820f; WORD $0x0000             // jb           LBB28_16, $16(%rip)
+	LONG $0x0010820f; WORD $0x0000             // jb           LBB30_16, $16(%rip)
 	LONG $0x00fb8141; WORD $0xf5e1; BYTE $0x05 // cmpl         $100000000, %r11d
 	LONG $0x000009b9; BYTE $0x00               // movl         $9, %ecx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 
-LBB28_16:
+LBB30_16:
 	WORD $0x014c; BYTE $0xc9 // addq         %r9, %rcx
 
-LBB28_17:
+LBB30_17:
 	WORD $0x8944; BYTE $0xd8                   // movl         %r11d, %eax
 	LONG $0xb71759ba; BYTE $0xd1               // movl         $3518437209, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -7458,7 +8600,7 @@ LBB28_17:
 	LONG $0x25eec148                           // shrq         $37, %rsi
 	WORD $0xde6b; BYTE $0x64                   // imull        $100, %esi, %ebx
 	WORD $0xd829                               // subl         %ebx, %eax
-	LONG $0x0e1d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15374(%rip), %rbx  /* _Digits(%rip) */
+	LONG $0xbe1d8d48; WORD $0x003f; BYTE $0x00 // leaq         $16318(%rip), %rbx  /* _Digits(%rip) */
 	LONG $0x4304b70f                           // movzwl       (%rbx,%rax,2), %eax
 	LONG $0xfe418966                           // movw         %ax, $-2(%rcx)
 	LONG $0x7304b70f                           // movzwl       (%rbx,%rsi,2), %eax
@@ -7467,22 +8609,22 @@ LBB28_17:
 	LONG $0xfcc18348                           // addq         $-4, %rcx
 	WORD $0x8941; BYTE $0xd3                   // movl         %edx, %r11d
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0175830f; WORD $0x0000             // jae          LBB28_25, $373(%rip)
-	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB28_27, $439(%rip)
+	LONG $0x0175830f; WORD $0x0000             // jae          LBB30_25, $373(%rip)
+	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB30_27, $439(%rip)
 
-LBB28_71:
+LBB30_71:
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x062e8f0f; WORD $0x0000             // jg           LBB28_84, $1582(%rip)
+	LONG $0x062e8f0f; WORD $0x0000             // jg           LBB30_84, $1582(%rip)
 	LONG $0x04c74166; WORD $0x3024; BYTE $0x2e // movw         $11824, (%r12)
 	LONG $0x02c48349                           // addq         $2, %r12
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x061a890f; WORD $0x0000             // jns          LBB28_84, $1562(%rip)
+	LONG $0x061a890f; WORD $0x0000             // jns          LBB30_84, $1562(%rip)
 	WORD $0x8945; BYTE $0xeb                   // movl         %r13d, %r11d
 	WORD $0xf741; BYTE $0xd3                   // notl         %r11d
 	WORD $0x2945; BYTE $0xf3                   // subl         %r14d, %r11d
 	WORD $0xc931                               // xorl         %ecx, %ecx
 	LONG $0x7ffb8341                           // cmpl         $127, %r11d
-	LONG $0x05e4820f; WORD $0x0000             // jb           LBB28_82, $1508(%rip)
+	LONG $0x05e4820f; WORD $0x0000             // jb           LBB30_82, $1508(%rip)
 	WORD $0x894c; BYTE $0xe7                   // movq         %r12, %rdi
 	LONG $0x01c38349                           // addq         $1, %r11
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
@@ -7494,22 +8636,22 @@ LBB28_71:
 	WORD $0x8945; BYTE $0xe7                   // movl         %r12d, %r15d
 	LONG $0x03e78341                           // andl         $3, %r15d
 	LONG $0x80fa8148; WORD $0x0001; BYTE $0x00 // cmpq         $384, %rdx
-	LONG $0x04aa830f; WORD $0x0000             // jae          LBB28_76, $1194(%rip)
+	LONG $0x04aa830f; WORD $0x0000             // jae          LBB30_76, $1194(%rip)
 	WORD $0xd231                               // xorl         %edx, %edx
-	LONG $0x000554e9; BYTE $0x00               // jmp          LBB28_78, $1364(%rip)
+	LONG $0x000554e9; BYTE $0x00               // jmp          LBB30_78, $1364(%rip)
 
-LBB28_124:
+LBB30_124:
 	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0xfec6820f; WORD $0xffff // jb           LBB28_127, $-314(%rip)
+	LONG $0xfec6820f; WORD $0xffff // jb           LBB30_127, $-314(%rip)
 
-LBB28_128:
+LBB30_128:
 	LONG $0xffc18348                           // addq         $-1, %rcx
-	LONG $0x601d8d4c; WORD $0x003b; BYTE $0x00 // leaq         $15200(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x101d8d4c; WORD $0x003f; BYTE $0x00 // leaq         $16144(%rip), %r11  /* _Digits(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_129:
+LBB30_129:
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0x1fde6948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rsi, %rbx
 	LONG $0x25ebc148                           // shrq         $37, %rbx
@@ -7521,29 +8663,29 @@ LBB28_129:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x00270f3d; BYTE $0x00               // cmpl         $9999, %eax
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_129, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_129, $-46(%rip)
 
-LBB28_130:
+LBB30_130:
 	WORD $0x634d; BYTE $0xf1                   // movslq       %r9d, %r14
 	WORD $0xfb83; BYTE $0x0a                   // cmpl         $10, %ebx
-	LONG $0x0023820f; WORD $0x0000             // jb           LBB28_132, $35(%rip)
+	LONG $0x0023820f; WORD $0x0000             // jb           LBB30_132, $35(%rip)
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0x1d0d8d48; WORD $0x003b; BYTE $0x00 // leaq         $15133(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xcd0d8d48; WORD $0x003e; BYTE $0x00 // leaq         $16077(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
 	WORD $0x014d; BYTE $0xf4                   // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0                   // cmpq         %r14, %r8
-	LONG $0x00188c0f; WORD $0x0000             // jl           LBB28_134, $24(%rip)
-	LONG $0x000413e9; BYTE $0x00               // jmp          LBB28_151, $1043(%rip)
+	LONG $0x00188c0f; WORD $0x0000             // jl           LBB30_134, $24(%rip)
+	LONG $0x000413e9; BYTE $0x00               // jmp          LBB30_151, $1043(%rip)
 
-LBB28_132:
+LBB30_132:
 	WORD $0xc380; BYTE $0x30       // addb         $48, %bl
 	LONG $0x241c8841               // movb         %bl, (%r12)
 	WORD $0x014d; BYTE $0xf4       // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0       // cmpq         %r14, %r8
-	LONG $0x04008d0f; WORD $0x0000 // jge          LBB28_151, $1024(%rip)
+	LONG $0x04008d0f; WORD $0x0000 // jge          LBB30_151, $1024(%rip)
 
-LBB28_134:
+LBB30_134:
 	LONG $0x2a048d4b                           // leaq         (%r10,%r13), %rax
 	LONG $0x000c8d49                           // leaq         (%r8,%rax), %rcx
 	LONG $0x01c18348                           // addq         $1, %rcx
@@ -7553,35 +8695,35 @@ LBB28_134:
 	WORD $0x014c; BYTE $0xc0                   // addq         %r8, %rax
 	WORD $0x2949; BYTE $0xc6                   // subq         %rax, %r14
 	LONG $0x10fe8349                           // cmpq         $16, %r14
-	LONG $0x03ca820f; WORD $0x0000             // jb           LBB28_150, $970(%rip)
+	LONG $0x03ca820f; WORD $0x0000             // jb           LBB30_150, $970(%rip)
 	LONG $0x80fe8149; WORD $0x0000; BYTE $0x00 // cmpq         $128, %r14
-	LONG $0x01ff830f; WORD $0x0000             // jae          LBB28_140, $511(%rip)
+	LONG $0x01ff830f; WORD $0x0000             // jae          LBB30_140, $511(%rip)
 	WORD $0x3145; BYTE $0xc9                   // xorl         %r9d, %r9d
-	LONG $0x00033ce9; BYTE $0x00               // jmp          LBB28_137, $828(%rip)
+	LONG $0x00033ce9; BYTE $0x00               // jmp          LBB30_137, $828(%rip)
 
-LBB28_18:
+LBB30_18:
 	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0021820f; WORD $0x0000             // jb           LBB28_21, $33(%rip)
+	LONG $0x0021820f; WORD $0x0000             // jb           LBB30_21, $33(%rip)
 	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0012820f; WORD $0x0000             // jb           LBB28_21, $18(%rip)
+	LONG $0x0012820f; WORD $0x0000             // jb           LBB30_21, $18(%rip)
 	LONG $0x000003b8; BYTE $0x00               // movl         $3, %eax
 	LONG $0xe8fb8141; WORD $0x0003; BYTE $0x00 // cmpl         $1000, %r11d
-	LONG $0x0356830f; WORD $0x0000             // jae          LBB28_23, $854(%rip)
+	LONG $0x0356830f; WORD $0x0000             // jae          LBB30_23, $854(%rip)
 
-LBB28_21:
+LBB30_21:
 	WORD $0x014c; BYTE $0xc8       // addq         %r9, %rax
 	WORD $0x8948; BYTE $0xc1       // movq         %rax, %rcx
 	LONG $0x64fb8341               // cmpl         $100, %r11d
-	LONG $0x0047820f; WORD $0x0000 // jb           LBB28_27, $71(%rip)
+	LONG $0x0047820f; WORD $0x0000 // jb           LBB30_27, $71(%rip)
 
-LBB28_25:
+LBB30_25:
 	LONG $0xffc18348                           // addq         $-1, %rcx
-	LONG $0x6a058d4c; WORD $0x003a; BYTE $0x00 // leaq         $14954(%rip), %r8  /* _Digits(%rip) */
+	LONG $0x1a058d4c; WORD $0x003e; BYTE $0x00 // leaq         $15898(%rip), %r8  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; WORD $0x9090     // .p2align 4, 0x90
 
-LBB28_26:
+LBB30_26:
 	WORD $0x8944; BYTE $0xde                   // movl         %r11d, %esi
 	WORD $0x8944; BYTE $0xdb                   // movl         %r11d, %ebx
 	LONG $0x1fdb694c; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rbx, %r11
@@ -7593,38 +8735,38 @@ LBB28_26:
 	LONG $0xff518966                           // movw         %dx, $-1(%rcx)
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffe81; WORD $0x0000             // cmpl         $9999, %esi
-	LONG $0xffce870f; WORD $0xffff             // ja           LBB28_26, $-50(%rip)
+	LONG $0xffce870f; WORD $0xffff             // ja           LBB30_26, $-50(%rip)
 
-LBB28_27:
+LBB30_27:
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0019820f; WORD $0x0000             // jb           LBB28_29, $25(%rip)
+	LONG $0x0019820f; WORD $0x0000             // jb           LBB30_29, $25(%rip)
 	WORD $0x8944; BYTE $0xd9                   // movl         %r11d, %ecx
-	LONG $0x1a158d48; WORD $0x003a; BYTE $0x00 // leaq         $14874(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xca158d48; WORD $0x003d; BYTE $0x00 // leaq         $15818(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x09894166                           // movw         %cx, (%r9)
 	WORD $0xf829                               // subl         %edi, %eax
-	LONG $0x000321e9; BYTE $0x00               // jmp          LBB28_153, $801(%rip)
+	LONG $0x000321e9; BYTE $0x00               // jmp          LBB30_153, $801(%rip)
 
-LBB28_29:
+LBB30_29:
 	LONG $0x30c38041             // addb         $48, %r11b
 	WORD $0x8845; BYTE $0x19     // movb         %r11b, (%r9)
 	WORD $0xf829                 // subl         %edi, %eax
-	LONG $0x000313e9; BYTE $0x00 // jmp          LBB28_153, $787(%rip)
+	LONG $0x000313e9; BYTE $0x00 // jmp          LBB30_153, $787(%rip)
 
-LBB28_49:
+LBB30_49:
 	LONG $0x0004b841; WORD $0x0000 // movl         $4, %r8d
 
-LBB28_51:
+LBB30_51:
 	LONG $0xfcc18348               // addq         $-4, %rcx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xfd5e820f; WORD $0xffff // jb           LBB28_53, $-674(%rip)
+	LONG $0xfd5e820f; WORD $0xffff // jb           LBB30_53, $-674(%rip)
 
-LBB28_54:
+LBB30_54:
 	LONG $0xffc18348                                                     // addq         $-1, %rcx
-	LONG $0xdf1d8d4c; WORD $0x0039; BYTE $0x00                           // leaq         $14815(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x8f1d8d4c; WORD $0x003d; BYTE $0x00                           // leaq         $15759(%rip), %r11  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_55:
+LBB30_55:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -7636,83 +8778,83 @@ LBB28_55:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd1870f; WORD $0xffff             // ja           LBB28_55, $-47(%rip)
+	LONG $0xffd1870f; WORD $0xffff             // ja           LBB30_55, $-47(%rip)
 
-LBB28_56:
+LBB30_56:
 	LONG $0x244c8d49; BYTE $0x01               // leaq         $1(%r12), %rcx
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001f820f; WORD $0x0000             // jb           LBB28_58, $31(%rip)
+	LONG $0x001f820f; WORD $0x0000             // jb           LBB30_58, $31(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
-	LONG $0x8a3d8d48; WORD $0x0039; BYTE $0x00 // leaq         $14730(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0x3a3d8d48; WORD $0x003d; BYTE $0x00 // leaq         $15674(%rip), %rdi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x77                   // movb         (%rdi,%rsi,2), %al
 	LONG $0x01775c8a                           // movb         $1(%rdi,%rsi,2), %bl
 	LONG $0x24448841; BYTE $0x01               // movb         %al, $1(%r12)
 	LONG $0x245c8841; BYTE $0x02               // movb         %bl, $2(%r12)
-	LONG $0x000004e9; BYTE $0x00               // jmp          LBB28_59, $4(%rip)
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB30_59, $4(%rip)
 
-LBB28_58:
+LBB30_58:
 	WORD $0x3004 // addb         $48, %al
 	WORD $0x0188 // movb         %al, (%rcx)
 
-LBB28_59:
+LBB30_59:
 	WORD $0x294d; BYTE $0xc2     // subq         %r8, %r10
 	WORD $0x014d; BYTE $0xea     // addq         %r13, %r10
 	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
 	WORD $0x294c; BYTE $0xc3     // subq         %r8, %rbx
 	WORD $0x9090                 // .p2align 4, 0x90
 
-LBB28_60:
+LBB30_60:
 	LONG $0xffc38348               // addq         $-1, %rbx
 	LONG $0x123c8041; BYTE $0x30   // cmpb         $48, (%r10,%rdx)
 	LONG $0xff528d4d               // leaq         $-1(%r10), %r10
-	LONG $0xffed840f; WORD $0xffff // je           LBB28_60, $-19(%rip)
+	LONG $0xffed840f; WORD $0xffff // je           LBB30_60, $-19(%rip)
 	LONG $0x24048841               // movb         %al, (%r12)
 	WORD $0x0148; BYTE $0xd3       // addq         %rdx, %rbx
 	LONG $0x02fb8348               // cmpq         $2, %rbx
-	LONG $0x00468c0f; WORD $0x0000 // jl           LBB28_62, $70(%rip)
+	LONG $0x00468c0f; WORD $0x0000 // jl           LBB30_62, $70(%rip)
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x02c08348               // addq         $2, %rax
 	WORD $0x01c6; BYTE $0x2e       // movb         $46, (%rcx)
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00438e0f; WORD $0x0000 // jle          LBB28_65, $67(%rip)
+	LONG $0x00438e0f; WORD $0x0000 // jle          LBB30_65, $67(%rip)
 
-LBB28_66:
+LBB30_66:
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0x2b0140c6               // movb         $43, $1(%rax)
 	WORD $0x8944; BYTE $0xc9       // movl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0x00448c0f; WORD $0x0000 // jl           LBB28_69, $68(%rip)
+	LONG $0x00448c0f; WORD $0x0000 // jl           LBB30_69, $68(%rip)
 
-LBB28_68:
+LBB30_68:
 	WORD $0x6348; BYTE $0xc9                   // movslq       %ecx, %rcx
-	LONG $0x07158d48; WORD $0x0039; BYTE $0x00 // leaq         $14599(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xb7158d48; WORD $0x003c; BYTE $0x00 // leaq         $15543(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x02488966                           // movw         %cx, $2(%rax)
 	LONG $0x04c08348                           // addq         $4, %rax
-	LONG $0x000209e9; BYTE $0x00               // jmp          LBB28_152, $521(%rip)
+	LONG $0x000209e9; BYTE $0x00               // jmp          LBB30_152, $521(%rip)
 
-LBB28_62:
+LBB30_62:
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB28_66, $-67(%rip)
+	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB30_66, $-67(%rip)
 
-LBB28_65:
+LBB30_65:
 	LONG $0x2d0140c6               // movb         $45, $1(%rax)
 	LONG $0x000001b9; BYTE $0x00   // movl         $1, %ecx
 	WORD $0x2944; BYTE $0xc9       // subl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB28_68, $-68(%rip)
+	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB30_68, $-68(%rip)
 
-LBB28_69:
+LBB30_69:
 	WORD $0xc180; BYTE $0x30     // addb         $48, %cl
 	WORD $0x4888; BYTE $0x02     // movb         %cl, $2(%rax)
 	LONG $0x03c08348             // addq         $3, %rax
-	LONG $0x0001d1e9; BYTE $0x00 // jmp          LBB28_152, $465(%rip)
+	LONG $0x0001d1e9; BYTE $0x00 // jmp          LBB30_152, $465(%rip)
 
-LBB28_140:
+LBB30_140:
 	WORD $0x894d; BYTE $0xf1       // movq         %r14, %r9
 	LONG $0x80e18349               // andq         $-128, %r9
 	LONG $0x80418d49               // leaq         $-128(%r9), %rax
@@ -7722,21 +8864,21 @@ LBB28_140:
 	WORD $0x8941; BYTE $0xdb       // movl         %ebx, %r11d
 	LONG $0x03e38341               // andl         $3, %r11d
 	LONG $0x01803d48; WORD $0x0000 // cmpq         $384, %rax
-	LONG $0x0007830f; WORD $0x0000 // jae          LBB28_142, $7(%rip)
+	LONG $0x0007830f; WORD $0x0000 // jae          LBB30_142, $7(%rip)
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	LONG $0x0000afe9; BYTE $0x00   // jmp          LBB28_144, $175(%rip)
+	LONG $0x0000afe9; BYTE $0x00   // jmp          LBB30_144, $175(%rip)
 
-LBB28_142:
+LBB30_142:
 	LONG $0x02048d4b               // leaq         (%r10,%r8), %rax
 	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
 	LONG $0x01e00548; WORD $0x0000 // addq         $480, %rax
 	LONG $0xfce38348               // andq         $-4, %rbx
 	WORD $0xf748; BYTE $0xdb       // negq         %rbx
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	QUAD $0xfffff810056ffdc5       // vmovdqa      $-2032(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff810056ffdc5       // vmovdqa      $-2032(%rip), %ymm0  /* LCPI30_0(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_143:
+LBB30_143:
 	QUAD $0xfffe2008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-480(%rax,%rcx)
 	QUAD $0xfffe4008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-448(%rax,%rcx)
 	QUAD $0xfffe6008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-416(%rax,%rcx)
@@ -7755,36 +8897,36 @@ LBB28_143:
 	LONG $0x047ffec5; BYTE $0x08               // vmovdqu      %ymm0, (%rax,%rcx)
 	LONG $0x00c18148; WORD $0x0002; BYTE $0x00 // addq         $512, %rcx
 	LONG $0x04c38348                           // addq         $4, %rbx
-	LONG $0xff6f850f; WORD $0xffff             // jne          LBB28_143, $-145(%rip)
+	LONG $0xff6f850f; WORD $0xffff             // jne          LBB30_143, $-145(%rip)
 
-LBB28_144:
+LBB30_144:
 	WORD $0x854d; BYTE $0xdb               // testq        %r11, %r11
-	LONG $0x004a840f; WORD $0x0000         // je           LBB28_147, $74(%rip)
+	LONG $0x004a840f; WORD $0x0000         // je           LBB30_147, $74(%rip)
 	WORD $0x014c; BYTE $0xd1               // addq         %r10, %rcx
 	WORD $0x014c; BYTE $0xc1               // addq         %r8, %rcx
 	LONG $0x29048d4a                       // leaq         (%rcx,%r13), %rax
 	LONG $0x60c08348                       // addq         $96, %rax
 	LONG $0x07e3c149                       // shlq         $7, %r11
 	WORD $0xc931                           // xorl         %ecx, %ecx
-	QUAD $0xfffff75a056ffdc5               // vmovdqa      $-2214(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff75a056ffdc5               // vmovdqa      $-2214(%rip), %ymm0  /* LCPI30_0(%rip) */
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_146:
+LBB30_146:
 	LONG $0x447ffec5; WORD $0xa008 // vmovdqu      %ymm0, $-96(%rax,%rcx)
 	LONG $0x447ffec5; WORD $0xc008 // vmovdqu      %ymm0, $-64(%rax,%rcx)
 	LONG $0x447ffec5; WORD $0xe008 // vmovdqu      %ymm0, $-32(%rax,%rcx)
 	LONG $0x047ffec5; BYTE $0x08   // vmovdqu      %ymm0, (%rax,%rcx)
 	LONG $0x80e98348               // subq         $-128, %rcx
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0xffdc850f; WORD $0xffff // jne          LBB28_146, $-36(%rip)
+	LONG $0xffdc850f; WORD $0xffff // jne          LBB30_146, $-36(%rip)
 
-LBB28_147:
+LBB30_147:
 	WORD $0x394d; BYTE $0xce       // cmpq         %r9, %r14
-	LONG $0x0093840f; WORD $0x0000 // je           LBB28_151, $147(%rip)
+	LONG $0x0093840f; WORD $0x0000 // je           LBB30_151, $147(%rip)
 	LONG $0x70c6f641               // testb        $112, %r14b
-	LONG $0x0071840f; WORD $0x0000 // je           LBB28_149, $113(%rip)
+	LONG $0x0071840f; WORD $0x0000 // je           LBB30_149, $113(%rip)
 
-LBB28_137:
+LBB30_137:
 	WORD $0x894c; BYTE $0xf0       // movq         %r14, %rax
 	LONG $0xf0e08348               // andq         $-16, %rax
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
@@ -7794,45 +8936,45 @@ LBB28_137:
 	WORD $0x8948; BYTE $0xc1       // movq         %rax, %rcx
 	WORD $0x294c; BYTE $0xc9       // subq         %r9, %rcx
 	WORD $0xdb31                   // xorl         %ebx, %ebx
-	QUAD $0xfffff716056ff9c5       // vmovdqa      $-2282(%rip), %xmm0  /* LCPI28_1(%rip) */
+	QUAD $0xfffff716056ff9c5       // vmovdqa      $-2282(%rip), %xmm0  /* LCPI30_1(%rip) */
 	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_138:
+LBB30_138:
 	LONG $0x7f7ac1c4; WORD $0x1a04 // vmovdqu      %xmm0, (%r10,%rbx)
 	LONG $0x10c38348               // addq         $16, %rbx
 	WORD $0x3948; BYTE $0xd9       // cmpq         %rbx, %rcx
-	LONG $0xffed850f; WORD $0xffff // jne          LBB28_138, $-19(%rip)
+	LONG $0xffed850f; WORD $0xffff // jne          LBB30_138, $-19(%rip)
 	WORD $0x3949; BYTE $0xc6       // cmpq         %rax, %r14
-	LONG $0x0034850f; WORD $0x0000 // jne          LBB28_150, $52(%rip)
-	LONG $0x00003fe9; BYTE $0x00   // jmp          LBB28_151, $63(%rip)
+	LONG $0x0034850f; WORD $0x0000 // jne          LBB30_150, $52(%rip)
+	LONG $0x00003fe9; BYTE $0x00   // jmp          LBB30_151, $63(%rip)
 
-LBB28_23:
+LBB30_23:
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
 	WORD $0x894c; BYTE $0xc9                   // movq         %r9, %rcx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 	LONG $0x05c18348                           // addq         $5, %rcx
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
-	LONG $0xfad2830f; WORD $0xffff             // jae          LBB28_17, $-1326(%rip)
+	LONG $0xfad2830f; WORD $0xffff             // jae          LBB30_17, $-1326(%rip)
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
-	LONG $0xfffc93e9; BYTE $0xff               // jmp          LBB28_25, $-877(%rip)
+	LONG $0xfffc93e9; BYTE $0xff               // jmp          LBB30_25, $-877(%rip)
 
-LBB28_149:
+LBB30_149:
 	WORD $0x014c; BYTE $0xca     // addq         %r9, %rdx
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_150:
+LBB30_150:
 	WORD $0x02c6; BYTE $0x30       // movb         $48, (%rdx)
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0x394c; BYTE $0xe2       // cmpq         %r12, %rdx
-	LONG $0xfff0820f; WORD $0xffff // jb           LBB28_150, $-16(%rip)
+	LONG $0xfff0820f; WORD $0xffff // jb           LBB30_150, $-16(%rip)
 
-LBB28_151:
+LBB30_151:
 	WORD $0x894c; BYTE $0xe0 // movq         %r12, %rax
 
-LBB28_152:
+LBB30_152:
 	WORD $0x2944; BYTE $0xe8 // subl         %r13d, %eax
 
-LBB28_153:
+LBB30_153:
 	LONG $0x10c48348         // addq         $16, %rsp
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
@@ -7843,16 +8985,16 @@ LBB28_153:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	BYTE $0xc3               // retq
 
-LBB28_76:
+LBB30_76:
 	LONG $0xd0558b48                           // movq         $-48(%rbp), %rdx
 	LONG $0x121c8d49                           // leaq         (%r10,%rdx), %rbx
 	LONG $0xe2c38148; WORD $0x0001; BYTE $0x00 // addq         $482, %rbx
 	LONG $0xfce48349                           // andq         $-4, %r12
 	WORD $0xf749; BYTE $0xdc                   // negq         %r12
 	WORD $0xd231                               // xorl         %edx, %edx
-	QUAD $0xfffff658056ffdc5                   // vmovdqa      $-2472(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff658056ffdc5                   // vmovdqa      $-2472(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_77:
+LBB30_77:
 	QUAD $0xfffe2013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-480(%rbx,%rdx)
 	QUAD $0xfffe4013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-448(%rbx,%rdx)
 	QUAD $0xfffe6013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-416(%rbx,%rdx)
@@ -7871,94 +9013,94 @@ LBB28_77:
 	LONG $0x047ffec5; BYTE $0x13               // vmovdqu      %ymm0, (%rbx,%rdx)
 	LONG $0x00c28148; WORD $0x0002; BYTE $0x00 // addq         $512, %rdx
 	LONG $0x04c48349                           // addq         $4, %r12
-	LONG $0xff6f850f; WORD $0xffff             // jne          LBB28_77, $-145(%rip)
+	LONG $0xff6f850f; WORD $0xffff             // jne          LBB30_77, $-145(%rip)
 
-LBB28_78:
+LBB30_78:
 	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0040840f; WORD $0x0000 // je           LBB28_81, $64(%rip)
+	LONG $0x0040840f; WORD $0x0000 // je           LBB30_81, $64(%rip)
 	WORD $0x014c; BYTE $0xd2       // addq         %r10, %rdx
 	LONG $0xd0758b48               // movq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xf2       // addq         %rsi, %rdx
 	LONG $0x62c28348               // addq         $98, %rdx
 	LONG $0x07e7c149               // shlq         $7, %r15
 	WORD $0xf631                   // xorl         %esi, %esi
-	QUAD $0xfffff5a2056ffdc5       // vmovdqa      $-2654(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff5a2056ffdc5       // vmovdqa      $-2654(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_80:
+LBB30_80:
 	LONG $0x447ffec5; WORD $0xa032 // vmovdqu      %ymm0, $-96(%rdx,%rsi)
 	LONG $0x447ffec5; WORD $0xc032 // vmovdqu      %ymm0, $-64(%rdx,%rsi)
 	LONG $0x447ffec5; WORD $0xe032 // vmovdqu      %ymm0, $-32(%rdx,%rsi)
 	LONG $0x047ffec5; BYTE $0x32   // vmovdqu      %ymm0, (%rdx,%rsi)
 	LONG $0x80ee8348               // subq         $-128, %rsi
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0xffdc850f; WORD $0xffff // jne          LBB28_80, $-36(%rip)
+	LONG $0xffdc850f; WORD $0xffff // jne          LBB30_80, $-36(%rip)
 
-LBB28_81:
+LBB30_81:
 	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
 	WORD $0x0149; BYTE $0xcc       // addq         %rcx, %r12
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0x0021840f; WORD $0x0000 // je           LBB28_84, $33(%rip)
+	LONG $0x0021840f; WORD $0x0000 // je           LBB30_84, $33(%rip)
 
-LBB28_82:
+LBB30_82:
 	WORD $0x0144; BYTE $0xc9               // addl         %r9d, %ecx
 	WORD $0xd9f7                           // negl         %ecx
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_83:
+LBB30_83:
 	LONG $0x2404c641; BYTE $0x30   // movb         $48, (%r12)
 	LONG $0x01c48349               // addq         $1, %r12
 	WORD $0xc183; BYTE $0xff       // addl         $-1, %ecx
-	LONG $0xffee850f; WORD $0xffff // jne          LBB28_83, $-18(%rip)
+	LONG $0xffee850f; WORD $0xffff // jne          LBB30_83, $-18(%rip)
 
-LBB28_84:
+LBB30_84:
 	LONG $0x043c8d4f                           // leaq         (%r12,%r8), %r15
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x0050820f; WORD $0x0000             // jb           LBB28_85, $80(%rip)
+	LONG $0x0050820f; WORD $0x0000             // jb           LBB30_85, $80(%rip)
 	WORD $0xc289                               // movl         %eax, %edx
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdaaf0f48                           // imulq        %rdx, %rbx
 	LONG $0x2debc148                           // shrq         $45, %rbx
 	LONG $0xd8f0d369; WORD $0xffff             // imull        $-10000, %ebx, %edx
 	WORD $0xc201                               // addl         %eax, %edx
-	LONG $0x004b840f; WORD $0x0000             // je           LBB28_87, $75(%rip)
+	LONG $0x004b840f; WORD $0x0000             // je           LBB30_87, $75(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0xf229                               // subl         %esi, %edx
-	LONG $0x69358d48; WORD $0x0035; BYTE $0x00 // leaq         $13673(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x19358d48; WORD $0x0039; BYTE $0x00 // leaq         $14617(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x5614b70f                           // movzwl       (%rsi,%rdx,2), %edx
 	LONG $0x57894166; BYTE $0xfe               // movw         %dx, $-2(%r15)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0x47894166; BYTE $0xfc               // movw         %ax, $-4(%r15)
 	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB28_89, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB30_89, $30(%rip)
 
-LBB28_85:
+LBB30_85:
 	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
 	WORD $0x894c; BYTE $0xfa       // movq         %r15, %rdx
 	WORD $0xc389                   // movl         %eax, %ebx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x001a830f; WORD $0x0000 // jae          LBB28_92, $26(%rip)
+	LONG $0x001a830f; WORD $0x0000 // jae          LBB30_92, $26(%rip)
 
-LBB28_91:
+LBB30_91:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x000055e9; BYTE $0x00 // jmp          LBB28_94, $85(%rip)
+	LONG $0x000055e9; BYTE $0x00 // jmp          LBB30_94, $85(%rip)
 
-LBB28_87:
+LBB30_87:
 	LONG $0x0004bb41; WORD $0x0000 // movl         $4, %r11d
 
-LBB28_89:
+LBB30_89:
 	LONG $0xfc578d49               // leaq         $-4(%r15), %rdx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xffe6820f; WORD $0xffff // jb           LBB28_91, $-26(%rip)
+	LONG $0xffe6820f; WORD $0xffff // jb           LBB30_91, $-26(%rip)
 
-LBB28_92:
+LBB30_92:
 	LONG $0xffc28348                           // addq         $-1, %rdx
-	LONG $0x19358d48; WORD $0x0035; BYTE $0x00 // leaq         $13593(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xc9358d48; WORD $0x0038; BYTE $0x00 // leaq         $14537(%rip), %rsi  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB28_93:
+LBB30_93:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -7970,24 +9112,24 @@ LBB28_93:
 	LONG $0xfec28348                           // addq         $-2, %rdx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_93, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_93, $-46(%rip)
 
-LBB28_94:
+LBB30_94:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001a820f; WORD $0x0000             // jb           LBB28_96, $26(%rip)
+	LONG $0x001a820f; WORD $0x0000             // jb           LBB30_96, $26(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xd00d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13520(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x800d8d48; WORD $0x0038; BYTE $0x00 // leaq         $14464(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x894d; BYTE $0xe2                   // movq         %r12, %r10
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
-	LONG $0x000009e9; BYTE $0x00               // jmp          LBB28_97, $9(%rip)
+	LONG $0x000009e9; BYTE $0x00               // jmp          LBB30_97, $9(%rip)
 
-LBB28_96:
+LBB30_96:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x894d; BYTE $0xe2 // movq         %r12, %r10
 	LONG $0x24048841         // movb         %al, (%r12)
 
-LBB28_97:
+LBB30_97:
 	WORD $0x294d; BYTE $0xdf     // subq         %r11, %r15
 	WORD $0x294d; BYTE $0xd8     // subq         %r11, %r8
 	LONG $0x01c08349             // addq         $1, %r8
@@ -8005,51 +9147,51 @@ LBB28_97:
 	WORD $0x8944; BYTE $0xe6     // movl         %r12d, %esi
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_98:
+LBB30_98:
 	WORD $0xc180; BYTE $0x03       // addb         $3, %cl
 	WORD $0xc683; BYTE $0x01       // addl         $1, %esi
 	LONG $0x1f7c8041; WORD $0x30ff // cmpb         $48, $-1(%r15,%rbx)
 	LONG $0xff5b8d48               // leaq         $-1(%rbx), %rbx
-	LONG $0xffea840f; WORD $0xffff // je           LBB28_98, $-22(%rip)
+	LONG $0xffea840f; WORD $0xffff // je           LBB30_98, $-22(%rip)
 	LONG $0x1f048d49               // leaq         (%r15,%rbx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00458e0f; WORD $0x0000 // jle          LBB28_100, $69(%rip)
+	LONG $0x00458e0f; WORD $0x0000 // jle          LBB30_100, $69(%rip)
 	WORD $0x2945; BYTE $0xdd       // subl         %r11d, %r13d
 	LONG $0x2b3c8d42               // leal         (%rbx,%r13), %edi
 	WORD $0xc783; BYTE $0x01       // addl         $1, %edi
 	WORD $0x3941; BYTE $0xf9       // cmpl         %edi, %r9d
-	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB28_102, $59(%rip)
+	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB30_102, $59(%rip)
 	WORD $0xc283; BYTE $0xff       // addl         $-1, %edx
 	WORD $0x6348; BYTE $0xc2       // movslq       %edx, %rax
 	LONG $0x18348d48               // leaq         (%rax,%rbx), %rsi
 	LONG $0x01c68348               // addq         $1, %rsi
 	WORD $0xf685                   // testl        %esi, %esi
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
-	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB28_120, $245(%rip)
+	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB30_120, $245(%rip)
 	WORD $0x8941; BYTE $0xf0       // movl         %esi, %r8d
 	LONG $0xff508d49               // leaq         $-1(%r8), %rdx
 	LONG $0x03fa8348               // cmpq         $3, %rdx
-	LONG $0x007b830f; WORD $0x0000 // jae          LBB28_121, $123(%rip)
+	LONG $0x007b830f; WORD $0x0000 // jae          LBB30_121, $123(%rip)
 	WORD $0xd231                   // xorl         %edx, %edx
-	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB28_117, $160(%rip)
+	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB30_117, $160(%rip)
 
-LBB28_100:
+LBB30_100:
 	LONG $0xd06d8b4c             // movq         $-48(%rbp), %r13
-	LONG $0xfffd1ee9; BYTE $0xff // jmp          LBB28_152, $-738(%rip)
+	LONG $0xfffd1ee9; BYTE $0xff // jmp          LBB30_152, $-738(%rip)
 
-LBB28_102:
+LBB30_102:
 	WORD $0x8945; BYTE $0xf6                   // movl         %r14d, %r14d
 	WORD $0x2949; BYTE $0xde                   // subq         %rbx, %r14
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0xfd0b8e0f; WORD $0xffff             // jle          LBB28_152, $-757(%rip)
+	LONG $0xfd0b8e0f; WORD $0xffff             // jle          LBB30_152, $-757(%rip)
 	WORD $0x8945; BYTE $0xe3                   // movl         %r12d, %r11d
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
 	WORD $0x2948; BYTE $0xd9                   // subq         %rbx, %rcx
 	WORD $0xd231                               // xorl         %edx, %edx
 	WORD $0xf983; BYTE $0x7f                   // cmpl         $127, %ecx
-	LONG $0x0204820f; WORD $0x0000             // jb           LBB28_112, $516(%rip)
+	LONG $0x0204820f; WORD $0x0000             // jb           LBB30_112, $516(%rip)
 	WORD $0x2949; BYTE $0xdb                   // subq         %rbx, %r11
 	WORD $0x8941; BYTE $0xc9                   // movl         %ecx, %r9d
 	LONG $0x01c18349                           // addq         $1, %r9
@@ -8065,28 +9207,28 @@ LBB28_102:
 	LONG $0x07e8c149                           // shrq         $7, %r8
 	LONG $0x01c08349                           // addq         $1, %r8
 	LONG $0x80f98148; WORD $0x0001; BYTE $0x00 // cmpq         $384, %rcx
-	LONG $0x0085830f; WORD $0x0000             // jae          LBB28_106, $133(%rip)
+	LONG $0x0085830f; WORD $0x0000             // jae          LBB30_106, $133(%rip)
 	WORD $0xc931                               // xorl         %ecx, %ecx
-	LONG $0x00013fe9; BYTE $0x00               // jmp          LBB28_108, $319(%rip)
+	LONG $0x00013fe9; BYTE $0x00               // jmp          LBB30_108, $319(%rip)
 
-LBB28_121:
+LBB30_121:
 	WORD $0xe683; BYTE $0xfc // andl         $-4, %esi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xd231             // xorl         %edx, %edx
 	QUAD $0x9090909090909090 // .p2align 4, 0x90
 
-LBB28_122:
+LBB30_122:
 	LONG $0x173c8d49               // leaq         (%r15,%rdx), %rdi
 	LONG $0xfd3b448b               // movl         $-3(%rbx,%rdi), %eax
 	LONG $0xfe3b4489               // movl         %eax, $-2(%rbx,%rdi)
 	LONG $0xfcc28348               // addq         $-4, %rdx
 	WORD $0x3948; BYTE $0xd6       // cmpq         %rdx, %rsi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_122, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_122, $-25(%rip)
 	WORD $0xf748; BYTE $0xda       // negq         %rdx
 
-LBB28_117:
+LBB30_117:
 	LONG $0x03c0f641                     // testb        $3, %r8b
-	LONG $0x0033840f; WORD $0x0000       // je           LBB28_120, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000       // je           LBB30_120, $51(%rip)
 	WORD $0xb60f; BYTE $0xf9             // movzbl       %cl, %edi
 	WORD $0xe783; BYTE $0x03             // andl         $3, %edi
 	WORD $0xf748; BYTE $0xdf             // negq         %rdi
@@ -8095,22 +9237,22 @@ LBB28_117:
 	WORD $0xd231                         // xorl         %edx, %edx
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_119:
+LBB30_119:
 	LONG $0x11348d48               // leaq         (%rcx,%rdx), %rsi
 	LONG $0x3304b60f               // movzbl       (%rbx,%rsi), %eax
 	LONG $0x01334488               // movb         %al, $1(%rbx,%rsi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0x3948; BYTE $0xd7       // cmpq         %rdx, %rdi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_119, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_119, $-25(%rip)
 
-LBB28_120:
+LBB30_120:
 	WORD $0x6349; BYTE $0xc1     // movslq       %r9d, %rax
 	LONG $0x0204c641; BYTE $0x2e // movb         $46, (%r10,%rax)
 	LONG $0x1f048d49             // leaq         (%r15,%rbx), %rax
 	LONG $0x02c08348             // addq         $2, %rax
-	LONG $0xfffc35e9; BYTE $0xff // jmp          LBB28_152, $-971(%rip)
+	LONG $0xfffc35e9; BYTE $0xff // jmp          LBB30_152, $-971(%rip)
 
-LBB28_106:
+LBB30_106:
 	WORD $0x8944; BYTE $0xde // movl         %r11d, %esi
 	LONG $0x01c68348         // addq         $1, %rsi
 	LONG $0x80e68348         // andq         $-128, %rsi
@@ -8120,9 +9262,9 @@ LBB28_106:
 	LONG $0xfce68348         // andq         $-4, %rsi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xc931             // xorl         %ecx, %ecx
-	QUAD $0xfffff29a056ffdc5 // vmovdqa      $-3430(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff29a056ffdc5 // vmovdqa      $-3430(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_107:
+LBB30_107:
 	LONG $0x0f3c8d49                           // leaq         (%r15,%rcx), %rdi
 	LONG $0x447ffec5; WORD $0x013b             // vmovdqu      %ymm0, $1(%rbx,%rdi)
 	LONG $0x447ffec5; WORD $0x213b             // vmovdqu      %ymm0, $33(%rbx,%rdi)
@@ -8142,12 +9284,12 @@ LBB28_107:
 	QUAD $0x0001e13b847ffec5; BYTE $0x00       // vmovdqu      %ymm0, $481(%rbx,%rdi)
 	LONG $0x00c18148; WORD $0x0002; BYTE $0x00 // addq         $512, %rcx
 	LONG $0x04c68348                           // addq         $4, %rsi
-	LONG $0xff67850f; WORD $0xffff             // jne          LBB28_107, $-153(%rip)
+	LONG $0xff67850f; WORD $0xffff             // jne          LBB30_107, $-153(%rip)
 
-LBB28_108:
+LBB30_108:
 	WORD $0x0148; BYTE $0xd8                   // addq         %rbx, %rax
 	LONG $0x03c0f641                           // testb        $3, %r8b
-	LONG $0x005c840f; WORD $0x0000             // je           LBB28_111, $92(%rip)
+	LONG $0x005c840f; WORD $0x0000             // je           LBB30_111, $92(%rip)
 	LONG $0x01c38341                           // addl         $1, %r11d
 	LONG $0x80e38141; WORD $0x0001; BYTE $0x00 // andl         $384, %r11d
 	LONG $0x80c38341                           // addl         $-128, %r11d
@@ -8159,9 +9301,9 @@ LBB28_108:
 	WORD $0x014c; BYTE $0xf9                   // addq         %r15, %rcx
 	LONG $0x61c18348                           // addq         $97, %rcx
 	WORD $0xf631                               // xorl         %esi, %esi
-	QUAD $0xfffff1c0056ffdc5                   // vmovdqa      $-3648(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff1c0056ffdc5                   // vmovdqa      $-3648(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_110:
+LBB30_110:
 	LONG $0x313c8d48               // leaq         (%rcx,%rsi), %rdi
 	LONG $0x447ffec5; WORD $0xa03b // vmovdqu      %ymm0, $-96(%rbx,%rdi)
 	LONG $0x447ffec5; WORD $0xc03b // vmovdqu      %ymm0, $-64(%rbx,%rdi)
@@ -8169,31 +9311,31 @@ LBB28_110:
 	LONG $0x047ffec5; BYTE $0x3b   // vmovdqu      %ymm0, (%rbx,%rdi)
 	LONG $0x80ee8348               // subq         $-128, %rsi
 	WORD $0x3949; BYTE $0xf0       // cmpq         %rsi, %r8
-	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_110, $-40(%rip)
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB30_110, $-40(%rip)
 
-LBB28_111:
+LBB30_111:
 	WORD $0x3949; BYTE $0xd1                                             // cmpq         %rdx, %r9
-	LONG $0xfb02840f; WORD $0xffff                                       // je           LBB28_152, $-1278(%rip)
+	LONG $0xfb02840f; WORD $0xffff                                       // je           LBB30_152, $-1278(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_112:
+LBB30_112:
 	WORD $0x00c6; BYTE $0x30       // movb         $48, (%rax)
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0xc283; BYTE $0x01       // addl         $1, %edx
 	WORD $0x3944; BYTE $0xf2       // cmpl         %r14d, %edx
-	LONG $0xffed8c0f; WORD $0xffff // jl           LBB28_112, $-19(%rip)
-	LONG $0xfffadbe9; BYTE $0xff   // jmp          LBB28_152, $-1317(%rip)
+	LONG $0xffed8c0f; WORD $0xffff // jl           LBB30_112, $-19(%rip)
+	LONG $0xfffadbe9; BYTE $0xff   // jmp          LBB30_152, $-1317(%rip)
 
-LBB28_1:
+LBB30_1:
 	WORD $0xc031                 // xorl         %eax, %eax
-	LONG $0xfffad7e9; BYTE $0xff // jmp          LBB28_153, $-1321(%rip)
+	LONG $0xfffad7e9; BYTE $0xff // jmp          LBB30_153, $-1321(%rip)
 
-LBB28_5:
+LBB30_5:
 	LONG $0xc84d894c                                   // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948                                   // movq         %rdi, $-48(%rbp)
 	LONG $0xff6bb841; WORD $0xffff                     // movl         $-149, %r8d
 	WORD $0x8941; BYTE $0xc3                           // movl         %eax, %r11d
-	LONG $0xfff208e9; BYTE $0xff                       // jmp          LBB28_6, $-3576(%rip)
+	LONG $0xfff208e9; BYTE $0xff                       // jmp          LBB30_6, $-3576(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 _format_significand:
@@ -8205,25 +9347,25 @@ _format_significand:
 	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
 	WORD $0x8948; BYTE $0xf8       // movq         %rdi, %rax
 	LONG $0x20e8c148               // shrq         $32, %rax
-	LONG $0x001c850f; WORD $0x0000 // jne          LBB29_2, $28(%rip)
+	LONG $0x001c850f; WORD $0x0000 // jne          LBB31_2, $28(%rip)
 	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
 	WORD $0x894d; BYTE $0xc6       // movq         %r8, %r14
 	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0x00e3830f; WORD $0x0000 // jae          LBB29_8, $227(%rip)
+	LONG $0x00e3830f; WORD $0x0000 // jae          LBB31_8, $227(%rip)
 
-LBB29_7:
+LBB31_7:
 	WORD $0xd789                 // movl         %edx, %edi
-	LONG $0x000132e9; BYTE $0x00 // jmp          LBB29_10, $306(%rip)
+	LONG $0x000132e9; BYTE $0x00 // jmp          LBB31_10, $306(%rip)
 
-LBB29_2:
+LBB31_2:
 	QUAD $0x77118461cefdb948; WORD $0xabcc     // movabsq      $-6067343680855748867, %rcx
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	WORD $0xf748; BYTE $0xe1                   // mulq         %rcx
 	LONG $0x1aeac148                           // shrq         $26, %rdx
 	LONG $0x1f00ca69; WORD $0xfa0a             // imull        $-100000000, %edx, %ecx
 	WORD $0xf901                               // addl         %edi, %ecx
-	LONG $0x00a4840f; WORD $0x0000             // je           LBB29_3, $164(%rip)
+	LONG $0x00a4840f; WORD $0x0000             // je           LBB31_3, $164(%rip)
 	WORD $0xc889                               // movl         %ecx, %eax
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
 	LONG $0xc1af0f49                           // imulq        %r9, %rax
@@ -8249,7 +9391,7 @@ LBB29_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0xe30d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12515(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x930d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13459(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -8261,21 +9403,21 @@ LBB29_2:
 	WORD $0x3145; BYTE $0xc9                   // xorl         %r9d, %r9d
 	LONG $0xf8708d4d                           // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000             // cmpl         $10000, %edx
-	LONG $0xff38820f; WORD $0xffff             // jb           LBB29_7, $-200(%rip)
-	LONG $0x000016e9; BYTE $0x00               // jmp          LBB29_8, $22(%rip)
+	LONG $0xff38820f; WORD $0xffff             // jb           LBB31_7, $-200(%rip)
+	LONG $0x000016e9; BYTE $0x00               // jmp          LBB31_8, $22(%rip)
 
-LBB29_3:
+LBB31_3:
 	LONG $0x0008b941; WORD $0x0000 // movl         $8, %r9d
 	LONG $0xf8708d4d               // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0xff1d820f; WORD $0xffff // jb           LBB29_7, $-227(%rip)
+	LONG $0xff1d820f; WORD $0xffff // jb           LBB31_7, $-227(%rip)
 
-LBB29_8:
+LBB31_8:
 	LONG $0x1759ba41; WORD $0xd1b7             // movl         $3518437209, %r10d
-	LONG $0x811d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12417(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x311d8d4c; WORD $0x0034; BYTE $0x00 // leaq         $13361(%rip), %r11  /* _Digits(%rip) */
 	BYTE $0x90                                 // .p2align 4, 0x90
 
-LBB29_9:
+LBB31_9:
 	WORD $0xd789                               // movl         %edx, %edi
 	LONG $0xfaaf0f49                           // imulq        %r10, %rdi
 	LONG $0x2defc148                           // shrq         $45, %rdi
@@ -8292,22 +9434,22 @@ LBB29_9:
 	LONG $0xfcc68349                           // addq         $-4, %r14
 	LONG $0xe0fffa81; WORD $0x05f5             // cmpl         $99999999, %edx
 	WORD $0xfa89                               // movl         %edi, %edx
-	LONG $0xffb8870f; WORD $0xffff             // ja           LBB29_9, $-72(%rip)
+	LONG $0xffb8870f; WORD $0xffff             // ja           LBB31_9, $-72(%rip)
 
-LBB29_10:
+LBB31_10:
 	WORD $0xff83; BYTE $0x64       // cmpl         $100, %edi
-	LONG $0x0020830f; WORD $0x0000 // jae          LBB29_11, $32(%rip)
+	LONG $0x0020830f; WORD $0x0000 // jae          LBB31_11, $32(%rip)
 	WORD $0xff83; BYTE $0x0a       // cmpl         $10, %edi
-	LONG $0x004d820f; WORD $0x0000 // jb           LBB29_14, $77(%rip)
+	LONG $0x004d820f; WORD $0x0000 // jb           LBB31_14, $77(%rip)
 
-LBB29_13:
+LBB31_13:
 	WORD $0xf889                               // movl         %edi, %eax
-	LONG $0x1d0d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12317(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xcd0d8d48; WORD $0x0033; BYTE $0x00 // leaq         $13261(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x46894166; BYTE $0xfe               // movw         %ax, $-2(%r14)
-	LONG $0x00003de9; BYTE $0x00               // jmp          LBB29_15, $61(%rip)
+	LONG $0x00003de9; BYTE $0x00               // jmp          LBB31_15, $61(%rip)
 
-LBB29_11:
+LBB31_11:
 	WORD $0xb70f; BYTE $0xc7                   // movzwl       %di, %eax
 	WORD $0xe8c1; BYTE $0x02                   // shrl         $2, %eax
 	LONG $0x147bc069; WORD $0x0000             // imull        $5243, %eax, %eax
@@ -8315,19 +9457,19 @@ LBB29_11:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xcf29                               // subl         %ecx, %edi
 	WORD $0xb70f; BYTE $0xcf                   // movzwl       %di, %ecx
-	LONG $0xf1158d48; WORD $0x002f; BYTE $0x00 // leaq         $12273(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xa1158d48; WORD $0x0033; BYTE $0x00 // leaq         $13217(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4e894166; BYTE $0xfe               // movw         %cx, $-2(%r14)
 	LONG $0xfec68349                           // addq         $-2, %r14
 	WORD $0xc789                               // movl         %eax, %edi
 	WORD $0xff83; BYTE $0x0a                   // cmpl         $10, %edi
-	LONG $0xffb3830f; WORD $0xffff             // jae          LBB29_13, $-77(%rip)
+	LONG $0xffb3830f; WORD $0xffff             // jae          LBB31_13, $-77(%rip)
 
-LBB29_14:
+LBB31_14:
 	LONG $0x30c78040         // addb         $48, %dil
 	WORD $0x8840; BYTE $0x3e // movb         %dil, (%rsi)
 
-LBB29_15:
+LBB31_15:
 	WORD $0x294d; BYTE $0xc8                   // subq         %r9, %r8
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
 	BYTE $0x5b                                 // popq         %rbx
@@ -8344,45 +9486,45 @@ _left_shift:
 	BYTE $0x53                                 // pushq        %rbx
 	WORD $0xf189                               // movl         %esi, %ecx
 	LONG $0x68f16b4c                           // imulq        $104, %rcx, %r14
-	LONG $0x9a158d48; WORD $0x0089; BYTE $0x00 // leaq         $35226(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
+	LONG $0x4a158d48; WORD $0x008d; BYTE $0x00 // leaq         $36170(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
 	LONG $0x16048b45                           // movl         (%r14,%rdx), %r8d
 	WORD $0x8b4c; BYTE $0x1f                   // movq         (%rdi), %r11
 	LONG $0x104f634c                           // movslq       $16(%rdi), %r9
 	WORD $0x8945; BYTE $0xca                   // movl         %r9d, %r10d
 	WORD $0x854d; BYTE $0xc9                   // testq        %r9, %r9
-	LONG $0x004c840f; WORD $0x0000             // je           LBB30_1, $76(%rip)
+	LONG $0x004c840f; WORD $0x0000             // je           LBB32_1, $76(%rip)
 	LONG $0x16348d49                           // leaq         (%r14,%rdx), %rsi
 	LONG $0x04c68348                           // addq         $4, %rsi
 	WORD $0xdb31                               // xorl         %ebx, %ebx
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB30_3:
+LBB32_3:
 	LONG $0x1e04b60f               // movzbl       (%rsi,%rbx), %eax
 	WORD $0xc084                   // testb        %al, %al
-	LONG $0x0041840f; WORD $0x0000 // je           LBB30_10, $65(%rip)
+	LONG $0x0041840f; WORD $0x0000 // je           LBB32_10, $65(%rip)
 	LONG $0x1b043841               // cmpb         %al, (%r11,%rbx)
-	LONG $0x01ba850f; WORD $0x0000 // jne          LBB30_5, $442(%rip)
+	LONG $0x01ba850f; WORD $0x0000 // jne          LBB32_5, $442(%rip)
 	LONG $0x01c38348               // addq         $1, %rbx
 	WORD $0x3949; BYTE $0xd9       // cmpq         %rbx, %r9
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB30_3, $-35(%rip)
+	LONG $0xffdd850f; WORD $0xffff // jne          LBB32_3, $-35(%rip)
 	WORD $0x8944; BYTE $0xce       // movl         %r9d, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB30_9, $21(%rip)
-	LONG $0x000014e9; BYTE $0x00   // jmp          LBB30_10, $20(%rip)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB32_9, $21(%rip)
+	LONG $0x000014e9; BYTE $0x00   // jmp          LBB32_10, $20(%rip)
 
-LBB30_1:
+LBB32_1:
 	WORD $0xf631                   // xorl         %esi, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0004840f; WORD $0x0000 // je           LBB30_10, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB32_10, $4(%rip)
 
-LBB30_9:
+LBB32_9:
 	LONG $0xffc08341 // addl         $-1, %r8d
 
-LBB30_10:
+LBB32_10:
 	WORD $0x8545; BYTE $0xd2                                             // testl        %r10d, %r10d
-	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB30_25, $162(%rip)
+	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB32_25, $162(%rip)
 	LONG $0x10048d43                                                     // leal         (%r8,%r10), %eax
 	WORD $0x634c; BYTE $0xf8                                             // movslq       %eax, %r15
 	LONG $0xffc18341                                                     // addl         $-1, %r9d
@@ -8391,7 +9533,7 @@ LBB30_10:
 	QUAD $0xcccccccccccdbe49; WORD $0xcccc                               // movabsq      $-3689348814741910323, %r14
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB30_12:
+LBB32_12:
 	WORD $0x8944; BYTE $0xc8       // movl         %r9d, %eax
 	LONG $0x34be0f49; BYTE $0x03   // movsbq       (%r11,%rax), %rsi
 	LONG $0xd0c68348               // addq         $-48, %rsi
@@ -8405,93 +9547,93 @@ LBB30_12:
 	WORD $0x8948; BYTE $0xf0       // movq         %rsi, %rax
 	WORD $0x2948; BYTE $0xd8       // subq         %rbx, %rax
 	LONG $0x087f394c               // cmpq         %r15, $8(%rdi)
-	LONG $0x000c860f; WORD $0x0000 // jbe          LBB30_18, $12(%rip)
+	LONG $0x000c860f; WORD $0x0000 // jbe          LBB32_18, $12(%rip)
 	WORD $0x3004                   // addb         $48, %al
 	LONG $0x3b048843               // movb         %al, (%r11,%r15)
-	LONG $0x000011e9; BYTE $0x00   // jmp          LBB30_20, $17(%rip)
+	LONG $0x000011e9; BYTE $0x00   // jmp          LBB32_20, $17(%rip)
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_18:
+LBB32_18:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x0007840f; WORD $0x0000             // je           LBB30_20, $7(%rip)
+	LONG $0x0007840f; WORD $0x0000             // je           LBB32_20, $7(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
 
-LBB30_20:
+LBB32_20:
 	LONG $0x02fa8349               // cmpq         $2, %r10
-	LONG $0x00148c0f; WORD $0x0000 // jl           LBB30_14, $20(%rip)
+	LONG $0x00148c0f; WORD $0x0000 // jl           LBB32_14, $20(%rip)
 	LONG $0xffc28349               // addq         $-1, %r10
 	WORD $0x8b4c; BYTE $0x1f       // movq         (%rdi), %r11
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0xffc78349               // addq         $-1, %r15
-	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB30_12, $-110(%rip)
+	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB32_12, $-110(%rip)
 
-LBB30_14:
+LBB32_14:
 	LONG $0x0afe8348               // cmpq         $10, %rsi
-	LONG $0x0071830f; WORD $0x0000 // jae          LBB30_15, $113(%rip)
+	LONG $0x0071830f; WORD $0x0000 // jae          LBB32_15, $113(%rip)
 
-LBB30_25:
+LBB32_25:
 	LONG $0x104f6348               // movslq       $16(%rdi), %rcx
 	WORD $0x6349; BYTE $0xc0       // movslq       %r8d, %rax
 	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0x084f8b48               // movq         $8(%rdi), %rcx
 	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
-	LONG $0x0005870f; WORD $0x0000 // ja           LBB30_27, $5(%rip)
+	LONG $0x0005870f; WORD $0x0000 // ja           LBB32_27, $5(%rip)
 	WORD $0x4f89; BYTE $0x10       // movl         %ecx, $16(%rdi)
 	WORD $0xc889                   // movl         %ecx, %eax
 
-LBB30_27:
+LBB32_27:
 	LONG $0x14470144               // addl         %r8d, $20(%rdi)
 	WORD $0xc085                   // testl        %eax, %eax
-	LONG $0x00328e0f; WORD $0x0000 // jle          LBB30_31, $50(%rip)
+	LONG $0x00328e0f; WORD $0x0000 // jle          LBB32_31, $50(%rip)
 	WORD $0x8b48; BYTE $0x0f       // movq         (%rdi), %rcx
 	WORD $0xc289                   // movl         %eax, %edx
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_29:
+LBB32_29:
 	WORD $0xc689                   // movl         %eax, %esi
 	LONG $0x30313c80               // cmpb         $48, (%rcx,%rsi)
-	LONG $0x0026850f; WORD $0x0000 // jne          LBB30_33, $38(%rip)
+	LONG $0x0026850f; WORD $0x0000 // jne          LBB32_33, $38(%rip)
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	LONG $0x01fa8348               // cmpq         $1, %rdx
-	LONG $0xffe08f0f; WORD $0xffff // jg           LBB30_29, $-32(%rip)
-	LONG $0x000006e9; BYTE $0x00   // jmp          LBB30_32, $6(%rip)
+	LONG $0xffe08f0f; WORD $0xffff // jg           LBB32_29, $-32(%rip)
+	LONG $0x000006e9; BYTE $0x00   // jmp          LBB32_32, $6(%rip)
 
-LBB30_31:
-	LONG $0x0007850f; WORD $0x0000 // jne          LBB30_33, $7(%rip)
+LBB32_31:
+	LONG $0x0007850f; WORD $0x0000 // jne          LBB32_33, $7(%rip)
 
-LBB30_32:
+LBB32_32:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 
-LBB30_33:
+LBB32_33:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	BYTE $0xc3   // retq
 
-LBB30_15:
+LBB32_15:
 	WORD $0x0145; BYTE $0xc1     // addl         %r8d, %r9d
 	WORD $0x6349; BYTE $0xf1     // movslq       %r9d, %rsi
 	LONG $0xffc68348             // addq         $-1, %rsi
-	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB30_16, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB32_16, $30(%rip)
 	QUAD $0x9090909090909090     // .p2align 4, 0x90
 
-LBB30_17:
+LBB32_17:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	WORD $0x0488; BYTE $0x33 // movb         %al, (%rbx,%rsi)
 
-LBB30_24:
+LBB32_24:
 	LONG $0xffc68348               // addq         $-1, %rsi
 	LONG $0x09f98348               // cmpq         $9, %rcx
-	LONG $0xff62860f; WORD $0xffff // jbe          LBB30_25, $-158(%rip)
+	LONG $0xff62860f; WORD $0xffff // jbe          LBB32_25, $-158(%rip)
 
-LBB30_16:
+LBB32_16:
 	WORD $0x8948; BYTE $0xd1                   // movq         %rdx, %rcx
 	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
 	WORD $0xf749; BYTE $0xe6                   // mulq         %r14
@@ -8501,15 +9643,15 @@ LBB30_16:
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
 	WORD $0x2948; BYTE $0xd8                   // subq         %rbx, %rax
 	LONG $0x08773948                           // cmpq         %rsi, $8(%rdi)
-	LONG $0xffc5870f; WORD $0xffff             // ja           LBB30_17, $-59(%rip)
+	LONG $0xffc5870f; WORD $0xffff             // ja           LBB32_17, $-59(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0xffc4840f; WORD $0xffff             // je           LBB30_24, $-60(%rip)
+	LONG $0xffc4840f; WORD $0xffff             // je           LBB32_24, $-60(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB30_24, $-72(%rip)
+	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB32_24, $-72(%rip)
 
-LBB30_5:
-	LONG $0xfe738c0f; WORD $0xffff // jl           LBB30_9, $-397(%rip)
-	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB30_10, $-398(%rip)
+LBB32_5:
+	LONG $0xfe738c0f; WORD $0xffff // jl           LBB32_9, $-397(%rip)
+	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB32_10, $-398(%rip)
 	LONG $0x90909090; BYTE $0x90   // .p2align 4, 0x90
 
 _right_shift:
@@ -8525,9 +9667,9 @@ _right_shift:
 	WORD $0xc031                   // xorl         %eax, %eax
 	LONG $0x90909090               // .p2align 4, 0x90
 
-LBB31_1:
+LBB33_1:
 	WORD $0x3949; BYTE $0xd3       // cmpq         %rdx, %r11
-	LONG $0x014f840f; WORD $0x0000 // je           LBB31_2, $335(%rip)
+	LONG $0x014f840f; WORD $0x0000 // je           LBB33_2, $335(%rip)
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	WORD $0x8b48; BYTE $0x37       // movq         (%rdi), %rsi
 	LONG $0x34be0f48; BYTE $0x16   // movsbq       (%rsi,%rdx), %rsi
@@ -8537,10 +9679,10 @@ LBB31_1:
 	WORD $0x8948; BYTE $0xc6       // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee       // shrq         %cl, %rsi
 	WORD $0x8548; BYTE $0xf6       // testq        %rsi, %rsi
-	LONG $0xffd0840f; WORD $0xffff // je           LBB31_1, $-48(%rip)
+	LONG $0xffd0840f; WORD $0xffff // je           LBB33_1, $-48(%rip)
 	WORD $0x8941; BYTE $0xd3       // movl         %edx, %r11d
 
-LBB31_7:
+LBB33_7:
 	WORD $0x578b; BYTE $0x14                                             // movl         $20(%rdi), %edx
 	WORD $0x2944; BYTE $0xda                                             // subl         %r11d, %edx
 	WORD $0xc283; BYTE $0x01                                             // addl         $1, %edx
@@ -8550,13 +9692,13 @@ LBB31_7:
 	WORD $0xf749; BYTE $0xd1                                             // notq         %r9
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	WORD $0x3945; BYTE $0xc3                                             // cmpl         %r8d, %r11d
-	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB31_10, $128(%rip)
+	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB33_10, $128(%rip)
 	WORD $0x634d; BYTE $0xc3                                             // movslq       %r11d, %r8
 	WORD $0x8b48; BYTE $0x37                                             // movq         (%rdi), %rsi
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_9:
+LBB33_9:
 	WORD $0x8948; BYTE $0xc2                               // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                               // shrq         %cl, %rdx
 	WORD $0x214c; BYTE $0xc8                               // andq         %r9, %rax
@@ -8572,95 +9714,384 @@ LBB31_9:
 	LONG $0xd0c08348                                       // addq         $-48, %rax
 	LONG $0x10576348                                       // movslq       $16(%rdi), %rdx
 	WORD $0x3948; BYTE $0xd3                               // cmpq         %rdx, %rbx
-	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB31_9, $-62(%rip)
-	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB31_10, $37(%rip)
+	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB33_9, $-62(%rip)
+	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB33_10, $37(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_12:
+LBB33_12:
 	LONG $0x30c68040         // addb         $48, %sil
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	LONG $0x13348840         // movb         %sil, (%rbx,%rdx)
 	WORD $0xc283; BYTE $0x01 // addl         $1, %edx
 	WORD $0x8941; BYTE $0xd2 // movl         %edx, %r10d
 
-LBB31_15:
+LBB33_15:
 	WORD $0x0148; BYTE $0xc0 // addq         %rax, %rax
 	LONG $0x80048d48         // leaq         (%rax,%rax,4), %rax
 
-LBB31_10:
+LBB33_10:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x002b840f; WORD $0x0000             // je           LBB31_16, $43(%rip)
+	LONG $0x002b840f; WORD $0x0000             // je           LBB33_16, $43(%rip)
 	WORD $0x8948; BYTE $0xc6                   // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee                   // shrq         %cl, %rsi
 	WORD $0x214c; BYTE $0xc8                   // andq         %r9, %rax
 	WORD $0x6349; BYTE $0xd2                   // movslq       %r10d, %rdx
 	LONG $0x08573948                           // cmpq         %rdx, $8(%rdi)
-	LONG $0xffc9870f; WORD $0xffff             // ja           LBB31_12, $-55(%rip)
+	LONG $0xffc9870f; WORD $0xffff             // ja           LBB33_12, $-55(%rip)
 	WORD $0x8548; BYTE $0xf6                   // testq        %rsi, %rsi
-	LONG $0xffd1840f; WORD $0xffff             // je           LBB31_15, $-47(%rip)
+	LONG $0xffd1840f; WORD $0xffff             // je           LBB33_15, $-47(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB31_15, $-59(%rip)
+	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB33_15, $-59(%rip)
 
-LBB31_16:
+LBB33_16:
 	LONG $0x10578944                     // movl         %r10d, $16(%rdi)
 	WORD $0x8545; BYTE $0xd2             // testl        %r10d, %r10d
-	LONG $0x00858e0f; WORD $0x0000       // jle          LBB31_20, $133(%rip)
+	LONG $0x00858e0f; WORD $0x0000       // jle          LBB33_20, $133(%rip)
 	WORD $0x8b48; BYTE $0x07             // movq         (%rdi), %rax
 	WORD $0x8944; BYTE $0xd1             // movl         %r10d, %ecx
 	LONG $0x01c18348                     // addq         $1, %rcx
 	LONG $0xffc28341                     // addl         $-1, %r10d
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_18:
+LBB33_18:
 	WORD $0x8944; BYTE $0xd2       // movl         %r10d, %edx
 	LONG $0x30103c80               // cmpb         $48, (%rax,%rdx)
-	LONG $0x0067850f; WORD $0x0000 // jne          LBB31_22, $103(%rip)
+	LONG $0x0067850f; WORD $0x0000 // jne          LBB33_22, $103(%rip)
 	LONG $0x10578944               // movl         %r10d, $16(%rdi)
 	LONG $0xffc18348               // addq         $-1, %rcx
 	LONG $0xffc28341               // addl         $-1, %r10d
 	LONG $0x01f98348               // cmpq         $1, %rcx
-	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB31_18, $-35(%rip)
-	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB31_21, $79(%rip)
+	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB33_18, $-35(%rip)
+	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB33_21, $79(%rip)
 
-LBB31_2:
+LBB33_2:
 	WORD $0x8548; BYTE $0xc0                                             // testq        %rax, %rax
-	LONG $0x0050840f; WORD $0x0000                                       // je           LBB31_23, $80(%rip)
+	LONG $0x0050840f; WORD $0x0000                                       // je           LBB33_23, $80(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 	WORD $0x8948; BYTE $0xc2                                             // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                                             // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2                                             // testq        %rdx, %rdx
-	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB31_7, $-332(%rip)
+	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB33_7, $-332(%rip)
 
-LBB31_4:
+LBB33_4:
 	WORD $0x0148; BYTE $0xc0       // addq         %rax, %rax
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	LONG $0x01c38341               // addl         $1, %r11d
 	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea       // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2       // testq        %rdx, %rdx
-	LONG $0xffe6840f; WORD $0xffff // je           LBB31_4, $-26(%rip)
-	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB31_7, $-363(%rip)
+	LONG $0xffe6840f; WORD $0xffff // je           LBB33_4, $-26(%rip)
+	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB33_7, $-363(%rip)
 
-LBB31_20:
-	LONG $0x0003840f; WORD $0x0000 // je           LBB31_21, $3(%rip)
+LBB33_20:
+	LONG $0x0003840f; WORD $0x0000 // je           LBB33_21, $3(%rip)
 
-LBB31_22:
+LBB33_22:
 	BYTE $0x5b // popq         %rbx
 	BYTE $0x5d // popq         %rbp
 	BYTE $0xc3 // retq
 
-LBB31_21:
+LBB33_21:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
 
-LBB31_23:
+LBB33_23:
 	LONG $0x001047c7; WORD $0x0000; BYTE $0x00 // movl         $0, $16(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
 	LONG $0x00000000; BYTE $0x00               // .p2align 4, 0x00
+
+LCPI34_0:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI34_1:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+	// .p2align 4, 0x90
+_advance_string_default:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x5741                               // pushq        %r15
+	WORD $0x5641                               // pushq        %r14
+	WORD $0x5541                               // pushq        %r13
+	WORD $0x5441                               // pushq        %r12
+	BYTE $0x53                                 // pushq        %rbx
+	BYTE $0x50                                 // pushq        %rax
+	LONG $0x087f8b4c                           // movq         $8(%rdi), %r15
+	WORD $0x2949; BYTE $0xf7                   // subq         %rsi, %r15
+	LONG $0x0368840f; WORD $0x0000             // je           LBB34_17, $872(%rip)
+	WORD $0x8b4c; BYTE $0x0f                   // movq         (%rdi), %r9
+	LONG $0xff02c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rdx)
+	LONG $0x40ff8349                           // cmpq         $64, %r15
+	LONG $0x01df820f; WORD $0x0000             // jb           LBB34_18, $479(%rip)
+	WORD $0x8948; BYTE $0xf7                   // movq         %rsi, %rdi
+	WORD $0xf748; BYTE $0xd7                   // notq         %rdi
+	QUAD $0xffffffffd045c748                   // movq         $-1, $-48(%rbp)
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	QUAD $0xffffff98056ff9c5                   // vmovdqa      $-104(%rip), %xmm0  /* LCPI34_0(%rip) */
+	QUAD $0xffffffa00d6ff9c5                   // vmovdqa      $-96(%rip), %xmm1  /* LCPI34_1(%rip) */
+
+	// .p2align 4, 0x90
+LBB34_3:
+	LONG $0x6f7ac1c4; WORD $0x3114             // vmovdqu      (%r9,%rsi), %xmm2
+	LONG $0x6f7ac1c4; WORD $0x315c; BYTE $0x10 // vmovdqu      $16(%r9,%rsi), %xmm3
+	LONG $0x6f7ac1c4; WORD $0x3164; BYTE $0x20 // vmovdqu      $32(%r9,%rsi), %xmm4
+	LONG $0x6f7ac1c4; WORD $0x316c; BYTE $0x30 // vmovdqu      $48(%r9,%rsi), %xmm5
+	LONG $0xf074e9c5                           // vpcmpeqb     %xmm0, %xmm2, %xmm6
+	LONG $0xe6d779c5                           // vpmovmskb    %xmm6, %r12d
+	LONG $0xf074e1c5                           // vpcmpeqb     %xmm0, %xmm3, %xmm6
+	LONG $0xded7f9c5                           // vpmovmskb    %xmm6, %ebx
+	LONG $0xf074d9c5                           // vpcmpeqb     %xmm0, %xmm4, %xmm6
+	LONG $0xc6d7f9c5                           // vpmovmskb    %xmm6, %eax
+	LONG $0xf074d1c5                           // vpcmpeqb     %xmm0, %xmm5, %xmm6
+	LONG $0xc6d779c5                           // vpmovmskb    %xmm6, %r8d
+	LONG $0xd174e9c5                           // vpcmpeqb     %xmm1, %xmm2, %xmm2
+	LONG $0xead779c5                           // vpmovmskb    %xmm2, %r13d
+	LONG $0xd174e1c5                           // vpcmpeqb     %xmm1, %xmm3, %xmm2
+	LONG $0xcad7f9c5                           // vpmovmskb    %xmm2, %ecx
+	LONG $0xd174d9c5                           // vpcmpeqb     %xmm1, %xmm4, %xmm2
+	LONG $0xd2d779c5                           // vpmovmskb    %xmm2, %r10d
+	LONG $0xd174d1c5                           // vpcmpeqb     %xmm1, %xmm5, %xmm2
+	LONG $0xdad779c5                           // vpmovmskb    %xmm2, %r11d
+	LONG $0x30e0c149                           // shlq         $48, %r8
+	LONG $0x20e0c148                           // shlq         $32, %rax
+	WORD $0x094c; BYTE $0xc0                   // orq          %r8, %rax
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xc3                   // orq          %rax, %rbx
+	WORD $0x0949; BYTE $0xdc                   // orq          %rbx, %r12
+	LONG $0x30e3c149                           // shlq         $48, %r11
+	LONG $0x20e2c149                           // shlq         $32, %r10
+	WORD $0x094d; BYTE $0xda                   // orq          %r11, %r10
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x094c; BYTE $0xd1                   // orq          %r10, %rcx
+	WORD $0x0949; BYTE $0xcd                   // orq          %rcx, %r13
+	LONG $0x0030850f; WORD $0x0000             // jne          LBB34_7, $48(%rip)
+	WORD $0x854d; BYTE $0xf6                   // testq        %r14, %r14
+	LONG $0x0040850f; WORD $0x0000             // jne          LBB34_9, $64(%rip)
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
+	LONG $0x0086850f; WORD $0x0000             // jne          LBB34_10, $134(%rip)
+
+LBB34_6:
+	LONG $0xc0c78349               // addq         $-64, %r15
+	LONG $0xc0c78348               // addq         $-64, %rdi
+	LONG $0x40c68348               // addq         $64, %rsi
+	LONG $0x3fff8349               // cmpq         $63, %r15
+	LONG $0xff4a870f; WORD $0xffff // ja           LBB34_3, $-182(%rip)
+	LONG $0x000081e9; BYTE $0x00   // jmp          LBB34_12, $129(%rip)
+
+LBB34_7:
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x000e850f; WORD $0x0000 // jne          LBB34_9, $14(%rip)
+	LONG $0xc5bc0f49               // bsfq         %r13, %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xd0458948               // movq         %rax, $-48(%rbp)
+	WORD $0x8948; BYTE $0x02       // movq         %rax, (%rdx)
+
+LBB34_9:
+	WORD $0x894c; BYTE $0xf0               // movq         %r14, %rax
+	WORD $0xf748; BYTE $0xd0               // notq         %rax
+	WORD $0x214c; BYTE $0xe8               // andq         %r13, %rax
+	LONG $0x00048d4c                       // leaq         (%rax,%rax), %r8
+	WORD $0x094d; BYTE $0xf0               // orq          %r14, %r8
+	WORD $0x894c; BYTE $0xc1               // movq         %r8, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2148; BYTE $0xd9               // andq         %rbx, %rcx
+	WORD $0x3145; BYTE $0xf6               // xorl         %r14d, %r14d
+	WORD $0x0148; BYTE $0xc1               // addq         %rax, %rcx
+	LONG $0xc6920f41                       // setb         %r14b
+	WORD $0x0148; BYTE $0xc9               // addq         %rcx, %rcx
+	QUAD $0x555555555555b848; WORD $0x5555 // movabsq      $6148914691236517205, %rax
+	WORD $0x3148; BYTE $0xc1               // xorq         %rax, %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x2149; BYTE $0xcc               // andq         %rcx, %r12
+	WORD $0x854d; BYTE $0xe4               // testq        %r12, %r12
+	LONG $0xff7a840f; WORD $0xffff         // je           LBB34_6, $-134(%rip)
+
+LBB34_10:
+	LONG $0xc4bc0f49         // bsfq         %r12, %rax
+	WORD $0x2948; BYTE $0xf8 // subq         %rdi, %rax
+
+LBB34_11:
+	LONG $0x08c48348 // addq         $8, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB34_12:
+	WORD $0x014c; BYTE $0xce       // addq         %r9, %rsi
+	LONG $0x20ff8349               // cmpq         $32, %r15
+	LONG $0x00f2820f; WORD $0x0000 // jb           LBB34_23, $242(%rip)
+
+LBB34_13:
+	LONG $0x066ffac5               // vmovdqu      (%rsi), %xmm0
+	LONG $0x4e6ffac5; BYTE $0x10   // vmovdqu      $16(%rsi), %xmm1
+	QUAD $0xfffffe36156ff9c5       // vmovdqa      $-458(%rip), %xmm2  /* LCPI34_0(%rip) */
+	QUAD $0xfffffe3e1d6ff9c5       // vmovdqa      $-450(%rip), %xmm3  /* LCPI34_1(%rip) */
+	LONG $0xe274f9c5               // vpcmpeqb     %xmm2, %xmm0, %xmm4
+	LONG $0xfcd7f9c5               // vpmovmskb    %xmm4, %edi
+	LONG $0xd274f1c5               // vpcmpeqb     %xmm2, %xmm1, %xmm2
+	LONG $0xcad7f9c5               // vpmovmskb    %xmm2, %ecx
+	LONG $0xc374f9c5               // vpcmpeqb     %xmm3, %xmm0, %xmm0
+	LONG $0xc0d7f9c5               // vpmovmskb    %xmm0, %eax
+	LONG $0xc374f1c5               // vpcmpeqb     %xmm3, %xmm1, %xmm0
+	LONG $0xd8d7f9c5               // vpmovmskb    %xmm0, %ebx
+	LONG $0x10e1c148               // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xcf       // orq          %rcx, %rdi
+	LONG $0x10e3c148               // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xd8       // orq          %rbx, %rax
+	LONG $0x0045850f; WORD $0x0000 // jne          LBB34_19, $69(%rip)
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x005b850f; WORD $0x0000 // jne          LBB34_21, $91(%rip)
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0x0088840f; WORD $0x0000 // je           LBB34_22, $136(%rip)
+
+LBB34_16:
+	LONG $0xc7bc0f48             // bsfq         %rdi, %rax
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xffff6fe9; BYTE $0xff // jmp          LBB34_11, $-145(%rip)
+
+LBB34_18:
+	WORD $0x014c; BYTE $0xce       // addq         %r9, %rsi
+	QUAD $0xffffffffd045c748       // movq         $-1, $-48(%rbp)
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	LONG $0x20ff8349               // cmpq         $32, %r15
+	LONG $0xff73830f; WORD $0xffff // jae          LBB34_13, $-141(%rip)
+	LONG $0x000060e9; BYTE $0x00   // jmp          LBB34_23, $96(%rip)
+
+LBB34_19:
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x0014850f; WORD $0x0000 // jne          LBB34_21, $20(%rip)
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	WORD $0x294c; BYTE $0xc9       // subq         %r9, %rcx
+	LONG $0xd8bc0f48               // bsfq         %rax, %rbx
+	WORD $0x0148; BYTE $0xcb       // addq         %rcx, %rbx
+	LONG $0xd05d8948               // movq         %rbx, $-48(%rbp)
+	WORD $0x8948; BYTE $0x1a       // movq         %rbx, (%rdx)
+
+LBB34_21:
+	WORD $0x8944; BYTE $0xf1       // movl         %r14d, %ecx
+	WORD $0xd1f7                   // notl         %ecx
+	WORD $0xc121                   // andl         %eax, %ecx
+	LONG $0x4e048d45               // leal         (%r14,%rcx,2), %r8d
+	WORD $0x1c8d; BYTE $0x09       // leal         (%rcx,%rcx), %ebx
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xc321                   // andl         %eax, %ebx
+	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0xcb01                   // addl         %ecx, %ebx
+	LONG $0xc6920f41               // setb         %r14b
+	WORD $0xdb01                   // addl         %ebx, %ebx
+	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
+	WORD $0x2144; BYTE $0xc3       // andl         %r8d, %ebx
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xdf21                   // andl         %ebx, %edi
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0xff78850f; WORD $0xffff // jne          LBB34_16, $-136(%rip)
+
+LBB34_22:
+	LONG $0x20c68348 // addq         $32, %rsi
+	LONG $0xe0c78349 // addq         $-32, %r15
+
+LBB34_23:
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x00b5850f; WORD $0x0000 // jne          LBB34_37, $181(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x00a1840f; WORD $0x0000 // je           LBB34_36, $161(%rip)
+
+LBB34_25:
+	WORD $0x894c; BYTE $0xcf // movq         %r9, %rdi
+	WORD $0xf748; BYTE $0xd7 // notq         %rdi
+	LONG $0x01c78348         // addq         $1, %rdi
+
+LBB34_26:
+	WORD $0xc031 // xorl         %eax, %eax
+
+LBB34_27:
+	WORD $0x8948; BYTE $0xc3       // movq         %rax, %rbx
+	LONG $0x060cb60f               // movzbl       (%rsi,%rax), %ecx
+	WORD $0xf980; BYTE $0x22       // cmpb         $34, %cl
+	LONG $0x007e840f; WORD $0x0000 // je           LBB34_35, $126(%rip)
+	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
+	LONG $0x0012840f; WORD $0x0000 // je           LBB34_30, $18(%rip)
+	LONG $0x01438d48               // leaq         $1(%rbx), %rax
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	LONG $0xffda850f; WORD $0xffff // jne          LBB34_27, $-38(%rip)
+	LONG $0x000053e9; BYTE $0x00   // jmp          LBB34_34, $83(%rip)
+
+LBB34_30:
+	LONG $0xff4f8d49                           // leaq         $-1(%r15), %rcx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x3948; BYTE $0xd9                   // cmpq         %rbx, %rcx
+	LONG $0xfe95840f; WORD $0xffff             // je           LBB34_11, $-363(%rip)
+	LONG $0xd07d8348; BYTE $0xff               // cmpq         $-1, $-48(%rbp)
+	LONG $0x000e850f; WORD $0x0000             // jne          LBB34_33, $14(%rip)
+	LONG $0x370c8d48                           // leaq         (%rdi,%rsi), %rcx
+	WORD $0x0148; BYTE $0xd9                   // addq         %rbx, %rcx
+	LONG $0xd04d8948                           // movq         %rcx, $-48(%rbp)
+	WORD $0x8948; BYTE $0x0a                   // movq         %rcx, (%rdx)
+
+LBB34_33:
+	WORD $0x0148; BYTE $0xde       // addq         %rbx, %rsi
+	LONG $0x02c68348               // addq         $2, %rsi
+	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
+	WORD $0x2948; BYTE $0xd9       // subq         %rbx, %rcx
+	LONG $0xfec18348               // addq         $-2, %rcx
+	LONG $0xfec78349               // addq         $-2, %r15
+	WORD $0x3949; BYTE $0xdf       // cmpq         %rbx, %r15
+	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
+	LONG $0xff85850f; WORD $0xffff // jne          LBB34_26, $-123(%rip)
+	LONG $0xfffe56e9; BYTE $0xff   // jmp          LBB34_11, $-426(%rip)
+
+LBB34_34:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0xf980; BYTE $0x22                   // cmpb         $34, %cl
+	LONG $0xfe46850f; WORD $0xffff             // jne          LBB34_11, $-442(%rip)
+
+LBB34_35:
+	WORD $0x0148; BYTE $0xde // addq         %rbx, %rsi
+	LONG $0x01c68348         // addq         $1, %rsi
+
+LBB34_36:
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
+	LONG $0xfffe34e9; BYTE $0xff // jmp          LBB34_11, $-460(%rip)
+
+LBB34_37:
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x0031840f; WORD $0x0000 // je           LBB34_17, $49(%rip)
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB34_40, $16(%rip)
+	WORD $0x894c; BYTE $0xc8       // movq         %r9, %rax
+	WORD $0xf748; BYTE $0xd0       // notq         %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xd0458948               // movq         %rax, $-48(%rbp)
+	WORD $0x8948; BYTE $0x02       // movq         %rax, (%rdx)
+
+LBB34_40:
+	LONG $0x01c68348               // addq         $1, %rsi
+	LONG $0xffc78349               // addq         $-1, %r15
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0xff1f850f; WORD $0xffff // jne          LBB34_25, $-225(%rip)
+	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB34_36, $-69(%rip)
+
+LBB34_17:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xfffdeee9; BYTE $0xff               // jmp          LBB34_11, $-530(%rip)
+	BYTE $0x00                                 // .p2align 4, 0x00
 
 _POW10_M128_TAB:
 	QUAD $0x1732c869cd60e453                           // .quad 1671618768450675795
@@ -10089,7 +11520,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_844550f5: // _pow10_ceil_sig.g
+_LB_416548d1: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -12744,7 +14175,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_8e30165b: // _pow10_ceil_sig_f32.g
+_LB_0853cced: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -12835,7 +14266,7 @@ _entry:
 _f32toa:
 	MOVQ  out+0(FP), DI
 	MOVSD val+8(FP), X0
-	CALL  ·__native_entry__+24592(SB) // _f32toa
+	CALL  ·__native_entry__+28656(SB) // _f32toa
 	MOVQ  AX, ret+16(FP)
 	RET
 
@@ -12857,6 +14288,27 @@ _f64toa:
 	MOVSD val+8(FP), X0
 	CALL  ·__native_entry__+496(SB) // _f64toa
 	MOVQ  AX, ret+16(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__get_by_path(SB), NOSPLIT | NOFRAME, $0 - 32
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -296(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_get_by_path:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	MOVQ path+16(FP), DX
+	CALL ·__native_entry__+26848(SB) // _get_by_path
+	MOVQ AX, ret+24(FP)
 	RET
 
 _stack_grow:
@@ -12963,7 +14415,7 @@ _skip_array:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+22864(SB) // _skip_array
+	CALL ·__native_entry__+20160(SB) // _skip_array
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -12983,7 +14435,7 @@ _entry:
 _skip_number:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
-	CALL ·__native_entry__+24336(SB) // _skip_number
+	CALL ·__native_entry__+23472(SB) // _skip_number
 	MOVQ AX, ret+16(FP)
 	RET
 
@@ -13005,7 +14457,7 @@ _skip_object:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+22912(SB) // _skip_object
+	CALL ·__native_entry__+22048(SB) // _skip_object
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -13027,8 +14479,28 @@ _skip_one:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+20992(SB) // _skip_one
+	CALL ·__native_entry__+23616(SB) // _skip_one
 	MOVQ AX, ret+32(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__skip_one_fast(SB), NOSPLIT | NOFRAME, $0 - 24
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -208(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_skip_one_fast:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	CALL ·__native_entry__+23824(SB) // _skip_one_fast
+	MOVQ AX, ret+16(FP)
 	RET
 
 _stack_grow:
@@ -13091,7 +14563,7 @@ _validate_one:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+24480(SB) // _validate_one
+	CALL ·__native_entry__+23648(SB) // _validate_one
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -13135,7 +14607,7 @@ _vnumber:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+18736(SB), AX // _vnumber
+	LEAQ ·__native_entry__+17904(SB), AX // _vnumber
 	JMP  AX
 
 _stack_grow:
@@ -13155,7 +14627,7 @@ _vsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+20288(SB), AX // _vsigned
+	LEAQ ·__native_entry__+19456(SB), AX // _vsigned
 	JMP  AX
 
 _stack_grow:
@@ -13196,7 +14668,7 @@ _vunsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+20640(SB), AX // _vunsigned
+	LEAQ ·__native_entry__+19808(SB), AX // _vunsigned
 	JMP  AX
 
 _stack_grow:

--- a/internal/native/avx/native_amd64_test.go
+++ b/internal/native/avx/native_amd64_test.go
@@ -591,3 +591,59 @@ func TestNative_SkipNumber(t *testing.T) {
     assert.Equal(t, 9, p)
     assert.Equal(t, 0, q)
 }
+
+func TestNative_SkipOneFast(t *testing.T) {
+    p := 0
+    s := ` {"asdf": [null, true, false, 1, 2.0, -3]}, 1234.5`
+    q := __skip_one_fast(&s, &p)
+    assert.Equal(t, 42, p)
+    assert.Equal(t, 1, q)
+    p = 0
+    s = `1, 2.5, -3, "asdf\nqwer", true, false, null, {}, [],`
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 1, p)
+    assert.Equal(t, 0, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 6, p)
+    assert.Equal(t, 3, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 10, p)
+    assert.Equal(t, 8, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 24, p)
+    assert.Equal(t, 12, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 30, p)
+    assert.Equal(t, 26, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 37, p)
+    assert.Equal(t, 32, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 43, p)
+    assert.Equal(t, 39, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 47, p)
+    assert.Equal(t, 45, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 51, p)
+    assert.Equal(t, 49, q)
+}
+
+func TestNative_SkipOneFast_Error(t *testing.T) {
+    for _, s := range([]string{
+        "{{", "[{",  "{{}",
+        `"asdf`, `"\\\"`,
+    }) {
+        p := 0
+        q := __skip_one_fast(&s, &p)
+        assert.True(t, q < 0)
+    }
+}

--- a/internal/native/avx/native_export_amd64.go
+++ b/internal/native/avx/native_export_amd64.go
@@ -41,7 +41,9 @@ var (
 
 var (
     S_skip_one    = _subr__skip_one
+    S_skip_one_fast = _subr__skip_one_fast
     S_skip_array  = _subr__skip_array
     S_skip_object = _subr__skip_object
     S_skip_number = _subr__skip_number
+    S_get_by_path = _subr__get_by_path
 )

--- a/internal/native/avx/native_subr_amd64.go
+++ b/internal/native/avx/native_subr_amd64.go
@@ -9,29 +9,32 @@ package avx
 func __native_entry__() uintptr
 
 var (
-    _subr__f32toa       = __native_entry__() + 24592
-    _subr__f64toa       = __native_entry__() + 496
-    _subr__html_escape  = __native_entry__() + 10480
-    _subr__i64toa       = __native_entry__() + 4176
-    _subr__lspace       = __native_entry__() + 80
-    _subr__quote        = __native_entry__() + 5552
-    _subr__skip_array   = __native_entry__() + 22864
-    _subr__skip_number  = __native_entry__() + 24336
-    _subr__skip_object  = __native_entry__() + 22912
-    _subr__skip_one     = __native_entry__() + 20992
-    _subr__u64toa       = __native_entry__() + 4288
-    _subr__unquote      = __native_entry__() + 7296
-    _subr__validate_one = __native_entry__() + 24480
-    _subr__value        = __native_entry__() + 13728
-    _subr__vnumber      = __native_entry__() + 18736
-    _subr__vsigned      = __native_entry__() + 20288
-    _subr__vstring      = __native_entry__() + 15808
-    _subr__vunsigned    = __native_entry__() + 20640
+    _subr__f32toa        = __native_entry__() + 28656
+    _subr__f64toa        = __native_entry__() + 496
+    _subr__get_by_path   = __native_entry__() + 26848
+    _subr__html_escape   = __native_entry__() + 10480
+    _subr__i64toa        = __native_entry__() + 4176
+    _subr__lspace        = __native_entry__() + 80
+    _subr__quote         = __native_entry__() + 5552
+    _subr__skip_array    = __native_entry__() + 20160
+    _subr__skip_number   = __native_entry__() + 23472
+    _subr__skip_object   = __native_entry__() + 22048
+    _subr__skip_one      = __native_entry__() + 23616
+    _subr__skip_one_fast = __native_entry__() + 23824
+    _subr__u64toa        = __native_entry__() + 4288
+    _subr__unquote       = __native_entry__() + 7296
+    _subr__validate_one  = __native_entry__() + 23648
+    _subr__value         = __native_entry__() + 13728
+    _subr__vnumber       = __native_entry__() + 17904
+    _subr__vsigned       = __native_entry__() + 19456
+    _subr__vstring       = __native_entry__() + 15808
+    _subr__vunsigned     = __native_entry__() + 19808
 )
 
 const (
     _stack__f32toa = 64
     _stack__f64toa = 80
+    _stack__get_by_path = 296
     _stack__html_escape = 64
     _stack__i64toa = 16
     _stack__lspace = 8
@@ -40,6 +43,7 @@ const (
     _stack__skip_number = 72
     _stack__skip_object = 128
     _stack__skip_one = 128
+    _stack__skip_one_fast = 208
     _stack__u64toa = 8
     _stack__unquote = 72
     _stack__validate_one = 128
@@ -53,6 +57,7 @@ const (
 var (
     _ = _subr__f32toa
     _ = _subr__f64toa
+    _ = _subr__get_by_path
     _ = _subr__html_escape
     _ = _subr__i64toa
     _ = _subr__lspace
@@ -61,6 +66,7 @@ var (
     _ = _subr__skip_number
     _ = _subr__skip_object
     _ = _subr__skip_one
+    _ = _subr__skip_one_fast
     _ = _subr__u64toa
     _ = _subr__unquote
     _ = _subr__validate_one
@@ -74,6 +80,7 @@ var (
 const (
     _ = _stack__f32toa
     _ = _stack__f64toa
+    _ = _stack__get_by_path
     _ = _stack__html_escape
     _ = _stack__i64toa
     _ = _stack__lspace
@@ -82,6 +89,7 @@ const (
     _ = _stack__skip_number
     _ = _stack__skip_object
     _ = _stack__skip_one
+    _ = _stack__skip_one_fast
     _ = _stack__u64toa
     _ = _stack__unquote
     _ = _stack__validate_one

--- a/internal/native/avx2/native_amd64.go
+++ b/internal/native/avx2/native_amd64.go
@@ -97,6 +97,11 @@ func __skip_one(s *string, p *int, m *types.StateMachine, flags uint64) (ret int
 //go:nosplit
 //go:noescape
 //goland:noinspection GoUnusedParameter
+func __skip_one_fast(s *string, p *int) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
 func __skip_array(s *string, p *int, m *types.StateMachine, flags uint64) (ret int)
 
 //go:nosplit
@@ -113,3 +118,8 @@ func __skip_number(s *string, p *int) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __get_by_path(s *string, p *int, path *[]interface{}) (ret int)

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -262,7 +262,7 @@ LBB1_8:
 	LONG $0x04e6c148                           // shlq         $4, %rsi
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xd348; BYTE $0xe3                   // shlq         %cl, %rbx
-	LONG $0x421d8d4c; WORD $0x00ac; BYTE $0x00 // leaq         $44098(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
+	LONG $0xa21d8d4c; WORD $0x00c0; BYTE $0x00 // leaq         $49314(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
 	LONG $0x1e648b4e; BYTE $0x08               // movq         $8(%rsi,%r11), %r12
 	WORD $0x8948; BYTE $0xd8                   // movq         %rbx, %rax
 	WORD $0xf749; BYTE $0xe4                   // mulq         %r12
@@ -435,7 +435,7 @@ LBB1_31:
 	LONG $0x0099820f; WORD $0x0000 // jb           LBB1_39, $153(%rip)
 	LONG $0x01678d4d               // leaq         $1(%r15), %r12
 	WORD $0x894c; BYTE $0xe6       // movq         %r12, %rsi
-	LONG $0x00771de8; BYTE $0x00   // callq        _format_significand, $30493(%rip)
+	LONG $0x00881de8; BYTE $0x00   // callq        _format_significand, $34845(%rip)
 	WORD $0x8948; BYTE $0xc3       // movq         %rax, %rbx
 	LONG $0xd07d8b48               // movq         $-48(%rbp), %rdi
 	WORD $0x2948; BYTE $0xf8       // subq         %rdi, %rax
@@ -472,7 +472,7 @@ LBB1_38:
 	WORD $0x0c8d; BYTE $0x12                   // leal         (%rdx,%rdx), %ecx
 	WORD $0x0c8d; BYTE $0x89                   // leal         (%rcx,%rcx,4), %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
-	LONG $0x460d8d48; WORD $0x00a8; BYTE $0x00 // leaq         $43078(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xa60d8d48; WORD $0x00bc; BYTE $0x00 // leaq         $48294(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x510cb70f                           // movzwl       (%rcx,%rdx,2), %ecx
 	LONG $0x024b8966                           // movw         %cx, $2(%rbx)
 	WORD $0x300c                               // orb          $48, %al
@@ -558,7 +558,7 @@ LBB1_52:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
 	LONG $0x007f8c0f; WORD $0x0000             // jl           LBB1_60, $127(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xf30d8d48; WORD $0x00a6; BYTE $0x00 // leaq         $42739(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x530d8d48; WORD $0x00bb; BYTE $0x00 // leaq         $47955(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x02438966                           // movw         %ax, $2(%rbx)
 	LONG $0x04c38348                           // addq         $4, %rbx
@@ -803,7 +803,7 @@ LBB1_96:
 LBB1_97:
 	WORD $0x894c; BYTE $0xfe     // movq         %r15, %rsi
 	WORD $0xf8c5; BYTE $0x77     // vzeroupper
-	LONG $0x007154e8; BYTE $0x00 // callq        _format_significand, $29012(%rip)
+	LONG $0x008254e8; BYTE $0x00 // callq        _format_significand, $33364(%rip)
 	WORD $0xc289                 // movl         %eax, %edx
 	WORD $0x2844; BYTE $0xfa     // subb         %r15b, %dl
 	WORD $0x2844; BYTE $0xf2     // subb         %r14b, %dl
@@ -1091,7 +1091,7 @@ LBB2_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0x100d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40720(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x700d8d48; WORD $0x00b3; BYTE $0x00 // leaq         $45936(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -1107,7 +1107,7 @@ LBB2_2:
 
 LBB2_5:
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
-	LONG $0xc9158d4c; WORD $0x009e; BYTE $0x00 // leaq         $40649(%rip), %r10  /* _Digits(%rip) */
+	LONG $0x29158d4c; WORD $0x00b3; BYTE $0x00 // leaq         $45865(%rip), %r10  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
 LBB2_6:
@@ -1139,7 +1139,7 @@ LBB2_7:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xca                   // movzwl       %dx, %ecx
-	LONG $0x51158d48; WORD $0x009e; BYTE $0x00 // leaq         $40529(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xb1158d48; WORD $0x00b2; BYTE $0x00 // leaq         $45745(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4b894166; BYTE $0xfe               // movw         %cx, $-2(%r11)
 	LONG $0xfec38349                           // addq         $-2, %r11
@@ -1149,7 +1149,7 @@ LBB2_9:
 	WORD $0xfa83; BYTE $0x0a                   // cmpl         $10, %edx
 	LONG $0x0018820f; WORD $0x0000             // jb           LBB2_11, $24(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x300d8d48; WORD $0x009e; BYTE $0x00 // leaq         $40496(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x900d8d48; WORD $0x00b2; BYTE $0x00 // leaq         $45712(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x43894166; BYTE $0xfe               // movw         %ax, $-2(%r11)
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
@@ -1225,7 +1225,7 @@ _u64toa:
 	WORD $0x0148; BYTE $0xc0                   // addq         %rax, %rax
 	LONG $0x03e8fe81; WORD $0x0000             // cmpl         $1000, %esi
 	LONG $0x0016820f; WORD $0x0000             // jb           LBB4_3, $22(%rip)
-	LONG $0x5c0d8d48; WORD $0x009d; BYTE $0x00 // leaq         $40284(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xbc0d8d48; WORD $0x00b1; BYTE $0x00 // leaq         $45500(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x0c8a; BYTE $0x0a                   // movb         (%rdx,%rcx), %cl
 	WORD $0x0f88                               // movb         %cl, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1239,14 +1239,14 @@ LBB4_3:
 LBB4_4:
 	WORD $0xb70f; BYTE $0xd2                   // movzwl       %dx, %edx
 	LONG $0x01ca8348                           // orq          $1, %rdx
-	LONG $0x34358d48; WORD $0x009d; BYTE $0x00 // leaq         $40244(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x94358d48; WORD $0x00b1; BYTE $0x00 // leaq         $45460(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x32                   // movb         (%rdx,%rsi), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x1488; BYTE $0x37                   // movb         %dl, (%rdi,%rsi)
 
 LBB4_6:
-	LONG $0x22158d48; WORD $0x009d; BYTE $0x00 // leaq         $40226(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x82158d48; WORD $0x00b1; BYTE $0x00 // leaq         $45442(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x10                   // movb         (%rax,%rdx), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1255,7 +1255,7 @@ LBB4_6:
 LBB4_7:
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x09158d48; WORD $0x009d; BYTE $0x00 // leaq         $40201(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x69158d48; WORD $0x00b1; BYTE $0x00 // leaq         $45417(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x10                   // movb         (%rax,%rdx), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1302,7 +1302,7 @@ LBB4_8:
 	WORD $0x014d; BYTE $0xdb                   // addq         %r11, %r11
 	LONG $0x9680fe81; WORD $0x0098             // cmpl         $10000000, %esi
 	LONG $0x0017820f; WORD $0x0000             // jb           LBB4_11, $23(%rip)
-	LONG $0x66058d48; WORD $0x009c; BYTE $0x00 // leaq         $40038(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xc6058d48; WORD $0x00b0; BYTE $0x00 // leaq         $45254(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x02048a41                           // movb         (%r10,%rax), %al
 	WORD $0x0788                               // movb         %al, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1316,14 +1316,14 @@ LBB4_11:
 LBB4_12:
 	WORD $0x8944; BYTE $0xd0                   // movl         %r10d, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x3a358d48; WORD $0x009c; BYTE $0x00 // leaq         $39994(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x9a358d48; WORD $0x00b0; BYTE $0x00 // leaq         $45210(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x0488; BYTE $0x37                   // movb         %al, (%rdi,%rsi)
 
 LBB4_14:
-	LONG $0x28058d48; WORD $0x009c; BYTE $0x00 // leaq         $39976(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x88058d48; WORD $0x00b0; BYTE $0x00 // leaq         $45192(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x01048a41                           // movb         (%r9,%rax), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1332,7 +1332,7 @@ LBB4_14:
 LBB4_15:
 	LONG $0xc1b70f41                           // movzwl       %r9w, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x0d358d48; WORD $0x009c; BYTE $0x00 // leaq         $39949(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x6d358d48; WORD $0x00b0; BYTE $0x00 // leaq         $45165(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0x0488; BYTE $0x17                   // movb         %al, (%rdi,%rdx)
@@ -1414,7 +1414,7 @@ LBB4_16:
 	LONG $0x000010b9; BYTE $0x00               // movl         $16, %ecx
 	WORD $0xc129                               // subl         %eax, %ecx
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0x14158d48; WORD $0x00c2; BYTE $0x00 // leaq         $49684(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x74158d48; WORD $0x00d6; BYTE $0x00 // leaq         $54900(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	WORD $0xc889                               // movl         %ecx, %eax
@@ -1440,7 +1440,7 @@ LBB4_20:
 	WORD $0xfa83; BYTE $0x63                   // cmpl         $99, %edx
 	LONG $0x001a870f; WORD $0x0000             // ja           LBB4_22, $26(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x570d8d48; WORD $0x009a; BYTE $0x00 // leaq         $39511(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb70d8d48; WORD $0x00ae; BYTE $0x00 // leaq         $44727(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	LONG $0x000002b9; BYTE $0x00               // movl         $2, %ecx
@@ -1463,7 +1463,7 @@ LBB4_22:
 	WORD $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0x070d8d48; WORD $0x009a; BYTE $0x00 // leaq         $39431(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x670d8d48; WORD $0x00ae; BYTE $0x00 // leaq         $44647(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x01478966                           // movw         %ax, $1(%rdi)
 	LONG $0x000003b9; BYTE $0x00               // movl         $3, %ecx
@@ -1473,7 +1473,7 @@ LBB4_24:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xe60d8d48; WORD $0x0099; BYTE $0x00 // leaq         $39398(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x460d8d48; WORD $0x00ae; BYTE $0x00 // leaq         $44614(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	WORD $0xb70f; BYTE $0xc2                   // movzwl       %dx, %eax
@@ -1572,8 +1572,8 @@ _quote:
 	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
 	WORD $0x8b4c; BYTE $0x11                   // movq         (%rcx), %r10
 	LONG $0x01c0f641                           // testb        $1, %r8b
-	LONG $0x1b058d48; WORD $0x00c0; BYTE $0x00 // leaq         $49179(%rip), %rax  /* __SingleQuoteTab(%rip) */
-	LONG $0x14058d4c; WORD $0x00d0; BYTE $0x00 // leaq         $53268(%rip), %r8  /* __DoubleQuoteTab(%rip) */
+	LONG $0x7b058d48; WORD $0x00d4; BYTE $0x00 // leaq         $54395(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG $0x74058d4c; WORD $0x00e4; BYTE $0x00 // leaq         $58484(%rip), %r8  /* __DoubleQuoteTab(%rip) */
 	LONG $0xc0440f4c                           // cmoveq       %rax, %r8
 	QUAD $0x00000000f5048d48                   // leaq         (,%rsi,8), %rax
 	WORD $0x3949; BYTE $0xc2                   // cmpq         %rax, %r10
@@ -1865,7 +1865,7 @@ LBB5_40:
 	LONG $0x5cb60f41; WORD $0x0015             // movzbl       (%r13,%rdx), %ebx
 	WORD $0x8948; BYTE $0xde                   // movq         %rbx, %rsi
 	LONG $0x04e6c148                           // shlq         $4, %rsi
-	LONG $0xbc058d48; WORD $0x00bb; BYTE $0x00 // leaq         $48060(%rip), %rax  /* __SingleQuoteTab(%rip) */
+	LONG $0x1c058d48; WORD $0x00d0; BYTE $0x00 // leaq         $53276(%rip), %rax  /* __SingleQuoteTab(%rip) */
 	LONG $0x063c8348; BYTE $0x00               // cmpq         $0, (%rsi,%rax)
 	LONG $0x0112850f; WORD $0x0000             // jne          LBB5_61, $274(%rip)
 	LONG $0x0f048d49                           // leaq         (%r15,%rcx), %rax
@@ -2128,7 +2128,7 @@ LBB5_92:
 	LONG $0xfffed8e9; BYTE $0xff   // jmp          LBB5_74, $-296(%rip)
 
 LBB5_93:
-	LONG $0xa60d8d4c; WORD $0x00d8; BYTE $0x00 // leaq         $55462(%rip), %r9  /* __EscTab(%rip) */
+	LONG $0x060d8d4c; WORD $0x00ed; BYTE $0x00 // leaq         $60678(%rip), %r9  /* __EscTab(%rip) */
 	QUAD $0xfffff7ce156f7dc5                   // vmovdqa      $-2098(%rip), %ymm10  /* LCPI5_0(%rip) */
 	QUAD $0xfffff7e60d6f7dc5                   // vmovdqa      $-2074(%rip), %ymm9  /* LCPI5_1(%rip) */
 	QUAD $0xfffff7fe1d6f7dc5                   // vmovdqa      $-2050(%rip), %ymm11  /* LCPI5_2(%rip) */
@@ -2551,7 +2551,7 @@ LBB6_41:
 LBB6_43:
 	WORD $0x014d; BYTE $0xf0                   // addq         %r14, %r8
 	LONG $0x43b60f41; BYTE $0xff               // movzbl       $-1(%r11), %eax
-	LONG $0xe40d8d48; WORD $0x00d3; BYTE $0x00 // leaq         $54244(%rip), %rcx  /* __UnquoteTab(%rip) */
+	LONG $0x440d8d48; WORD $0x00e8; BYTE $0x00 // leaq         $59460(%rip), %rcx  /* __UnquoteTab(%rip) */
 	WORD $0x048a; BYTE $0x08                   // movb         (%rax,%rcx), %al
 	WORD $0xff3c                               // cmpb         $-1, %al
 	LONG $0x0029840f; WORD $0x0000             // je           LBB6_46, $41(%rip)
@@ -3367,7 +3367,7 @@ _html_escape:
 	QUAD $0xffffff1d256ffdc5                                 // vmovdqa      $-227(%rip), %ymm4  /* LCPI7_1(%rip) */
 	QUAD $0xffffff352d6ffdc5                                 // vmovdqa      $-203(%rip), %ymm5  /* LCPI7_2(%rip) */
 	QUAD $0xffffff4d356ffdc5                                 // vmovdqa      $-179(%rip), %ymm6  /* LCPI7_3(%rip) */
-	LONG $0xd6358d4c; WORD $0x00c8; BYTE $0x00               // leaq         $51414(%rip), %r14  /* __HtmlQuoteTab(%rip) */
+	LONG $0x36358d4c; WORD $0x00dd; BYTE $0x00               // leaq         $56630(%rip), %r14  /* __HtmlQuoteTab(%rip) */
 	LONG $0xd05d8b4c                                         // movq         $-48(%rbp), %r11
 	LONG $0xc87d8b4c                                         // movq         $-56(%rbp), %r15
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
@@ -3581,7 +3581,7 @@ LBB7_58:
 	WORD $0x3949; BYTE $0xc5                   // cmpq         %rax, %r13
 	LONG $0x01b88d0f; WORD $0x0000             // jge          LBB7_59, $440(%rip)
 	LONG $0x08fd8349                           // cmpq         $8, %r13
-	LONG $0x90358d4c; WORD $0x00c5; BYTE $0x00 // leaq         $50576(%rip), %r14  /* __HtmlQuoteTab(%rip) */
+	LONG $0xf0358d4c; WORD $0x00d9; BYTE $0x00 // leaq         $55792(%rip), %r14  /* __HtmlQuoteTab(%rip) */
 	LONG $0x01e1820f; WORD $0x0000             // jb           LBB7_70, $481(%rip)
 	WORD $0x8949; BYTE $0x08                   // movq         %rcx, (%r8)
 	LONG $0x24448d49; BYTE $0x08               // leaq         $8(%r12), %rax
@@ -3715,7 +3715,7 @@ LBB7_22:
 
 LBB7_59:
 	WORD $0xf883; BYTE $0x08                   // cmpl         $8, %eax
-	LONG $0xd9358d4c; WORD $0x00c3; BYTE $0x00 // leaq         $50137(%rip), %r14  /* __HtmlQuoteTab(%rip) */
+	LONG $0x39358d4c; WORD $0x00d8; BYTE $0x00 // leaq         $55353(%rip), %r14  /* __HtmlQuoteTab(%rip) */
 	LONG $0x0074820f; WORD $0x0000             // jb           LBB7_60, $116(%rip)
 	WORD $0x8949; BYTE $0x08                   // movq         %rcx, (%r8)
 	LONG $0x24548d4d; BYTE $0x08               // leaq         $8(%r12), %r10
@@ -3813,7 +3813,7 @@ LBB7_57:
 	WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 LBB7_82:
-	LONG $0xc9358d4c; WORD $0x00c2; BYTE $0x00 // leaq         $49865(%rip), %r14  /* __HtmlQuoteTab(%rip) */
+	LONG $0x29358d4c; WORD $0x00d7; BYTE $0x00 // leaq         $55081(%rip), %r14  /* __HtmlQuoteTab(%rip) */
 
 LBB7_83:
 	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
@@ -3975,7 +3975,7 @@ LBB8_5:
 	WORD $0xd348; BYTE $0xe7                   // shlq         %cl, %rdi
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0x04e1c148                           // shlq         $4, %rcx
-	LONG $0x313d8d4c; WORD $0x004b; BYTE $0x00 // leaq         $19249(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0x913d8d4c; WORD $0x005f; BYTE $0x00 // leaq         $24465(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	LONG $0x3964f74a; BYTE $0x08               // mulq         $8(%rcx,%r15)
 	WORD $0x8949; BYTE $0xc3                   // movq         %rax, %r11
@@ -4111,7 +4111,7 @@ LBB9_5:
 	LONG $0xd05d8948                           // movq         %rbx, $-48(%rbp)
 	LONG $0x005a8e0f; WORD $0x0000             // jle          LBB9_12, $90(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0xd8358d4c; WORD $0x0074; BYTE $0x00 // leaq         $29912(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x38358d4c; WORD $0x0089; BYTE $0x00 // leaq         $35128(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_8, $45(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
@@ -4124,7 +4124,7 @@ LBB9_10:
 LBB9_11:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x004745e8; BYTE $0x00 // callq        _right_shift, $18245(%rip)
+	LONG $0x005845e8; BYTE $0x00 // callq        _right_shift, $22597(%rip)
 
 LBB9_7:
 	WORD $0x0141; BYTE $0xdc       // addl         %ebx, %r12d
@@ -4141,7 +4141,7 @@ LBB9_8:
 	LONG $0xffffd3e9; BYTE $0xff   // jmp          LBB9_7, $-45(%rip)
 
 LBB9_12:
-	LONG $0x81358d4c; WORD $0x0074; BYTE $0x00 // leaq         $29825(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0xe1358d4c; WORD $0x0088; BYTE $0x00 // leaq         $35041(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_14, $45(%rip)
 
 LBB9_18:
@@ -4153,7 +4153,7 @@ LBB9_18:
 LBB9_20:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x0044c6e8; BYTE $0x00 // callq        _left_shift, $17606(%rip)
+	LONG $0x0055c6e8; BYTE $0x00 // callq        _left_shift, $21958(%rip)
 	LONG $0x14478b41             // movl         $20(%r15), %eax
 
 LBB9_13:
@@ -4195,7 +4195,7 @@ LBB9_21:
 LBB9_25:
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x00003cbe; BYTE $0x00   // movl         $60, %esi
-	LONG $0x004653e8; BYTE $0x00   // callq        _right_shift, $18003(%rip)
+	LONG $0x005753e8; BYTE $0x00   // callq        _right_shift, $22355(%rip)
 	LONG $0x3cc48341               // addl         $60, %r12d
 	LONG $0x88fc8341               // cmpl         $-120, %r12d
 	LONG $0xffe58c0f; WORD $0xffff // jl           LBB9_25, $-27(%rip)
@@ -4221,7 +4221,7 @@ LBB9_31:
 	WORD $0xf741; BYTE $0xdc       // negl         %r12d
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	WORD $0x8944; BYTE $0xe6       // movl         %r12d, %esi
-	LONG $0x0045ffe8; BYTE $0x00   // callq        _right_shift, $17919(%rip)
+	LONG $0x0056ffe8; BYTE $0x00   // callq        _right_shift, $22271(%rip)
 	LONG $0xfc02be41; WORD $0xffff // movl         $-1022, %r14d
 
 LBB9_32:
@@ -4229,7 +4229,7 @@ LBB9_32:
 	LONG $0x000d840f; WORD $0x0000 // je           LBB9_34, $13(%rip)
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x000035be; BYTE $0x00   // movl         $53, %esi
-	LONG $0x0043c1e8; BYTE $0x00   // callq        _left_shift, $17345(%rip)
+	LONG $0x0054c1e8; BYTE $0x00   // callq        _left_shift, $21697(%rip)
 
 LBB9_34:
 	LONG $0x14478b41                           // movl         $20(%r15), %eax
@@ -4720,7 +4720,7 @@ LBB11_2:
 	LONG $0xb07d8d48               // leaq         $-80(%rbp), %rdi
 	LONG $0xd0758d48               // leaq         $-48(%rbp), %rsi
 	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
-	LONG $0x001344e8; BYTE $0x00   // callq        _vnumber, $4932(%rip)
+	LONG $0x001064e8; BYTE $0x00   // callq        _vnumber, $4196(%rip)
 	LONG $0xd05d8b48               // movq         $-48(%rbp), %rbx
 	LONG $0x0002eee9; BYTE $0x00   // jmp          LBB11_49, $750(%rip)
 
@@ -4742,7 +4742,7 @@ LBB11_4:
 LBB11_7:
 	WORD $0x8948; BYTE $0xdf                   // movq         %rbx, %rdi
 	WORD $0x894c; BYTE $0xe6                   // movq         %r12, %rsi
-	LONG $0x002591e8; BYTE $0x00               // callq        _do_skip_number, $9617(%rip)
+	LONG $0x002291e8; BYTE $0x00               // callq        _do_skip_number, $8849(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
 	LONG $0x0290880f; WORD $0x0000             // js           LBB11_45, $656(%rip)
 	WORD $0x0148; BYTE $0xc3                   // addq         %rax, %rbx
@@ -5428,6 +5428,11 @@ LCPI14_2:
 
 	// .p2align 4, 0x90
 _advance_string:
+	WORD $0xc1f6; BYTE $0x20       // testb        $32, %cl
+	LONG $0x0005850f; WORD $0x0000 // jne          LBB14_2, $5(%rip)
+	LONG $0x004892e9; BYTE $0x00   // jmp          _advance_string_default, $18578(%rip)
+
+LBB14_2:
 	BYTE $0x55                                 // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
 	WORD $0x5741                               // pushq        %r15
@@ -5435,121 +5440,38 @@ _advance_string:
 	WORD $0x5541                               // pushq        %r13
 	WORD $0x5441                               // pushq        %r12
 	BYTE $0x53                                 // pushq        %rbx
-	LONG $0x18ec8348                           // subq         $24, %rsp
-	LONG $0xd0558948                           // movq         %rdx, $-48(%rbp)
-	WORD $0xc1f6; BYTE $0x20                   // testb        $32, %cl
-	LONG $0x0135850f; WORD $0x0000             // jne          LBB14_12, $309(%rip)
-	LONG $0x087f8b4c                           // movq         $8(%rdi), %r15
-	WORD $0x2949; BYTE $0xf7                   // subq         %rsi, %r15
-	LONG $0x090c840f; WORD $0x0000             // je           LBB14_107, $2316(%rip)
-	WORD $0x8b4c; BYTE $0x1f                   // movq         (%rdi), %r11
-	LONG $0xd0458b48                           // movq         $-48(%rbp), %rax
-	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
-	LONG $0x40ff8349                           // cmpq         $64, %r15
-	LONG $0x0726820f; WORD $0x0000             // jb           LBB14_108, $1830(%rip)
-	WORD $0x8948; BYTE $0xf3                   // movq         %rsi, %rbx
-	WORD $0xf748; BYTE $0xd3                   // notq         %rbx
-	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
-	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
-	QUAD $0xffffff45056ffdc5                   // vmovdqa      $-187(%rip), %ymm0  /* LCPI14_0(%rip) */
-	QUAD $0xffffff5d0d6ffdc5                   // vmovdqa      $-163(%rip), %ymm1  /* LCPI14_1(%rip) */
-	QUAD $0xaaaaaaaaaaaab949; WORD $0xaaaa     // movabsq      $-6148914691236517206, %r9
-	QUAD $0x555555555555ba49; WORD $0x5555     // movabsq      $6148914691236517205, %r10
-	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
-
-LBB14_4:
-	LONG $0x6f7ec1c4; WORD $0x3314             // vmovdqu      (%r11,%rsi), %ymm2
-	LONG $0x6f7ec1c4; WORD $0x335c; BYTE $0x20 // vmovdqu      $32(%r11,%rsi), %ymm3
-	LONG $0xe074edc5                           // vpcmpeqb     %ymm0, %ymm2, %ymm4
-	LONG $0xfcd7fdc5                           // vpmovmskb    %ymm4, %edi
-	LONG $0xe074e5c5                           // vpcmpeqb     %ymm0, %ymm3, %ymm4
-	LONG $0xd4d7fdc5                           // vpmovmskb    %ymm4, %edx
-	LONG $0xd174edc5                           // vpcmpeqb     %ymm1, %ymm2, %ymm2
-	LONG $0xc2d7fdc5                           // vpmovmskb    %ymm2, %eax
-	LONG $0xd174e5c5                           // vpcmpeqb     %ymm1, %ymm3, %ymm2
-	LONG $0xcad7fdc5                           // vpmovmskb    %ymm2, %ecx
-	LONG $0x20e2c148                           // shlq         $32, %rdx
-	WORD $0x0948; BYTE $0xd7                   // orq          %rdx, %rdi
-	LONG $0x20e1c148                           // shlq         $32, %rcx
-	WORD $0x0948; BYTE $0xc8                   // orq          %rcx, %rax
-	LONG $0x0030850f; WORD $0x0000             // jne          LBB14_8, $48(%rip)
-	WORD $0x854d; BYTE $0xf6                   // testq        %r14, %r14
-	LONG $0x003f850f; WORD $0x0000             // jne          LBB14_10, $63(%rip)
-	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
-	WORD $0x8548; BYTE $0xff                   // testq        %rdi, %rdi
-	LONG $0x0071850f; WORD $0x0000             // jne          LBB14_11, $113(%rip)
-
-LBB14_7:
-	LONG $0xc0c78349               // addq         $-64, %r15
-	LONG $0xc0c38348               // addq         $-64, %rbx
-	LONG $0x40c68348               // addq         $64, %rsi
-	LONG $0x3fff8349               // cmpq         $63, %r15
-	LONG $0xff94870f; WORD $0xffff // ja           LBB14_4, $-108(%rip)
-	LONG $0x0005f2e9; BYTE $0x00   // jmp          LBB14_98, $1522(%rip)
-
-LBB14_8:
-	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x000e850f; WORD $0x0000 // jne          LBB14_10, $14(%rip)
-	LONG $0xc0bc0f4c               // bsfq         %rax, %r8
-	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	WORD $0x894c; BYTE $0x01       // movq         %r8, (%rcx)
-
-LBB14_10:
-	WORD $0x894c; BYTE $0xf1       // movq         %r14, %rcx
-	WORD $0xf748; BYTE $0xd1       // notq         %rcx
-	WORD $0x2148; BYTE $0xc1       // andq         %rax, %rcx
-	LONG $0x09248d4c               // leaq         (%rcx,%rcx), %r12
-	WORD $0x094d; BYTE $0xf4       // orq          %r14, %r12
-	WORD $0x894c; BYTE $0xe2       // movq         %r12, %rdx
-	WORD $0xf748; BYTE $0xd2       // notq         %rdx
-	WORD $0x2148; BYTE $0xc2       // andq         %rax, %rdx
-	WORD $0x214c; BYTE $0xca       // andq         %r9, %rdx
-	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
-	WORD $0x0148; BYTE $0xca       // addq         %rcx, %rdx
-	LONG $0xc6920f41               // setb         %r14b
-	WORD $0x0148; BYTE $0xd2       // addq         %rdx, %rdx
-	WORD $0x314c; BYTE $0xd2       // xorq         %r10, %rdx
-	WORD $0x214c; BYTE $0xe2       // andq         %r12, %rdx
-	WORD $0xf748; BYTE $0xd2       // notq         %rdx
-	WORD $0x2148; BYTE $0xd7       // andq         %rdx, %rdi
-	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0xff8f840f; WORD $0xffff // je           LBB14_7, $-113(%rip)
-
-LBB14_11:
-	LONG $0xc7bc0f48             // bsfq         %rdi, %rax
-	WORD $0x2948; BYTE $0xd8     // subq         %rbx, %rax
-	LONG $0x00053ee9; BYTE $0x00 // jmp          LBB14_94, $1342(%rip)
-
-LBB14_12:
+	LONG $0x20ec8348                           // subq         $32, %rsp
 	LONG $0x08778b4c                           // movq         $8(%rdi), %r14
 	WORD $0x2949; BYTE $0xf6                   // subq         %rsi, %r14
-	LONG $0x07d7840f; WORD $0x0000             // je           LBB14_107, $2007(%rip)
-	WORD $0x8b4c; BYTE $0x3f                   // movq         (%rdi), %r15
-	WORD $0x014c; BYTE $0xfe                   // addq         %r15, %rsi
-	LONG $0xd0458b48                           // movq         $-48(%rbp), %rax
-	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
-	LONG $0xc87d894c                           // movq         %r15, $-56(%rbp)
-	WORD $0xf749; BYTE $0xdf                   // negq         %r15
+	LONG $0x062d840f; WORD $0x0000             // je           LBB14_91, $1581(%rip)
+	WORD $0x8b48; BYTE $0x07                   // movq         (%rdi), %rax
+	WORD $0x0148; BYTE $0xc6                   // addq         %rax, %rsi
+	LONG $0xc8558948                           // movq         %rdx, $-56(%rbp)
+	LONG $0xff02c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rdx)
+	LONG $0xd0458948                           // movq         %rax, $-48(%rbp)
+	WORD $0xf748; BYTE $0xd8                   // negq         %rax
+	LONG $0xb8458948                           // movq         %rax, $-72(%rbp)
 	QUAD $0xffffffffc045c748                   // movq         $-1, $-64(%rbp)
-	QUAD $0xfffffe18056ffdc5                   // vmovdqa      $-488(%rip), %ymm0  /* LCPI14_0(%rip) */
-	QUAD $0xfffffe300d6ffdc5                   // vmovdqa      $-464(%rip), %ymm1  /* LCPI14_1(%rip) */
-	QUAD $0xfffffe48156ffdc5                   // vmovdqa      $-440(%rip), %ymm2  /* LCPI14_2(%rip) */
+	QUAD $0xffffff48056ffdc5                   // vmovdqa      $-184(%rip), %ymm0  /* LCPI14_0(%rip) */
+	QUAD $0xffffff600d6ffdc5                   // vmovdqa      $-160(%rip), %ymm1  /* LCPI14_1(%rip) */
+	QUAD $0xffffff78156ffdc5                   // vmovdqa      $-136(%rip), %ymm2  /* LCPI14_2(%rip) */
 	LONG $0xdb76e5c5                           // vpcmpeqd     %ymm3, %ymm3, %ymm3
+	LONG $0x000040ba; BYTE $0x00               // movl         $64, %edx
 
-LBB14_14:
+LBB14_4:
 	LONG $0x40fe8349               // cmpq         $64, %r14
-	LONG $0x02a2820f; WORD $0x0000 // jb           LBB14_52, $674(%rip)
-	LONG $0x37248d4d               // leaq         (%r15,%rsi), %r12
+	LONG $0x02ba820f; WORD $0x0000 // jb           LBB14_42, $698(%rip)
+	LONG $0xb8458b48               // movq         $-72(%rbp), %rax
+	LONG $0x30248d4c               // leaq         (%rax,%rsi), %r12
 	WORD $0xff31                   // xorl         %edi, %edi
 	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
-	BYTE $0x90                     // .p2align 4, 0x90
+	QUAD $0x9090909090909090       // .p2align 4, 0x90
 
-LBB14_16:
+LBB14_6:
 	LONG $0x246ffec5; BYTE $0x3e   // vmovdqu      (%rsi,%rdi), %ymm4
 	LONG $0x6c6ffec5; WORD $0x203e // vmovdqu      $32(%rsi,%rdi), %ymm5
 	LONG $0xf074ddc5               // vpcmpeqb     %ymm0, %ymm4, %ymm6
-	LONG $0xded7fdc5               // vpmovmskb    %ymm6, %ebx
+	LONG $0xfed77dc5               // vpmovmskb    %ymm6, %r15d
 	LONG $0xf074d5c5               // vpcmpeqb     %ymm0, %ymm5, %ymm6
 	LONG $0xd6d77dc5               // vpmovmskb    %ymm6, %r10d
 	LONG $0xf174ddc5               // vpcmpeqb     %ymm1, %ymm4, %ymm6
@@ -5562,47 +5484,47 @@ LBB14_16:
 	LONG $0xded77dc5               // vpmovmskb    %ymm6, %r11d
 	LONG $0xc5d7fdc5               // vpmovmskb    %ymm5, %eax
 	LONG $0x20e2c149               // shlq         $32, %r10
-	WORD $0x094c; BYTE $0xd3       // orq          %r10, %rbx
+	WORD $0x094d; BYTE $0xd7       // orq          %r10, %r15
 	LONG $0x20e0c149               // shlq         $32, %r8
 	LONG $0x20e3c149               // shlq         $32, %r11
 	LONG $0x20e0c148               // shlq         $32, %rax
 	WORD $0x094d; BYTE $0xc1       // orq          %r8, %r9
-	LONG $0x0058850f; WORD $0x0000 // jne          LBB14_23, $88(%rip)
+	LONG $0x0058850f; WORD $0x0000 // jne          LBB14_13, $88(%rip)
 	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x006f850f; WORD $0x0000 // jne          LBB14_25, $111(%rip)
+	LONG $0x006f850f; WORD $0x0000 // jne          LBB14_15, $111(%rip)
 	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
 
-LBB14_19:
+LBB14_9:
 	LONG $0xec64edc5               // vpcmpgtb     %ymm4, %ymm2, %ymm5
 	LONG $0xf364ddc5               // vpcmpgtb     %ymm3, %ymm4, %ymm6
 	LONG $0xeedbd5c5               // vpand        %ymm6, %ymm5, %ymm5
-	LONG $0xd5d7fdc5               // vpmovmskb    %ymm5, %edx
-	LONG $0xccd7fdc5               // vpmovmskb    %ymm4, %ecx
-	WORD $0x0949; BYTE $0xd3       // orq          %rdx, %r11
-	WORD $0x0948; BYTE $0xc8       // orq          %rcx, %rax
-	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
-	LONG $0x00a6850f; WORD $0x0000 // jne          LBB14_26, $166(%rip)
+	LONG $0xcdd7fdc5               // vpmovmskb    %ymm5, %ecx
+	LONG $0xdcd7fdc5               // vpmovmskb    %ymm4, %ebx
+	WORD $0x0949; BYTE $0xcb       // orq          %rcx, %r11
+	WORD $0x0948; BYTE $0xd8       // orq          %rbx, %rax
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x00a6850f; WORD $0x0000 // jne          LBB14_16, $166(%rip)
 	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x0474850f; WORD $0x0000 // jne          LBB14_96, $1140(%rip)
+	LONG $0x0481850f; WORD $0x0000 // jne          LBB14_86, $1153(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x01ac850f; WORD $0x0000 // jne          LBB14_46, $428(%rip)
+	LONG $0x01ac850f; WORD $0x0000 // jne          LBB14_36, $428(%rip)
 	LONG $0xc0c68349               // addq         $-64, %r14
 	LONG $0x40c78348               // addq         $64, %rdi
 	LONG $0x3ffe8349               // cmpq         $63, %r14
-	LONG $0xff52870f; WORD $0xffff // ja           LBB14_16, $-174(%rip)
-	LONG $0x00019ee9; BYTE $0x00   // jmp          LBB14_47, $414(%rip)
+	LONG $0xff52870f; WORD $0xffff // ja           LBB14_6, $-174(%rip)
+	LONG $0x0001a6e9; BYTE $0x00   // jmp          LBB14_37, $422(%rip)
 
-LBB14_23:
+LBB14_13:
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_25, $21(%rip)
-	LONG $0xd1bc0f49               // bsfq         %r9, %rdx
-	WORD $0x014c; BYTE $0xe2       // addq         %r12, %rdx
-	WORD $0x0148; BYTE $0xfa       // addq         %rdi, %rdx
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_15, $21(%rip)
+	LONG $0xd9bc0f49               // bsfq         %r9, %rbx
+	WORD $0x014c; BYTE $0xe3       // addq         %r12, %rbx
+	WORD $0x0148; BYTE $0xfb       // addq         %rdi, %rbx
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	LONG $0xc05d8948               // movq         %rbx, $-64(%rbp)
+	WORD $0x8948; BYTE $0x19       // movq         %rbx, (%rcx)
 
-LBB14_25:
+LBB14_15:
 	WORD $0x894d; BYTE $0xe8                                             // movq         %r13, %r8
 	WORD $0xf749; BYTE $0xd0                                             // notq         %r8
 	WORD $0x214d; BYTE $0xc8                                             // andq         %r9, %r8
@@ -5611,146 +5533,148 @@ LBB14_25:
 	WORD $0x8949; BYTE $0xca                                             // movq         %rcx, %r10
 	WORD $0xf749; BYTE $0xd2                                             // notq         %r10
 	WORD $0x214d; BYTE $0xca                                             // andq         %r9, %r10
-	QUAD $0xaaaaaaaaaaaaba48; WORD $0xaaaa                               // movabsq      $-6148914691236517206, %rdx
-	WORD $0x2149; BYTE $0xd2                                             // andq         %rdx, %r10
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa                               // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2149; BYTE $0xda                                             // andq         %rbx, %r10
 	WORD $0x3145; BYTE $0xed                                             // xorl         %r13d, %r13d
 	WORD $0x014d; BYTE $0xc2                                             // addq         %r8, %r10
 	LONG $0xc5920f41                                                     // setb         %r13b
 	WORD $0x014d; BYTE $0xd2                                             // addq         %r10, %r10
-	QUAD $0x555555555555ba48; WORD $0x5555                               // movabsq      $6148914691236517205, %rdx
-	WORD $0x3149; BYTE $0xd2                                             // xorq         %rdx, %r10
+	QUAD $0x555555555555bb48; WORD $0x5555                               // movabsq      $6148914691236517205, %rbx
+	WORD $0x3149; BYTE $0xda                                             // xorq         %rbx, %r10
 	WORD $0x2149; BYTE $0xca                                             // andq         %rcx, %r10
 	WORD $0xf749; BYTE $0xd2                                             // notq         %r10
-	WORD $0x214c; BYTE $0xd3                                             // andq         %r10, %rbx
-	LONG $0xffff46e9; BYTE $0xff                                         // jmp          LBB14_19, $-186(%rip)
+	WORD $0x214d; BYTE $0xd7                                             // andq         %r10, %r15
+	LONG $0xffff46e9; BYTE $0xff                                         // jmp          LBB14_9, $-186(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_26:
+LBB14_16:
 	LONG $0x0040bc41; WORD $0x0000 // movl         $64, %r12d
 	LONG $0x0040b941; WORD $0x0000 // movl         $64, %r9d
 	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_28, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_18, $4(%rip)
 	LONG $0xcbbc0f4d               // bsfq         %r11, %r9
 
-LBB14_28:
-	LONG $0xdbbc0f48               // bsfq         %rbx, %rbx
+LBB14_18:
+	LONG $0xdfbc0f49               // bsfq         %r15, %rbx
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_30, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_20, $4(%rip)
 	LONG $0xe0bc0f4c               // bsfq         %rax, %r12
 
-LBB14_30:
+LBB14_20:
 	WORD $0x3949; BYTE $0xd9       // cmpq         %rbx, %r9
-	LONG $0x0436820f; WORD $0x0000 // jb           LBB14_104, $1078(%rip)
+	LONG $0x000040ba; BYTE $0x00   // movl         $64, %edx
+	LONG $0x03e8820f; WORD $0x0000 // jb           LBB14_89, $1000(%rip)
 	WORD $0x3949; BYTE $0xdc       // cmpq         %rbx, %r12
-	LONG $0x0387830f; WORD $0x0000 // jae          LBB14_95, $903(%rip)
+	LONG $0x038f830f; WORD $0x0000 // jae          LBB14_85, $911(%rip)
+	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
 
-LBB14_32:
-	WORD $0x0148; BYTE $0xfe // addq         %rdi, %rsi
+LBB14_23:
+	WORD $0x014c; BYTE $0xe6       // addq         %r12, %rsi
+	WORD $0x294d; BYTE $0xe6       // subq         %r12, %r14
+	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB14_33:
-	WORD $0x014c; BYTE $0xe6                           // addq         %r12, %rsi
-	WORD $0x294d; BYTE $0xe6                           // subq         %r12, %r14
-	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
-
-LBB14_34:
+LBB14_24:
 	LONG $0x04fe8349                                                     // cmpq         $4, %r14
-	LONG $0x01ee820f; WORD $0x0000                                       // jb           LBB14_64, $494(%rip)
+	LONG $0x01fb820f; WORD $0x0000                                       // jb           LBB14_54, $507(%rip)
 	WORD $0x068b                                                         // movl         (%rsi), %eax
 	WORD $0xc189                                                         // movl         %eax, %ecx
 	LONG $0xc0f0e181; WORD $0x00c0                                       // andl         $12632304, %ecx
 	LONG $0x80e0f981; WORD $0x0080                                       // cmpl         $8421600, %ecx
-	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_38, $48(%rip)
+	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_28, $48(%rip)
 	WORD $0xc389                                                         // movl         %eax, %ebx
 	LONG $0x200fe381; WORD $0x0000                                       // andl         $8207, %ebx
 	LONG $0x200dfb81; WORD $0x0000                                       // cmpl         $8205, %ebx
-	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_38, $28(%rip)
+	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_28, $28(%rip)
 	LONG $0x000003bf; BYTE $0x00                                         // movl         $3, %edi
 	WORD $0xdb85                                                         // testl        %ebx, %ebx
-	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_44, $109(%rip)
+	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_34, $109(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_38:
+LBB14_28:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0e0e181; WORD $0x0000 // andl         $49376, %ecx
 	LONG $0x80c0f981; WORD $0x0000 // cmpl         $32960, %ecx
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_40, $16(%rip)
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_30, $16(%rip)
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0x000002bf; BYTE $0x00   // movl         $2, %edi
 	WORD $0xe183; BYTE $0x1e       // andl         $30, %ecx
-	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_44, $58(%rip)
+	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_34, $58(%rip)
 
-LBB14_40:
+LBB14_30:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0f8e181; WORD $0xc0c0 // andl         $-1061109512, %ecx
 	LONG $0x80f0f981; WORD $0x8080 // cmpl         $-2139062032, %ecx
-	LONG $0x02c7850f; WORD $0x0000 // jne          LBB14_91, $711(%rip)
+	LONG $0x02d4850f; WORD $0x0000 // jne          LBB14_81, $724(%rip)
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0x3007e181; WORD $0x0000 // andl         $12295, %ecx
-	LONG $0x02b9840f; WORD $0x0000 // je           LBB14_91, $697(%rip)
+	LONG $0x02c6840f; WORD $0x0000 // je           LBB14_81, $710(%rip)
 	LONG $0x000004bf; BYTE $0x00   // movl         $4, %edi
 	WORD $0x04a8                   // testb        $4, %al
-	LONG $0x000b840f; WORD $0x0000 // je           LBB14_44, $11(%rip)
+	LONG $0x000b840f; WORD $0x0000 // je           LBB14_34, $11(%rip)
 	LONG $0x00300325; BYTE $0x00   // andl         $12291, %eax
-	LONG $0x02a1850f; WORD $0x0000 // jne          LBB14_91, $673(%rip)
+	LONG $0x02ae850f; WORD $0x0000 // jne          LBB14_81, $686(%rip)
 
-LBB14_44:
+LBB14_34:
 	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
 	WORD $0x2949; BYTE $0xfe       // subq         %rdi, %r14
-	LONG $0xfdb2840f; WORD $0xffff // je           LBB14_14, $-590(%rip)
+	LONG $0xfda7840f; WORD $0xffff // je           LBB14_4, $-601(%rip)
 	WORD $0x3e80; BYTE $0x00       // cmpb         $0, (%rsi)
-	LONG $0xff3d880f; WORD $0xffff // js           LBB14_34, $-195(%rip)
-	LONG $0xfffda4e9; BYTE $0xff   // jmp          LBB14_14, $-604(%rip)
+	LONG $0xff3d880f; WORD $0xffff // js           LBB14_24, $-195(%rip)
+	LONG $0xfffd99e9; BYTE $0xff   // jmp          LBB14_4, $-615(%rip)
 
-LBB14_46:
+LBB14_36:
 	LONG $0xe0bc0f4c             // bsfq         %rax, %r12
-	LONG $0xffff1be9; BYTE $0xff // jmp          LBB14_32, $-229(%rip)
+	WORD $0x0148; BYTE $0xfe     // addq         %rdi, %rsi
+	LONG $0x000040ba; BYTE $0x00 // movl         $64, %edx
+	LONG $0xffff1be9; BYTE $0xff // jmp          LBB14_23, $-229(%rip)
 
-LBB14_47:
+LBB14_37:
 	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
+	LONG $0x000040ba; BYTE $0x00   // movl         $64, %edx
 	LONG $0x20fe8349               // cmpq         $32, %r14
-	LONG $0x0111820f; WORD $0x0000 // jb           LBB14_63, $273(%rip)
+	LONG $0x0111820f; WORD $0x0000 // jb           LBB14_53, $273(%rip)
 
-LBB14_48:
+LBB14_38:
 	LONG $0x266ffec5               // vmovdqu      (%rsi), %ymm4
 	LONG $0xe874ddc5               // vpcmpeqb     %ymm0, %ymm4, %ymm5
 	LONG $0xcdd77dc5               // vpmovmskb    %ymm5, %r9d
 	LONG $0xe974ddc5               // vpcmpeqb     %ymm1, %ymm4, %ymm5
 	LONG $0xfdd7fdc5               // vpmovmskb    %ymm5, %edi
 	WORD $0xff85                   // testl        %edi, %edi
-	LONG $0x0030850f; WORD $0x0000 // jne          LBB14_53, $48(%rip)
+	LONG $0x0030850f; WORD $0x0000 // jne          LBB14_43, $48(%rip)
 	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x004b850f; WORD $0x0000 // jne          LBB14_55, $75(%rip)
+	LONG $0x004b850f; WORD $0x0000 // jne          LBB14_45, $75(%rip)
 	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0079840f; WORD $0x0000 // je           LBB14_56, $121(%rip)
+	LONG $0x007e840f; WORD $0x0000 // je           LBB14_46, $126(%rip)
 
-LBB14_51:
+LBB14_41:
 	LONG $0xd9bc0f4d             // bsfq         %r9, %r11
-	LONG $0x000076e9; BYTE $0x00 // jmp          LBB14_57, $118(%rip)
+	LONG $0x00007be9; BYTE $0x00 // jmp          LBB14_47, $123(%rip)
 
-LBB14_52:
+LBB14_42:
 	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
 	LONG $0x20fe8349               // cmpq         $32, %r14
-	LONG $0xffb9830f; WORD $0xffff // jae          LBB14_48, $-71(%rip)
-	LONG $0x0000c5e9; BYTE $0x00   // jmp          LBB14_63, $197(%rip)
+	LONG $0xffb9830f; WORD $0xffff // jae          LBB14_38, $-71(%rip)
+	LONG $0x0000c5e9; BYTE $0x00   // jmp          LBB14_53, $197(%rip)
 
-LBB14_53:
+LBB14_43:
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_55, $25(%rip)
+	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_45, $25(%rip)
 	WORD $0x8948; BYTE $0xf0       // movq         %rsi, %rax
-	LONG $0xc8452b48               // subq         $-56(%rbp), %rax
+	LONG $0xd0452b48               // subq         $-48(%rbp), %rax
 	LONG $0xcfbc0f48               // bsfq         %rdi, %rcx
 	WORD $0x0148; BYTE $0xc1       // addq         %rax, %rcx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
+	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
 	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
 
-LBB14_55:
+LBB14_45:
 	WORD $0x8944; BYTE $0xe8       // movl         %r13d, %eax
 	WORD $0xd0f7                   // notl         %eax
 	WORD $0xf821                   // andl         %edi, %eax
 	WORD $0x0c8d; BYTE $0x00       // leal         (%rax,%rax), %ecx
-	LONG $0x45548d41; BYTE $0x00   // leal         (%r13,%rax,2), %edx
+	LONG $0x455c8d41; BYTE $0x00   // leal         (%r13,%rax,2), %ebx
 	WORD $0xd1f7                   // notl         %ecx
 	WORD $0xf921                   // andl         %edi, %ecx
 	LONG $0xaaaae181; WORD $0xaaaa // andl         $-1431655766, %ecx
@@ -5759,156 +5683,156 @@ LBB14_55:
 	LONG $0xc5920f41               // setb         %r13b
 	WORD $0xc901                   // addl         %ecx, %ecx
 	LONG $0x5555f181; WORD $0x5555 // xorl         $1431655765, %ecx
-	WORD $0xd121                   // andl         %edx, %ecx
+	WORD $0xd921                   // andl         %ebx, %ecx
 	WORD $0xd1f7                   // notl         %ecx
 	WORD $0x2141; BYTE $0xc9       // andl         %ecx, %r9d
+	LONG $0x000040ba; BYTE $0x00   // movl         $64, %edx
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0xff87850f; WORD $0xffff // jne          LBB14_51, $-121(%rip)
+	LONG $0xff82850f; WORD $0xffff // jne          LBB14_41, $-126(%rip)
 
-LBB14_56:
+LBB14_46:
 	LONG $0x0040bb41; WORD $0x0000 // movl         $64, %r11d
 
-LBB14_57:
+LBB14_47:
 	LONG $0xec64edc5               // vpcmpgtb     %ymm4, %ymm2, %ymm5
 	LONG $0xf364ddc5               // vpcmpgtb     %ymm3, %ymm4, %ymm6
 	LONG $0xeedbd5c5               // vpand        %ymm6, %ymm5, %ymm5
 	LONG $0xfdd7fdc5               // vpmovmskb    %ymm5, %edi
 	LONG $0xc4d7fdc5               // vpmovmskb    %ymm4, %eax
 	LONG $0xe0bc0f44               // bsfl         %eax, %r12d
-	LONG $0x000040b9; BYTE $0x00   // movl         $64, %ecx
-	LONG $0xe1440f44               // cmovel       %ecx, %r12d
+	LONG $0xe2440f44               // cmovel       %edx, %r12d
 	WORD $0xbc0f; BYTE $0xdf       // bsfl         %edi, %ebx
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x001c840f; WORD $0x0000 // je           LBB14_60, $28(%rip)
+	LONG $0x001c840f; WORD $0x0000 // je           LBB14_50, $28(%rip)
 	WORD $0xff85                   // testl        %edi, %edi
-	WORD $0x440f; BYTE $0xd9       // cmovel       %ecx, %ebx
+	WORD $0x440f; BYTE $0xda       // cmovel       %edx, %ebx
 	WORD $0x3949; BYTE $0xdb       // cmpq         %rbx, %r11
-	LONG $0x028c870f; WORD $0x0000 // ja           LBB14_109, $652(%rip)
+	LONG $0x021a870f; WORD $0x0000 // ja           LBB14_92, $538(%rip)
 	WORD $0x394d; BYTE $0xe3       // cmpq         %r12, %r11
-	LONG $0xfe1d870f; WORD $0xffff // ja           LBB14_33, $-483(%rip)
-	LONG $0x000251e9; BYTE $0x00   // jmp          LBB14_105, $593(%rip)
+	LONG $0xfe15870f; WORD $0xffff // ja           LBB14_23, $-491(%rip)
+	LONG $0x0001fbe9; BYTE $0x00   // jmp          LBB14_90, $507(%rip)
 
-LBB14_60:
+LBB14_50:
 	WORD $0xff85                   // testl        %edi, %edi
-	LONG $0x0284850f; WORD $0x0000 // jne          LBB14_110, $644(%rip)
+	LONG $0x0212850f; WORD $0x0000 // jne          LBB14_93, $530(%rip)
 	WORD $0xc085                   // testl        %eax, %eax
-	LONG $0xfe08850f; WORD $0xffff // jne          LBB14_33, $-504(%rip)
+	LONG $0xfe00850f; WORD $0xffff // jne          LBB14_23, $-512(%rip)
 	LONG $0x20c68348               // addq         $32, %rsi
 	LONG $0xe0c68349               // addq         $-32, %r14
 
-LBB14_63:
+LBB14_53:
 	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x03d9850f; WORD $0x0000 // jne          LBB14_136, $985(%rip)
+	LONG $0x020e850f; WORD $0x0000 // jne          LBB14_94, $526(%rip)
 
-LBB14_64:
+LBB14_54:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 
-LBB14_65:
+LBB14_55:
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
-	LONG $0x0159840f; WORD $0x0000 // je           LBB14_94, $345(%rip)
+	LONG $0x0159840f; WORD $0x0000 // je           LBB14_84, $345(%rip)
 	WORD $0xb60f; BYTE $0x3e       // movzbl       (%rsi), %edi
 	WORD $0xff83; BYTE $0x22       // cmpl         $34, %edi
-	LONG $0x01f8840f; WORD $0x0000 // je           LBB14_103, $504(%rip)
+	LONG $0x019f840f; WORD $0x0000 // je           LBB14_88, $415(%rip)
 	LONG $0x5cff8040               // cmpb         $92, %dil
-	LONG $0x00fd840f; WORD $0x0000 // je           LBB14_87, $253(%rip)
+	LONG $0x00fd840f; WORD $0x0000 // je           LBB14_77, $253(%rip)
 	LONG $0x1fff8040               // cmpb         $31, %dil
-	LONG $0x0127860f; WORD $0x0000 // jbe          LBB14_91, $295(%rip)
+	LONG $0x0127860f; WORD $0x0000 // jbe          LBB14_81, $295(%rip)
 	WORD $0x8440; BYTE $0xff       // testb        %dil, %dil
-	LONG $0x000d880f; WORD $0x0000 // js           LBB14_71, $13(%rip)
+	LONG $0x000d880f; WORD $0x0000 // js           LBB14_61, $13(%rip)
 	LONG $0x01c68348               // addq         $1, %rsi
 	LONG $0xffc68349               // addq         $-1, %r14
-	LONG $0xffffc1e9; BYTE $0xff   // jmp          LBB14_65, $-63(%rip)
+	LONG $0xffffc1e9; BYTE $0xff   // jmp          LBB14_55, $-63(%rip)
 
-LBB14_71:
+LBB14_61:
 	LONG $0x04fe8349               // cmpq         $4, %r14
-	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_73, $7(%rip)
+	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_63, $7(%rip)
 	WORD $0x3e8b                   // movl         (%rsi), %edi
-	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_77, $40(%rip)
+	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_67, $40(%rip)
 
-LBB14_73:
+LBB14_63:
 	LONG $0x02fe8349               // cmpq         $2, %r14
-	LONG $0x001b840f; WORD $0x0000 // je           LBB14_76, $27(%rip)
+	LONG $0x001b840f; WORD $0x0000 // je           LBB14_66, $27(%rip)
 	LONG $0x01fe8349               // cmpq         $1, %r14
-	LONG $0x0014840f; WORD $0x0000 // je           LBB14_77, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB14_67, $20(%rip)
 	LONG $0x027eb60f               // movzbl       $2(%rsi), %edi
 	WORD $0xb70f; BYTE $0x0e       // movzwl       (%rsi), %ecx
 	WORD $0xe7c1; BYTE $0x10       // shll         $16, %edi
 	WORD $0xcf09                   // orl          %ecx, %edi
-	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_77, $3(%rip)
+	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_67, $3(%rip)
 
-LBB14_76:
+LBB14_66:
 	WORD $0xb70f; BYTE $0x3e // movzwl       (%rsi), %edi
 
-LBB14_77:
+LBB14_67:
 	WORD $0xf989                   // movl         %edi, %ecx
 	LONG $0xc0f0e181; WORD $0x00c0 // andl         $12632304, %ecx
 	LONG $0x80e0f981; WORD $0x0080 // cmpl         $8421600, %ecx
-	LONG $0x0022850f; WORD $0x0000 // jne          LBB14_80, $34(%rip)
+	LONG $0x0022850f; WORD $0x0000 // jne          LBB14_70, $34(%rip)
 	WORD $0xfb89                   // movl         %edi, %ebx
 	LONG $0x200fe381; WORD $0x0000 // andl         $8207, %ebx
 	LONG $0x200dfb81; WORD $0x0000 // cmpl         $8205, %ebx
-	LONG $0x000e840f; WORD $0x0000 // je           LBB14_80, $14(%rip)
+	LONG $0x000e840f; WORD $0x0000 // je           LBB14_70, $14(%rip)
 	LONG $0x0003b941; WORD $0x0000 // movl         $3, %r9d
 	WORD $0xdb85                   // testl        %ebx, %ebx
-	LONG $0x0063850f; WORD $0x0000 // jne          LBB14_86, $99(%rip)
+	LONG $0x0063850f; WORD $0x0000 // jne          LBB14_76, $99(%rip)
 
-LBB14_80:
+LBB14_70:
 	WORD $0xf989                   // movl         %edi, %ecx
 	LONG $0xc0e0e181; WORD $0x0000 // andl         $49376, %ecx
 	LONG $0x80c0f981; WORD $0x0000 // cmpl         $32960, %ecx
-	LONG $0x0011850f; WORD $0x0000 // jne          LBB14_82, $17(%rip)
+	LONG $0x0011850f; WORD $0x0000 // jne          LBB14_72, $17(%rip)
 	WORD $0xf989                   // movl         %edi, %ecx
 	LONG $0x0002b941; WORD $0x0000 // movl         $2, %r9d
 	WORD $0xe183; BYTE $0x1e       // andl         $30, %ecx
-	LONG $0x003e850f; WORD $0x0000 // jne          LBB14_86, $62(%rip)
+	LONG $0x003e850f; WORD $0x0000 // jne          LBB14_76, $62(%rip)
 
-LBB14_82:
+LBB14_72:
 	WORD $0xf989                   // movl         %edi, %ecx
 	LONG $0xc0f8e181; WORD $0xc0c0 // andl         $-1061109512, %ecx
 	LONG $0x80f0f981; WORD $0x8080 // cmpl         $-2139062032, %ecx
-	LONG $0x0069850f; WORD $0x0000 // jne          LBB14_91, $105(%rip)
+	LONG $0x0069850f; WORD $0x0000 // jne          LBB14_81, $105(%rip)
 	WORD $0xf989                   // movl         %edi, %ecx
 	LONG $0x3007e181; WORD $0x0000 // andl         $12295, %ecx
-	LONG $0x005b840f; WORD $0x0000 // je           LBB14_91, $91(%rip)
+	LONG $0x005b840f; WORD $0x0000 // je           LBB14_81, $91(%rip)
 	LONG $0x0004b941; WORD $0x0000 // movl         $4, %r9d
 	LONG $0x04c7f640               // testb        $4, %dil
-	LONG $0x000c840f; WORD $0x0000 // je           LBB14_86, $12(%rip)
+	LONG $0x000c840f; WORD $0x0000 // je           LBB14_76, $12(%rip)
 	LONG $0x3003e781; WORD $0x0000 // andl         $12291, %edi
-	LONG $0x003f850f; WORD $0x0000 // jne          LBB14_91, $63(%rip)
+	LONG $0x003f850f; WORD $0x0000 // jne          LBB14_81, $63(%rip)
 
-LBB14_86:
+LBB14_76:
 	WORD $0x014c; BYTE $0xce     // addq         %r9, %rsi
 	WORD $0x294d; BYTE $0xce     // subq         %r9, %r14
-	LONG $0xfffee4e9; BYTE $0xff // jmp          LBB14_65, $-284(%rip)
+	LONG $0xfffee4e9; BYTE $0xff // jmp          LBB14_55, $-284(%rip)
 
-LBB14_87:
+LBB14_77:
 	LONG $0x01fe8349               // cmpq         $1, %r14
-	LONG $0x003c840f; WORD $0x0000 // je           LBB14_94, $60(%rip)
+	LONG $0x003c840f; WORD $0x0000 // je           LBB14_84, $60(%rip)
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_90, $18(%rip)
+	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_80, $18(%rip)
 	WORD $0x8948; BYTE $0xf2       // movq         %rsi, %rdx
-	LONG $0xc8552b48               // subq         $-56(%rbp), %rdx
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
+	LONG $0xd0552b48               // subq         $-48(%rbp), %rdx
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
 	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
 
-LBB14_90:
+LBB14_80:
 	LONG $0x02c68348             // addq         $2, %rsi
 	LONG $0xfec68349             // addq         $-2, %r14
-	LONG $0xfffeb0e9; BYTE $0xff // jmp          LBB14_65, $-336(%rip)
+	LONG $0xfffeb0e9; BYTE $0xff // jmp          LBB14_55, $-336(%rip)
 
-LBB14_91:
-	LONG $0xc8752b48 // subq         $-56(%rbp), %rsi
+LBB14_81:
+	LONG $0xd0752b48 // subq         $-48(%rbp), %rsi
 
-LBB14_92:
-	LONG $0xd0458b48         // movq         $-48(%rbp), %rax
+LBB14_82:
+	LONG $0xc8458b48         // movq         $-56(%rbp), %rax
 	WORD $0x8948; BYTE $0x30 // movq         %rsi, (%rax)
 
-LBB14_93:
+LBB14_83:
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
 
-LBB14_94:
-	LONG $0x18c48348         // addq         $24, %rsp
+LBB14_84:
+	LONG $0x20c48348         // addq         $32, %rsp
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
 	WORD $0x5d41             // popq         %r13
@@ -5918,230 +5842,78 @@ LBB14_94:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	BYTE $0xc3               // retq
 
-LBB14_95:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_85:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xde     // addq         %rbx, %rsi
 	LONG $0x37048d48             // leaq         (%rdi,%rsi), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0xffffdae9; BYTE $0xff // jmp          LBB14_94, $-38(%rip)
+	LONG $0xffffdae9; BYTE $0xff // jmp          LBB14_84, $-38(%rip)
 
-LBB14_96:
+LBB14_86:
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
 	LONG $0xc07d8348; BYTE $0xff               // cmpq         $-1, $-64(%rbp)
-	LONG $0xffc8850f; WORD $0xffff             // jne          LBB14_94, $-56(%rip)
+	LONG $0xffc8850f; WORD $0xffff             // jne          LBB14_84, $-56(%rip)
 	LONG $0xcbbc0f49                           // bsfq         %r11, %rcx
-	LONG $0xc8752b48                           // subq         $-56(%rbp), %rsi
+	LONG $0xd0752b48                           // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xce                   // addq         %rcx, %rsi
 	WORD $0x0148; BYTE $0xfe                   // addq         %rdi, %rsi
-	LONG $0xd04d8b48                           // movq         $-48(%rbp), %rcx
+	LONG $0xc84d8b48                           // movq         $-56(%rbp), %rcx
 	WORD $0x8948; BYTE $0x31                   // movq         %rsi, (%rcx)
-	LONG $0xffffaee9; BYTE $0xff               // jmp          LBB14_94, $-82(%rip)
+	LONG $0xffffaee9; BYTE $0xff               // jmp          LBB14_84, $-82(%rip)
 
-LBB14_98:
-	WORD $0x014c; BYTE $0xde       // addq         %r11, %rsi
-	LONG $0x20ff8349               // cmpq         $32, %r15
-	LONG $0x0116820f; WORD $0x0000 // jb           LBB14_115, $278(%rip)
-
-LBB14_99:
-	LONG $0x066ffec5               // vmovdqu      (%rsi), %ymm0
-	QUAD $0xfffff8a40d74fdc5       // vpcmpeqb     $-1884(%rip), %ymm0, %ymm1  /* LCPI14_0(%rip) */
-	LONG $0xf9d7fdc5               // vpmovmskb    %ymm1, %edi
-	QUAD $0xfffff8b80574fdc5       // vpcmpeqb     $-1864(%rip), %ymm0, %ymm0  /* LCPI14_1(%rip) */
-	LONG $0xc0d7fdc5               // vpmovmskb    %ymm0, %eax
-	WORD $0xc085                   // testl        %eax, %eax
-	LONG $0x0094850f; WORD $0x0000 // jne          LBB14_111, $148(%rip)
-	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
-	LONG $0x00a9850f; WORD $0x0000 // jne          LBB14_113, $169(%rip)
-	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
-	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x00d5840f; WORD $0x0000 // je           LBB14_114, $213(%rip)
-
-LBB14_102:
-	LONG $0xc7bc0f48             // bsfq         %rdi, %rax
-	WORD $0x294c; BYTE $0xde     // subq         %r11, %rsi
-	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
-	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0xffff55e9; BYTE $0xff // jmp          LBB14_94, $-171(%rip)
-
-LBB14_103:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_88:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	LONG $0x01c68348             // addq         $1, %rsi
-	LONG $0x00015fe9; BYTE $0x00 // jmp          LBB14_128, $351(%rip)
+	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
+	LONG $0xffff9ee9; BYTE $0xff // jmp          LBB14_84, $-98(%rip)
 
-LBB14_104:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_89:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x014c; BYTE $0xce     // addq         %r9, %rsi
 	WORD $0x0148; BYTE $0xfe     // addq         %rdi, %rsi
-	LONG $0xffff2be9; BYTE $0xff // jmp          LBB14_92, $-213(%rip)
+	LONG $0xffff81e9; BYTE $0xff // jmp          LBB14_82, $-127(%rip)
 
-LBB14_105:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_90:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	LONG $0x1e048d4a             // leaq         (%rsi,%r11), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0xffff28e9; BYTE $0xff // jmp          LBB14_94, $-216(%rip)
+	LONG $0xffff7ee9; BYTE $0xff // jmp          LBB14_84, $-130(%rip)
 
-LBB14_108:
-	WORD $0x014c; BYTE $0xde                   // addq         %r11, %rsi
-	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
-	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
-	LONG $0x20ff8349                           // cmpq         $32, %r15
-	LONG $0xff70830f; WORD $0xffff             // jae          LBB14_99, $-144(%rip)
-	LONG $0x000081e9; BYTE $0x00               // jmp          LBB14_115, $129(%rip)
-
-LBB14_109:
+LBB14_92:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xc6     // addq         %rax, %rsi
-	LONG $0xfffef0e9; BYTE $0xff // jmp          LBB14_92, $-272(%rip)
+	LONG $0xffff62e9; BYTE $0xff // jmp          LBB14_82, $-158(%rip)
 
-LBB14_110:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_93:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	WORD $0xd889                 // movl         %ebx, %eax
 	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
-	LONG $0xd04d8b48             // movq         $-48(%rbp), %rcx
+	LONG $0xc84d8b48             // movq         $-56(%rbp), %rcx
 	WORD $0x8948; BYTE $0x01     // movq         %rax, (%rcx)
-	LONG $0xfffee2e9; BYTE $0xff // jmp          LBB14_93, $-286(%rip)
+	LONG $0xffff54e9; BYTE $0xff // jmp          LBB14_83, $-172(%rip)
 
-LBB14_111:
-	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x0014850f; WORD $0x0000 // jne          LBB14_113, $20(%rip)
-	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
-	WORD $0x294c; BYTE $0xd9       // subq         %r11, %rcx
-	LONG $0xc0bc0f4c               // bsfq         %rax, %r8
-	WORD $0x0149; BYTE $0xc8       // addq         %rcx, %r8
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	WORD $0x894c; BYTE $0x01       // movq         %r8, (%rcx)
-
-LBB14_113:
-	WORD $0x8944; BYTE $0xf1       // movl         %r14d, %ecx
-	WORD $0xd1f7                   // notl         %ecx
-	WORD $0xc121                   // andl         %eax, %ecx
-	WORD $0x148d; BYTE $0x09       // leal         (%rcx,%rcx), %edx
-	LONG $0x4e1c8d41               // leal         (%r14,%rcx,2), %ebx
-	WORD $0xd2f7                   // notl         %edx
-	WORD $0xc221                   // andl         %eax, %edx
-	LONG $0xaaaae281; WORD $0xaaaa // andl         $-1431655766, %edx
-	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
-	WORD $0xca01                   // addl         %ecx, %edx
-	LONG $0xc6920f41               // setb         %r14b
-	WORD $0xd201                   // addl         %edx, %edx
-	LONG $0x5555f281; WORD $0x5555 // xorl         $1431655765, %edx
-	WORD $0xda21                   // andl         %ebx, %edx
-	WORD $0xd2f7                   // notl         %edx
-	WORD $0xd721                   // andl         %edx, %edi
-	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0xff2b850f; WORD $0xffff // jne          LBB14_102, $-213(%rip)
-
-LBB14_114:
-	LONG $0x20c68348 // addq         $32, %rsi
-	LONG $0xe0c78349 // addq         $-32, %r15
-
-LBB14_115:
+LBB14_94:
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
-	LONG $0x00b9850f; WORD $0x0000 // jne          LBB14_131, $185(%rip)
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x008d840f; WORD $0x0000 // je           LBB14_127, $141(%rip)
-
-LBB14_117:
-	WORD $0x894d; BYTE $0xd9                   // movq         %r11, %r9
-	WORD $0xf749; BYTE $0xd1                   // notq         %r9
-	LONG $0x01c18349                           // addq         $1, %r9
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-
-LBB14_118:
-	WORD $0xff31 // xorl         %edi, %edi
-
-LBB14_119:
-	LONG $0x3e1cb60f               // movzbl       (%rsi,%rdi), %ebx
-	WORD $0xfb80; BYTE $0x22       // cmpb         $34, %bl
-	LONG $0x0066840f; WORD $0x0000 // je           LBB14_126, $102(%rip)
-	WORD $0xfb80; BYTE $0x5c       // cmpb         $92, %bl
-	LONG $0x0012840f; WORD $0x0000 // je           LBB14_122, $18(%rip)
-	LONG $0x01c78348               // addq         $1, %rdi
-	WORD $0x3949; BYTE $0xff       // cmpq         %rdi, %r15
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB14_119, $-35(%rip)
-	LONG $0x00005de9; BYTE $0x00   // jmp          LBB14_129, $93(%rip)
-
-LBB14_122:
-	LONG $0xff4f8d49               // leaq         $-1(%r15), %rcx
-	WORD $0x3948; BYTE $0xf9       // cmpq         %rdi, %rcx
-	LONG $0xfe31840f; WORD $0xffff // je           LBB14_94, $-463(%rip)
-	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x000e850f; WORD $0x0000 // jne          LBB14_125, $14(%rip)
-	LONG $0x31048d4d               // leaq         (%r9,%rsi), %r8
-	WORD $0x0149; BYTE $0xf8       // addq         %rdi, %r8
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	WORD $0x894c; BYTE $0x01       // movq         %r8, (%rcx)
-
-LBB14_125:
-	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
-	LONG $0x02c68348               // addq         $2, %rsi
-	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
-	WORD $0x2948; BYTE $0xf9       // subq         %rdi, %rcx
-	LONG $0xfec18348               // addq         $-2, %rcx
-	LONG $0xfec78349               // addq         $-2, %r15
-	WORD $0x3949; BYTE $0xff       // cmpq         %rdi, %r15
-	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
-	LONG $0xff90850f; WORD $0xffff // jne          LBB14_118, $-112(%rip)
-	LONG $0xfffdf3e9; BYTE $0xff   // jmp          LBB14_94, $-525(%rip)
-
-LBB14_126:
-	WORD $0x0148; BYTE $0xfe // addq         %rdi, %rsi
-	LONG $0x01c68348         // addq         $1, %rsi
-
-LBB14_127:
-	WORD $0x294c; BYTE $0xde // subq         %r11, %rsi
-
-LBB14_128:
-	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
-	LONG $0xfffde1e9; BYTE $0xff // jmp          LBB14_94, $-543(%rip)
-
-LBB14_129:
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	WORD $0xfb80; BYTE $0x22                   // cmpb         $34, %bl
-	LONG $0xfdd1850f; WORD $0xffff             // jne          LBB14_94, $-559(%rip)
-	WORD $0x014c; BYTE $0xfe                   // addq         %r15, %rsi
-	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB14_127, $-35(%rip)
-
-LBB14_131:
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0066840f; WORD $0x0000 // je           LBB14_107, $102(%rip)
-	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_134, $16(%rip)
-	WORD $0x894d; BYTE $0xd8       // movq         %r11, %r8
-	WORD $0xf749; BYTE $0xd0       // notq         %r8
-	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
-	WORD $0x894c; BYTE $0x00       // movq         %r8, (%rax)
-
-LBB14_134:
-	LONG $0x01c68348               // addq         $1, %rsi
-	LONG $0xffc78349               // addq         $-1, %r15
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0xff1c850f; WORD $0xffff // jne          LBB14_117, $-228(%rip)
-	LONG $0xffffa4e9; BYTE $0xff   // jmp          LBB14_127, $-92(%rip)
-
-LBB14_136:
-	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
-	LONG $0x002d840f; WORD $0x0000 // je           LBB14_107, $45(%rip)
+	LONG $0x002d840f; WORD $0x0000 // je           LBB14_91, $45(%rip)
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_139, $21(%rip)
-	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_97, $21(%rip)
+	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
 	WORD $0xf748; BYTE $0xd1       // notq         %rcx
 	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
+	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
 	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
 
-LBB14_139:
+LBB14_97:
 	LONG $0x01c68348             // addq         $1, %rsi
 	LONG $0xffc68349             // addq         $-1, %r14
-	LONG $0xfffbf1e9; BYTE $0xff // jmp          LBB14_64, $-1039(%rip)
+	LONG $0xfffdbce9; BYTE $0xff // jmp          LBB14_54, $-580(%rip)
 
-LBB14_107:
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff             // movq         $-1, %rax
-	LONG $0xfffd4ee9; BYTE $0xff                           // jmp          LBB14_94, $-690(%rip)
-	QUAD $0x0000000000000000; LONG $0x00000000; BYTE $0x00 // .p2align 4, 0x00
+LBB14_91:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff         // movq         $-1, %rax
+	LONG $0xffff19e9; BYTE $0xff                       // jmp          LBB14_84, $-231(%rip)
+	QUAD $0x0000000000000000; WORD $0x0000; BYTE $0x00 // .p2align 4, 0x00
 
 LCPI15_0:
 	LONG $0x43300000 // .long 1127219200
@@ -6524,7 +6296,7 @@ LBB15_61:
 	WORD $0xfe83; BYTE $0x17                   // cmpl         $23, %esi
 	LONG $0x003f8c0f; WORD $0x0000             // jl           LBB15_70, $63(%rip)
 	WORD $0x468d; BYTE $0xea                   // leal         $-22(%rsi), %eax
-	LONG $0xa60d8d48; WORD $0x00c7; BYTE $0x00 // leaq         $51110(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0xe60d8d48; WORD $0x00de; BYTE $0x00 // leaq         $57062(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x000016b8; BYTE $0x00               // movl         $22, %eax
@@ -6534,7 +6306,7 @@ LBB15_67:
 	WORD $0xfe83; BYTE $0xea                   // cmpl         $-22, %esi
 	LONG $0x0052820f; WORD $0x0000             // jb           LBB15_74, $82(%rip)
 	WORD $0xdef7                               // negl         %esi
-	LONG $0x80058d48; WORD $0x00c7; BYTE $0x00 // leaq         $51072(%rip), %rax  /* _P10_TAB(%rip) */
+	LONG $0xc0058d48; WORD $0x00de; BYTE $0x00 // leaq         $57024(%rip), %rax  /* _P10_TAB(%rip) */
 	LONG $0x045efbc5; BYTE $0xf0               // vdivsd       (%rax,%rsi,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x00009de9; BYTE $0x00               // jmp          LBB15_78, $157(%rip)
@@ -6549,7 +6321,7 @@ LBB15_71:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	LONG $0x0018870f; WORD $0x0000             // ja           LBB15_74, $24(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0x460d8d48; WORD $0x00c7; BYTE $0x00 // leaq         $51014(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x860d8d48; WORD $0x00de; BYTE $0x00 // leaq         $56966(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc0               // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x000063e9; BYTE $0x00               // jmp          LBB15_78, $99(%rip)
@@ -6560,7 +6332,7 @@ LBB15_74:
 	LONG $0xc04d8d48               // leaq         $-64(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	LONG $0xa8758948               // movq         %rsi, $-88(%rbp)
-	LONG $0xffdd1fe8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8929(%rip)
+	LONG $0xffdfffe8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8193(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x004d840f; WORD $0x0000 // je           LBB15_80, $77(%rip)
 	LONG $0xa8758b48               // movq         $-88(%rbp), %rsi
@@ -6570,7 +6342,7 @@ LBB15_74:
 	LONG $0xb04d8d48               // leaq         $-80(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	WORD $0x558b; BYTE $0xd4       // movl         $-44(%rbp), %edx
-	LONG $0xffdcf6e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8970(%rip)
+	LONG $0xffdfd6e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8234(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x0024840f; WORD $0x0000 // je           LBB15_80, $36(%rip)
 	LONG $0x4d10fbc5; BYTE $0xb0   // vmovsd       $-80(%rbp), %xmm1
@@ -6591,7 +6363,7 @@ LBB15_80:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	LONG $0xc8558b48             // movq         $-56(%rbp), %rdx
 	LONG $0xa04d8b48             // movq         $-96(%rbp), %rcx
-	LONG $0xffe42ee8; BYTE $0xff // callq        _atof_native, $-7122(%rip)
+	LONG $0xffe70ee8; BYTE $0xff // callq        _atof_native, $-6386(%rip)
 	LONG $0x4511fbc5; BYTE $0xc0 // vmovsd       %xmm0, $-64(%rbp)
 	LONG $0x7ef9e1c4; BYTE $0xc0 // vmovq        %xmm0, %rax
 	LONG $0x000009e9; BYTE $0x00 // jmp          LBB15_83, $9(%rip)
@@ -6866,17 +6638,18 @@ LBB17_9:
 	BYTE $0xc3               // retq
 	WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-_skip_one:
-	BYTE $0x55                                 // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
-	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
-	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
-	BYTE $0x5d                                 // popq         %rbp
-	LONG $0x000003e9; BYTE $0x00               // jmp          _fsm_exec, $3(%rip)
-	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
+_skip_array:
+	BYTE $0x55                                             // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
+	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
+	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
+	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
+	BYTE $0x5d                                             // popq         %rbp
+	LONG $0x00000de9; BYTE $0x00                           // jmp          _fsm_exec, $13(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _fsm_exec:
 	BYTE $0x55                                 // pushq        %rbp
@@ -6920,7 +6693,7 @@ LBB19_7:
 	WORD $0x8949; BYTE $0xd7       // movq         %rdx, %r15
 	WORD $0x8948; BYTE $0xd7       // movq         %rdx, %rdi
 	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
-	LONG $0xffe91ee8; BYTE $0xff   // callq        _advance_ns, $-5858(%rip)
+	LONG $0xffebeee8; BYTE $0xff   // callq        _advance_ns, $-5138(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x03c5840f; WORD $0x0000 // je           LBB19_61, $965(%rip)
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
@@ -6972,7 +6745,7 @@ LBB19_17:
 	WORD $0x8948; BYTE $0xde                   // movq         %rbx, %rsi
 	LONG $0xc0558d48                           // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48                           // movq         $-72(%rbp), %rcx
-	LONG $0xffec6be8; BYTE $0xff               // callq        _advance_string, $-5013(%rip)
+	LONG $0xffef3be8; BYTE $0xff               // callq        _advance_string, $-4293(%rip)
 	WORD $0x8949; BYTE $0xc5                   // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
 	LONG $0x012d890f; WORD $0x0000             // jns          LBB19_35, $301(%rip)
@@ -7029,7 +6802,7 @@ LBB19_29:
 	WORD $0x014c; BYTE $0xef       // addq         %r13, %rdi
 	LONG $0x08728b48               // movq         $8(%rdx), %rsi
 	WORD $0x294c; BYTE $0xee       // subq         %r13, %rsi
-	LONG $0x0007c8e8; BYTE $0x00   // callq        _do_skip_number, $1992(%rip)
+	LONG $0x000798e8; BYTE $0x00   // callq        _do_skip_number, $1944(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0283880f; WORD $0x0000 // js           LBB19_62, $643(%rip)
 	WORD $0x8b48; BYTE $0x0b       // movq         (%rbx), %rcx
@@ -7060,7 +6833,7 @@ LBB19_33:
 	WORD $0x894c; BYTE $0xf6                   // movq         %r14, %rsi
 	LONG $0xc0558d48                           // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48                           // movq         $-72(%rbp), %rcx
-	LONG $0xffeb47e8; BYTE $0xff               // callq        _advance_string, $-5305(%rip)
+	LONG $0xffee17e8; BYTE $0xff               // callq        _advance_string, $-4585(%rip)
 	WORD $0x8949; BYTE $0xc5                   // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
 	LONG $0x002f890f; WORD $0x0000             // jns          LBB19_38, $47(%rip)
@@ -7112,7 +6885,7 @@ LBB19_42:
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
-	LONG $0xffeaa8e8; BYTE $0xff   // callq        _advance_string, $-5464(%rip)
+	LONG $0xffed78e8; BYTE $0xff   // callq        _advance_string, $-4744(%rip)
 	WORD $0x8949; BYTE $0xc5       // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0136890f; WORD $0x0000 // jns          LBB19_58, $310(%rip)
@@ -7125,7 +6898,7 @@ LBB19_44:
 	WORD $0x014c; BYTE $0xef       // addq         %r13, %rdi
 	LONG $0x08728b48               // movq         $8(%rdx), %rsi
 	WORD $0x294c; BYTE $0xee       // subq         %r13, %rsi
-	LONG $0x00068ee8; BYTE $0x00   // callq        _do_skip_number, $1678(%rip)
+	LONG $0x00065ee8; BYTE $0x00   // callq        _do_skip_number, $1630(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0171880f; WORD $0x0000 // js           LBB19_67, $369(%rip)
 	WORD $0x0149; BYTE $0x06       // addq         %rax, (%r14)
@@ -7462,19 +7235,6 @@ LJTI19_1:
 	LONG $0xfffffea9 // .long L19_1_set_56
 
 	// .p2align 4, 0x90
-_skip_array:
-	BYTE $0x55                                             // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
-	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
-	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
-	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
-	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff88de9; BYTE $0xff                           // jmp          _fsm_exec, $-1907(%rip)
-	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
-
 _skip_object:
 	BYTE $0x55                                             // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
@@ -7485,7 +7245,7 @@ _skip_object:
 	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
 	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
 	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff85de9; BYTE $0xff                           // jmp          _fsm_exec, $-1955(%rip)
+	LONG $0xfff88de9; BYTE $0xff                           // jmp          _fsm_exec, $-1907(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _skip_string:
@@ -7499,18 +7259,18 @@ _skip_string:
 	WORD $0x8b48; BYTE $0x1e       // movq         (%rsi), %rbx
 	LONG $0xe8558d48               // leaq         $-24(%rbp), %rdx
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
-	LONG $0xffe5c0e8; BYTE $0xff   // callq        _advance_string, $-6720(%rip)
+	LONG $0xffe8c0e8; BYTE $0xff   // callq        _advance_string, $-5952(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0009890f; WORD $0x0000 // jns          LBB22_1, $9(%rip)
+	LONG $0x0009890f; WORD $0x0000 // jns          LBB21_1, $9(%rip)
 	LONG $0xe84d8b48               // movq         $-24(%rbp), %rcx
-	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB22_3, $10(%rip)
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB21_3, $10(%rip)
 
-LBB22_1:
+LBB21_1:
 	LONG $0xffc38348         // addq         $-1, %rbx
 	WORD $0x8948; BYTE $0xc1 // movq         %rax, %rcx
 	WORD $0x8948; BYTE $0xd8 // movq         %rbx, %rax
 
-LBB22_3:
+LBB21_3:
 	WORD $0x8949; BYTE $0x0e // movq         %rcx, (%r14)
 	LONG $0x10c48348         // addq         $16, %rsp
 	BYTE $0x5b               // popq         %rbx
@@ -7533,17 +7293,17 @@ _skip_negative:
 	WORD $0x8948; BYTE $0xc7       // movq         %rax, %rdi
 	LONG $0x00017ee8; BYTE $0x00   // callq        _do_skip_number, $382(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x000c880f; WORD $0x0000 // js           LBB23_1, $12(%rip)
+	LONG $0x000c880f; WORD $0x0000 // js           LBB22_1, $12(%rip)
 	WORD $0x0149; BYTE $0x06       // addq         %rax, (%r14)
 	LONG $0xffc38348               // addq         $-1, %rbx
-	LONG $0x00000de9; BYTE $0x00   // jmp          LBB23_3, $13(%rip)
+	LONG $0x00000de9; BYTE $0x00   // jmp          LBB22_3, $13(%rip)
 
-LBB23_1:
+LBB22_1:
 	WORD $0xf748; BYTE $0xd0                   // notq         %rax
 	WORD $0x0149; BYTE $0x06                   // addq         %rax, (%r14)
 	LONG $0xfec3c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rbx
 
-LBB23_3:
+LBB22_3:
 	WORD $0x8948; BYTE $0xd8 // movq         %rbx, %rax
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5e41             // popq         %r14
@@ -7551,54 +7311,54 @@ LBB23_3:
 	BYTE $0xc3               // retq
 	LONG $0x00000000         // .p2align 5, 0x00
 
-LCPI24_0:
+LCPI23_0:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI24_1:
+LCPI23_1:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI24_2:
+LCPI23_2:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI24_3:
+LCPI23_3:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI24_4:
+LCPI23_4:
 	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
 	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
 
-LCPI24_5:
+LCPI23_5:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI24_6:
+LCPI23_6:
 	QUAD $0x4545454545454545; QUAD $0x4545454545454545 // .space 16, 'EEEEEEEEEEEEEEEE'
 	QUAD $0x4545454545454545; QUAD $0x4545454545454545 // .space 16, 'EEEEEEEEEEEEEEEE'
 
 	// .p2align 4, 0x00
-LCPI24_7:
+LCPI23_7:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI24_8:
+LCPI23_8:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI24_9:
+LCPI23_9:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI24_10:
+LCPI23_10:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI24_11:
+LCPI23_11:
 	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
 
-LCPI24_12:
+LCPI23_12:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI24_13:
+LCPI23_13:
 	QUAD $0x4545454545454545; QUAD $0x4545454545454545 // .space 16, 'EEEEEEEEEEEEEEEE'
 
 	// .p2align 4, 0x90
@@ -7610,38 +7370,38 @@ _do_skip_number:
 	WORD $0x5441                           // pushq        %r12
 	BYTE $0x53                             // pushq        %rbx
 	WORD $0x8548; BYTE $0xf6               // testq        %rsi, %rsi
-	LONG $0x03a5840f; WORD $0x0000         // je           LBB24_1, $933(%rip)
+	LONG $0x03a5840f; WORD $0x0000         // je           LBB23_1, $933(%rip)
 	WORD $0x3f80; BYTE $0x30               // cmpb         $48, (%rdi)
-	LONG $0x0035850f; WORD $0x0000         // jne          LBB24_6, $53(%rip)
+	LONG $0x0035850f; WORD $0x0000         // jne          LBB23_6, $53(%rip)
 	LONG $0x000001b8; BYTE $0x00           // movl         $1, %eax
 	LONG $0x01fe8348                       // cmpq         $1, %rsi
-	LONG $0x04b9840f; WORD $0x0000         // je           LBB24_81, $1209(%rip)
+	LONG $0x04b9840f; WORD $0x0000         // je           LBB23_81, $1209(%rip)
 	WORD $0x4f8a; BYTE $0x01               // movb         $1(%rdi), %cl
 	WORD $0xc180; BYTE $0xd2               // addb         $-46, %cl
 	WORD $0xf980; BYTE $0x37               // cmpb         $55, %cl
-	LONG $0x04aa870f; WORD $0x0000         // ja           LBB24_81, $1194(%rip)
+	LONG $0x04aa870f; WORD $0x0000         // ja           LBB23_81, $1194(%rip)
 	WORD $0xb60f; BYTE $0xc9               // movzbl       %cl, %ecx
 	QUAD $0x000000800001ba48; WORD $0x0080 // movabsq      $36028797027352577, %rdx
 	LONG $0xcaa30f48                       // btq          %rcx, %rdx
-	LONG $0x0493830f; WORD $0x0000         // jae          LBB24_81, $1171(%rip)
+	LONG $0x0493830f; WORD $0x0000         // jae          LBB23_81, $1171(%rip)
 
-LBB24_6:
+LBB23_6:
 	LONG $0xffc1c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r9
 	LONG $0x20fe8348                           // cmpq         $32, %rsi
-	LONG $0x048e820f; WORD $0x0000             // jb           LBB24_7, $1166(%rip)
+	LONG $0x048e820f; WORD $0x0000             // jb           LBB23_7, $1166(%rip)
 	WORD $0xc031                               // xorl         %eax, %eax
-	QUAD $0xfffffe43056ffdc5                   // vmovdqa      $-445(%rip), %ymm0  /* LCPI24_0(%rip) */
-	QUAD $0xfffffe5b0d6ffdc5                   // vmovdqa      $-421(%rip), %ymm1  /* LCPI24_1(%rip) */
-	QUAD $0xfffffe73156ffdc5                   // vmovdqa      $-397(%rip), %ymm2  /* LCPI24_2(%rip) */
-	QUAD $0xfffffe8b1d6ffdc5                   // vmovdqa      $-373(%rip), %ymm3  /* LCPI24_3(%rip) */
-	QUAD $0xfffffea3256ffdc5                   // vmovdqa      $-349(%rip), %ymm4  /* LCPI24_4(%rip) */
-	QUAD $0xfffffebb2d6ffdc5                   // vmovdqa      $-325(%rip), %ymm5  /* LCPI24_5(%rip) */
-	QUAD $0xfffffed3356ffdc5                   // vmovdqa      $-301(%rip), %ymm6  /* LCPI24_6(%rip) */
+	QUAD $0xfffffe43056ffdc5                   // vmovdqa      $-445(%rip), %ymm0  /* LCPI23_0(%rip) */
+	QUAD $0xfffffe5b0d6ffdc5                   // vmovdqa      $-421(%rip), %ymm1  /* LCPI23_1(%rip) */
+	QUAD $0xfffffe73156ffdc5                   // vmovdqa      $-397(%rip), %ymm2  /* LCPI23_2(%rip) */
+	QUAD $0xfffffe8b1d6ffdc5                   // vmovdqa      $-373(%rip), %ymm3  /* LCPI23_3(%rip) */
+	QUAD $0xfffffea3256ffdc5                   // vmovdqa      $-349(%rip), %ymm4  /* LCPI23_4(%rip) */
+	QUAD $0xfffffebb2d6ffdc5                   // vmovdqa      $-325(%rip), %ymm5  /* LCPI23_5(%rip) */
+	QUAD $0xfffffed3356ffdc5                   // vmovdqa      $-301(%rip), %ymm6  /* LCPI23_6(%rip) */
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
 	LONG $0x90909090; BYTE $0x90               // .p2align 4, 0x90
 
-LBB24_9:
+LBB23_9:
 	LONG $0x3c6ffec5; BYTE $0x07   // vmovdqu      (%rdi,%rax), %ymm7
 	LONG $0xc06445c5               // vpcmpgtb     %ymm0, %ymm7, %ymm8
 	LONG $0xcf6475c5               // vpcmpgtb     %ymm7, %ymm1, %ymm9
@@ -7662,7 +7422,7 @@ LBB24_9:
 	WORD $0xf748; BYTE $0xd1       // notq         %rcx
 	LONG $0xf1bc0f4c               // bsfq         %rcx, %r14
 	LONG $0x20fe8341               // cmpl         $32, %r14d
-	LONG $0x0017840f; WORD $0x0000 // je           LBB24_11, $23(%rip)
+	LONG $0x0017840f; WORD $0x0000 // je           LBB23_11, $23(%rip)
 	LONG $0xffffffbb; BYTE $0xff   // movl         $-1, %ebx
 	WORD $0x8944; BYTE $0xf1       // movl         %r14d, %ecx
 	WORD $0xe3d3                   // shll         %cl, %ebx
@@ -7672,69 +7432,69 @@ LBB24_9:
 	WORD $0x2144; BYTE $0xdb       // andl         %r11d, %ebx
 	WORD $0x8941; BYTE $0xdb       // movl         %ebx, %r11d
 
-LBB24_11:
+LBB23_11:
 	WORD $0x4a8d; BYTE $0xff       // leal         $-1(%rdx), %ecx
 	WORD $0xd121                   // andl         %edx, %ecx
-	LONG $0x0385850f; WORD $0x0000 // jne          LBB24_12, $901(%rip)
+	LONG $0x0385850f; WORD $0x0000 // jne          LBB23_12, $901(%rip)
 	LONG $0xff4f8d41               // leal         $-1(%r15), %ecx
 	WORD $0x2144; BYTE $0xf9       // andl         %r15d, %ecx
-	LONG $0x0378850f; WORD $0x0000 // jne          LBB24_12, $888(%rip)
+	LONG $0x0378850f; WORD $0x0000 // jne          LBB23_12, $888(%rip)
 	LONG $0xff4b8d41               // leal         $-1(%r11), %ecx
 	WORD $0x2144; BYTE $0xd9       // andl         %r11d, %ecx
-	LONG $0x036b850f; WORD $0x0000 // jne          LBB24_12, $875(%rip)
+	LONG $0x036b850f; WORD $0x0000 // jne          LBB23_12, $875(%rip)
 	WORD $0xd285                   // testl        %edx, %edx
-	LONG $0x0013840f; WORD $0x0000 // je           LBB24_19, $19(%rip)
+	LONG $0x0013840f; WORD $0x0000 // je           LBB23_19, $19(%rip)
 	WORD $0xbc0f; BYTE $0xca       // bsfl         %edx, %ecx
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x035e850f; WORD $0x0000 // jne          LBB24_82, $862(%rip)
+	LONG $0x035e850f; WORD $0x0000 // jne          LBB23_82, $862(%rip)
 	WORD $0x0148; BYTE $0xc1       // addq         %rax, %rcx
 	WORD $0x8949; BYTE $0xca       // movq         %rcx, %r10
 
-LBB24_19:
+LBB23_19:
 	WORD $0x8545; BYTE $0xff       // testl        %r15d, %r15d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_22, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_22, $20(%rip)
 	LONG $0xcfbc0f41               // bsfl         %r15d, %ecx
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x0341850f; WORD $0x0000 // jne          LBB24_82, $833(%rip)
+	LONG $0x0341850f; WORD $0x0000 // jne          LBB23_82, $833(%rip)
 	WORD $0x0148; BYTE $0xc1       // addq         %rax, %rcx
 	WORD $0x8949; BYTE $0xc8       // movq         %rcx, %r8
 
-LBB24_22:
+LBB23_22:
 	WORD $0x8545; BYTE $0xdb       // testl        %r11d, %r11d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_25, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_25, $20(%rip)
 	LONG $0xcbbc0f41               // bsfl         %r11d, %ecx
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x0324850f; WORD $0x0000 // jne          LBB24_82, $804(%rip)
+	LONG $0x0324850f; WORD $0x0000 // jne          LBB23_82, $804(%rip)
 	WORD $0x0148; BYTE $0xc1       // addq         %rax, %rcx
 	WORD $0x8949; BYTE $0xc9       // movq         %rcx, %r9
 
-LBB24_25:
+LBB23_25:
 	LONG $0x20fe8341               // cmpl         $32, %r14d
-	LONG $0x021f850f; WORD $0x0000 // jne          LBB24_83, $543(%rip)
+	LONG $0x021f850f; WORD $0x0000 // jne          LBB23_83, $543(%rip)
 	LONG $0xe0c68348               // addq         $-32, %rsi
 	LONG $0x20c08348               // addq         $32, %rax
 	LONG $0x1ffe8348               // cmpq         $31, %rsi
-	LONG $0xfef8870f; WORD $0xffff // ja           LBB24_9, $-264(%rip)
+	LONG $0xfef8870f; WORD $0xffff // ja           LBB23_9, $-264(%rip)
 	WORD $0xf8c5; BYTE $0x77       // vzeroupper
 	WORD $0x0148; BYTE $0xf8       // addq         %rdi, %rax
 	WORD $0x8949; BYTE $0xc6       // movq         %rax, %r14
 	LONG $0x10fe8348               // cmpq         $16, %rsi
-	LONG $0x0150820f; WORD $0x0000 // jb           LBB24_49, $336(%rip)
+	LONG $0x0150820f; WORD $0x0000 // jb           LBB23_49, $336(%rip)
 
-LBB24_29:
+LBB23_29:
 	WORD $0x894d; BYTE $0xf3     // movq         %r14, %r11
 	WORD $0x2949; BYTE $0xfb     // subq         %rdi, %r11
 	WORD $0xc031                 // xorl         %eax, %eax
-	QUAD $0xfffffdb5056f79c5     // vmovdqa      $-587(%rip), %xmm8  /* LCPI24_7(%rip) */
-	QUAD $0xfffffdbd0d6f79c5     // vmovdqa      $-579(%rip), %xmm9  /* LCPI24_8(%rip) */
-	QUAD $0xfffffdc5156f79c5     // vmovdqa      $-571(%rip), %xmm10  /* LCPI24_9(%rip) */
-	QUAD $0xfffffdcd1d6f79c5     // vmovdqa      $-563(%rip), %xmm11  /* LCPI24_10(%rip) */
-	QUAD $0xfffffdd5256ff9c5     // vmovdqa      $-555(%rip), %xmm4  /* LCPI24_11(%rip) */
-	QUAD $0xfffffddd2d6ff9c5     // vmovdqa      $-547(%rip), %xmm5  /* LCPI24_12(%rip) */
-	QUAD $0xfffffde5356ff9c5     // vmovdqa      $-539(%rip), %xmm6  /* LCPI24_13(%rip) */
+	QUAD $0xfffffdb5056f79c5     // vmovdqa      $-587(%rip), %xmm8  /* LCPI23_7(%rip) */
+	QUAD $0xfffffdbd0d6f79c5     // vmovdqa      $-579(%rip), %xmm9  /* LCPI23_8(%rip) */
+	QUAD $0xfffffdc5156f79c5     // vmovdqa      $-571(%rip), %xmm10  /* LCPI23_9(%rip) */
+	QUAD $0xfffffdcd1d6f79c5     // vmovdqa      $-563(%rip), %xmm11  /* LCPI23_10(%rip) */
+	QUAD $0xfffffdd5256ff9c5     // vmovdqa      $-555(%rip), %xmm4  /* LCPI23_11(%rip) */
+	QUAD $0xfffffddd2d6ff9c5     // vmovdqa      $-547(%rip), %xmm5  /* LCPI23_12(%rip) */
+	QUAD $0xfffffde5356ff9c5     // vmovdqa      $-539(%rip), %xmm6  /* LCPI23_13(%rip) */
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB24_30:
+LBB23_30:
 	LONG $0x6f7ac1c4; WORD $0x063c // vmovdqu      (%r14,%rax), %xmm7
 	LONG $0x6441c1c4; BYTE $0xc0   // vpcmpgtb     %xmm8, %xmm7, %xmm0
 	LONG $0xcf64b1c5               // vpcmpgtb     %xmm7, %xmm9, %xmm1
@@ -7755,7 +7515,7 @@ LBB24_30:
 	WORD $0xd1f7                   // notl         %ecx
 	WORD $0xbc0f; BYTE $0xc9       // bsfl         %ecx, %ecx
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_32, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_32, $20(%rip)
 	LONG $0xffffffbb; BYTE $0xff   // movl         $-1, %ebx
 	WORD $0xe3d3                   // shll         %cl, %ebx
 	WORD $0xd3f7                   // notl         %ebx
@@ -7764,167 +7524,167 @@ LBB24_30:
 	WORD $0x2144; BYTE $0xfb       // andl         %r15d, %ebx
 	WORD $0x8941; BYTE $0xdf       // movl         %ebx, %r15d
 
-LBB24_32:
+LBB23_32:
 	WORD $0x5a8d; BYTE $0xff       // leal         $-1(%rdx), %ebx
 	WORD $0xd321                   // andl         %edx, %ebx
-	LONG $0x0243850f; WORD $0x0000 // jne          LBB24_33, $579(%rip)
+	LONG $0x0243850f; WORD $0x0000 // jne          LBB23_33, $579(%rip)
 	LONG $0x245c8d41; BYTE $0xff   // leal         $-1(%r12), %ebx
 	WORD $0x2144; BYTE $0xe3       // andl         %r12d, %ebx
-	LONG $0x0235850f; WORD $0x0000 // jne          LBB24_33, $565(%rip)
+	LONG $0x0235850f; WORD $0x0000 // jne          LBB23_33, $565(%rip)
 	LONG $0xff5f8d41               // leal         $-1(%r15), %ebx
 	WORD $0x2144; BYTE $0xfb       // andl         %r15d, %ebx
-	LONG $0x0228850f; WORD $0x0000 // jne          LBB24_33, $552(%rip)
+	LONG $0x0228850f; WORD $0x0000 // jne          LBB23_33, $552(%rip)
 	WORD $0xd285                   // testl        %edx, %edx
-	LONG $0x0016840f; WORD $0x0000 // je           LBB24_40, $22(%rip)
+	LONG $0x0016840f; WORD $0x0000 // je           LBB23_40, $22(%rip)
 	WORD $0xbc0f; BYTE $0xd2       // bsfl         %edx, %edx
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x0223850f; WORD $0x0000 // jne          LBB24_84, $547(%rip)
+	LONG $0x0223850f; WORD $0x0000 // jne          LBB23_84, $547(%rip)
 	WORD $0x014c; BYTE $0xda       // addq         %r11, %rdx
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd2       // movq         %rdx, %r10
 
-LBB24_40:
+LBB23_40:
 	WORD $0x8545; BYTE $0xe4       // testl        %r12d, %r12d
-	LONG $0x0017840f; WORD $0x0000 // je           LBB24_43, $23(%rip)
+	LONG $0x0017840f; WORD $0x0000 // je           LBB23_43, $23(%rip)
 	LONG $0xd4bc0f41               // bsfl         %r12d, %edx
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x0203850f; WORD $0x0000 // jne          LBB24_84, $515(%rip)
+	LONG $0x0203850f; WORD $0x0000 // jne          LBB23_84, $515(%rip)
 	WORD $0x014c; BYTE $0xda       // addq         %r11, %rdx
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd0       // movq         %rdx, %r8
 
-LBB24_43:
+LBB23_43:
 	WORD $0x8545; BYTE $0xff       // testl        %r15d, %r15d
-	LONG $0x0017840f; WORD $0x0000 // je           LBB24_46, $23(%rip)
+	LONG $0x0017840f; WORD $0x0000 // je           LBB23_46, $23(%rip)
 	LONG $0xd7bc0f41               // bsfl         %r15d, %edx
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x01e3850f; WORD $0x0000 // jne          LBB24_84, $483(%rip)
+	LONG $0x01e3850f; WORD $0x0000 // jne          LBB23_84, $483(%rip)
 	WORD $0x014c; BYTE $0xda       // addq         %r11, %rdx
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
 	WORD $0x8949; BYTE $0xd1       // movq         %rdx, %r9
 
-LBB24_46:
+LBB23_46:
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x00dd850f; WORD $0x0000 // jne          LBB24_65, $221(%rip)
+	LONG $0x00dd850f; WORD $0x0000 // jne          LBB23_65, $221(%rip)
 	LONG $0xf0c68348               // addq         $-16, %rsi
 	LONG $0x10c08348               // addq         $16, %rax
 	LONG $0x0ffe8348               // cmpq         $15, %rsi
-	LONG $0xfef8870f; WORD $0xffff // ja           LBB24_30, $-264(%rip)
+	LONG $0xfef8870f; WORD $0xffff // ja           LBB23_30, $-264(%rip)
 	WORD $0x0149; BYTE $0xc6       // addq         %rax, %r14
 
-LBB24_49:
+LBB23_49:
 	WORD $0x8548; BYTE $0xf6                   // testq        %rsi, %rsi
-	LONG $0x00c7840f; WORD $0x0000             // je           LBB24_67, $199(%rip)
+	LONG $0x00c7840f; WORD $0x0000             // je           LBB23_67, $199(%rip)
 	LONG $0x361c8d4d                           // leaq         (%r14,%rsi), %r11
 	WORD $0x894c; BYTE $0xf2                   // movq         %r14, %rdx
 	WORD $0x2948; BYTE $0xfa                   // subq         %rdi, %rdx
 	WORD $0xc031                               // xorl         %eax, %eax
-	LONG $0xdd3d8d4c; WORD $0x0001; BYTE $0x00 // leaq         $477(%rip), %r15  /* LJTI24_0(%rip) */
-	LONG $0x000031e9; BYTE $0x00               // jmp          LBB24_51, $49(%rip)
+	LONG $0xdd3d8d4c; WORD $0x0001; BYTE $0x00 // leaq         $477(%rip), %r15  /* LJTI23_0(%rip) */
+	LONG $0x000031e9; BYTE $0x00               // jmp          LBB23_51, $49(%rip)
 
-LBB24_53:
+LBB23_53:
 	WORD $0xf983; BYTE $0x65       // cmpl         $101, %ecx
-	LONG $0x00a3850f; WORD $0x0000 // jne          LBB24_66, $163(%rip)
+	LONG $0x00a3850f; WORD $0x0000 // jne          LBB23_66, $163(%rip)
 
-LBB24_54:
+LBB23_54:
 	LONG $0xfff88349                                       // cmpq         $-1, %r8
-	LONG $0x0180850f; WORD $0x0000                         // jne          LBB24_59, $384(%rip)
+	LONG $0x0180850f; WORD $0x0000                         // jne          LBB23_59, $384(%rip)
 	LONG $0x02048d4c                                       // leaq         (%rdx,%rax), %r8
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB24_63:
+LBB23_63:
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x3948; BYTE $0xc6       // cmpq         %rax, %rsi
-	LONG $0x012d840f; WORD $0x0000 // je           LBB24_64, $301(%rip)
+	LONG $0x012d840f; WORD $0x0000 // je           LBB23_64, $301(%rip)
 
-LBB24_51:
+LBB23_51:
 	LONG $0x0cbe0f41; BYTE $0x06   // movsbl       (%r14,%rax), %ecx
 	WORD $0x598d; BYTE $0xd0       // leal         $-48(%rcx), %ebx
 	WORD $0xfb83; BYTE $0x0a       // cmpl         $10, %ebx
-	LONG $0xffe2820f; WORD $0xffff // jb           LBB24_63, $-30(%rip)
+	LONG $0xffe2820f; WORD $0xffff // jb           LBB23_63, $-30(%rip)
 	WORD $0x598d; BYTE $0xd5       // leal         $-43(%rcx), %ebx
 	WORD $0xfb83; BYTE $0x1a       // cmpl         $26, %ebx
-	LONG $0xffb2870f; WORD $0xffff // ja           LBB24_53, $-78(%rip)
+	LONG $0xffb2870f; WORD $0xffff // ja           LBB23_53, $-78(%rip)
 	LONG $0x9f0c6349               // movslq       (%r15,%rbx,4), %rcx
 	WORD $0x014c; BYTE $0xf9       // addq         %r15, %rcx
 	JMP  CX
 
-LBB24_61:
+LBB23_61:
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x0132850f; WORD $0x0000 // jne          LBB24_59, $306(%rip)
+	LONG $0x0132850f; WORD $0x0000 // jne          LBB23_59, $306(%rip)
 	LONG $0x020c8d4c               // leaq         (%rdx,%rax), %r9
-	LONG $0xffffbae9; BYTE $0xff   // jmp          LBB24_63, $-70(%rip)
+	LONG $0xffffbae9; BYTE $0xff   // jmp          LBB23_63, $-70(%rip)
 
-LBB24_57:
+LBB23_57:
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x011f850f; WORD $0x0000 // jne          LBB24_59, $287(%rip)
+	LONG $0x011f850f; WORD $0x0000 // jne          LBB23_59, $287(%rip)
 	LONG $0x02148d4c               // leaq         (%rdx,%rax), %r10
-	LONG $0xffffa7e9; BYTE $0xff   // jmp          LBB24_63, $-89(%rip)
+	LONG $0xffffa7e9; BYTE $0xff   // jmp          LBB23_63, $-89(%rip)
 
-LBB24_1:
+LBB23_1:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0x000120e9; BYTE $0x00               // jmp          LBB24_81, $288(%rip)
+	LONG $0x000120e9; BYTE $0x00               // jmp          LBB23_81, $288(%rip)
 
-LBB24_83:
+LBB23_83:
 	WORD $0x0149; BYTE $0xc6                   // addq         %rax, %r14
 	WORD $0x0149; BYTE $0xfe                   // addq         %rdi, %r14
 	WORD $0xf8c5; BYTE $0x77                   // vzeroupper
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xd2                   // testq        %r10, %r10
-	LONG $0x001d850f; WORD $0x0000             // jne          LBB24_68, $29(%rip)
-	LONG $0x000102e9; BYTE $0x00               // jmp          LBB24_81, $258(%rip)
+	LONG $0x001d850f; WORD $0x0000             // jne          LBB23_68, $29(%rip)
+	LONG $0x000102e9; BYTE $0x00               // jmp          LBB23_81, $258(%rip)
 
-LBB24_65:
+LBB23_65:
 	WORD $0xc989             // movl         %ecx, %ecx
 	WORD $0x0149; BYTE $0xce // addq         %rcx, %r14
 
-LBB24_66:
+LBB23_66:
 	WORD $0x0149; BYTE $0xc6 // addq         %rax, %r14
 
-LBB24_67:
+LBB23_67:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xd2                   // testq        %r10, %r10
-	LONG $0x00ea840f; WORD $0x0000             // je           LBB24_81, $234(%rip)
+	LONG $0x00ea840f; WORD $0x0000             // je           LBB23_81, $234(%rip)
 
-LBB24_68:
+LBB23_68:
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x00e1840f; WORD $0x0000 // je           LBB24_81, $225(%rip)
+	LONG $0x00e1840f; WORD $0x0000 // je           LBB23_81, $225(%rip)
 	WORD $0x854d; BYTE $0xc0       // testq        %r8, %r8
-	LONG $0x00d8840f; WORD $0x0000 // je           LBB24_81, $216(%rip)
+	LONG $0x00d8840f; WORD $0x0000 // je           LBB23_81, $216(%rip)
 	WORD $0x2949; BYTE $0xfe       // subq         %rdi, %r14
 	LONG $0xff468d49               // leaq         $-1(%r14), %rax
 	WORD $0x3949; BYTE $0xc2       // cmpq         %rax, %r10
-	LONG $0x0033840f; WORD $0x0000 // je           LBB24_73, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000 // je           LBB23_73, $51(%rip)
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x002a840f; WORD $0x0000 // je           LBB24_73, $42(%rip)
+	LONG $0x002a840f; WORD $0x0000 // je           LBB23_73, $42(%rip)
 	WORD $0x3949; BYTE $0xc0       // cmpq         %rax, %r8
-	LONG $0x0021840f; WORD $0x0000 // je           LBB24_73, $33(%rip)
+	LONG $0x0021840f; WORD $0x0000 // je           LBB23_73, $33(%rip)
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x00238e0f; WORD $0x0000 // jle          LBB24_77, $35(%rip)
+	LONG $0x00238e0f; WORD $0x0000 // jle          LBB23_77, $35(%rip)
 	LONG $0xff418d49               // leaq         $-1(%r9), %rax
 	WORD $0x3949; BYTE $0xc0       // cmpq         %rax, %r8
-	LONG $0x0016840f; WORD $0x0000 // je           LBB24_77, $22(%rip)
+	LONG $0x0016840f; WORD $0x0000 // je           LBB23_77, $22(%rip)
 	WORD $0xf749; BYTE $0xd1       // notq         %r9
 	WORD $0x894c; BYTE $0xc8       // movq         %r9, %rax
-	LONG $0x000095e9; BYTE $0x00   // jmp          LBB24_81, $149(%rip)
+	LONG $0x000095e9; BYTE $0x00   // jmp          LBB23_81, $149(%rip)
 
-LBB24_73:
+LBB23_73:
 	WORD $0xf749; BYTE $0xde     // negq         %r14
 	WORD $0x894c; BYTE $0xf0     // movq         %r14, %rax
-	LONG $0x00008ae9; BYTE $0x00 // jmp          LBB24_81, $138(%rip)
+	LONG $0x00008ae9; BYTE $0x00 // jmp          LBB23_81, $138(%rip)
 
-LBB24_77:
+LBB23_77:
 	WORD $0x894c; BYTE $0xd0       // movq         %r10, %rax
 	WORD $0x094c; BYTE $0xc0       // orq          %r8, %rax
 	WORD $0x990f; BYTE $0xc0       // setns        %al
-	LONG $0x0014880f; WORD $0x0000 // js           LBB24_80, $20(%rip)
+	LONG $0x0014880f; WORD $0x0000 // js           LBB23_80, $20(%rip)
 	WORD $0x394d; BYTE $0xc2       // cmpq         %r8, %r10
-	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB24_80, $11(%rip)
+	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB23_80, $11(%rip)
 	WORD $0xf749; BYTE $0xd2       // notq         %r10
 	WORD $0x894c; BYTE $0xd0       // movq         %r10, %rax
-	LONG $0x000067e9; BYTE $0x00   // jmp          LBB24_81, $103(%rip)
+	LONG $0x000067e9; BYTE $0x00   // jmp          LBB23_81, $103(%rip)
 
-LBB24_80:
+LBB23_80:
 	LONG $0xff488d49             // leaq         $-1(%r8), %rcx
 	WORD $0x3949; BYTE $0xca     // cmpq         %rcx, %r10
 	WORD $0xf749; BYTE $0xd0     // notq         %r8
@@ -7932,47 +7692,47 @@ LBB24_80:
 	WORD $0xc084                 // testb        %al, %al
 	LONG $0xc6440f4d             // cmoveq       %r14, %r8
 	WORD $0x894c; BYTE $0xc0     // movq         %r8, %rax
-	LONG $0x00004be9; BYTE $0x00 // jmp          LBB24_81, $75(%rip)
+	LONG $0x00004be9; BYTE $0x00 // jmp          LBB23_81, $75(%rip)
 
-LBB24_64:
+LBB23_64:
 	WORD $0x894d; BYTE $0xde                   // movq         %r11, %r14
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xd2                   // testq        %r10, %r10
-	LONG $0xff4e850f; WORD $0xffff             // jne          LBB24_68, $-178(%rip)
-	LONG $0x000033e9; BYTE $0x00               // jmp          LBB24_81, $51(%rip)
+	LONG $0xff4e850f; WORD $0xffff             // jne          LBB23_68, $-178(%rip)
+	LONG $0x000033e9; BYTE $0x00               // jmp          LBB23_81, $51(%rip)
 
-LBB24_12:
+LBB23_12:
 	WORD $0xbc0f; BYTE $0xc9     // bsfl         %ecx, %ecx
-	LONG $0x000002e9; BYTE $0x00 // jmp          LBB24_13, $2(%rip)
+	LONG $0x000002e9; BYTE $0x00 // jmp          LBB23_13, $2(%rip)
 
-LBB24_82:
+LBB23_82:
 	WORD $0xc989 // movl         %ecx, %ecx
 
-LBB24_13:
+LBB23_13:
 	WORD $0xf748; BYTE $0xd0     // notq         %rax
 	WORD $0x2948; BYTE $0xc8     // subq         %rcx, %rax
-	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB24_81, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB23_81, $30(%rip)
 
-LBB24_33:
+LBB23_33:
 	WORD $0xbc0f; BYTE $0xcb     // bsfl         %ebx, %ecx
-	LONG $0x00000ae9; BYTE $0x00 // jmp          LBB24_34, $10(%rip)
+	LONG $0x00000ae9; BYTE $0x00 // jmp          LBB23_34, $10(%rip)
 
-LBB24_59:
+LBB23_59:
 	WORD $0x294c; BYTE $0xf7     // subq         %r14, %rdi
-	LONG $0x000008e9; BYTE $0x00 // jmp          LBB24_60, $8(%rip)
+	LONG $0x000008e9; BYTE $0x00 // jmp          LBB23_60, $8(%rip)
 
-LBB24_84:
+LBB23_84:
 	WORD $0xd189 // movl         %edx, %ecx
 
-LBB24_34:
+LBB23_34:
 	WORD $0x294c; BYTE $0xf7 // subq         %r14, %rdi
 	WORD $0x2948; BYTE $0xcf // subq         %rcx, %rdi
 
-LBB24_60:
+LBB23_60:
 	WORD $0xf748; BYTE $0xd0 // notq         %rax
 	WORD $0x0148; BYTE $0xf8 // addq         %rdi, %rax
 
-LBB24_81:
+LBB23_81:
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
 	WORD $0x5e41             // popq         %r14
@@ -7981,47 +7741,47 @@ LBB24_81:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	BYTE $0xc3               // retq
 
-LBB24_7:
+LBB23_7:
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
 	WORD $0x8949; BYTE $0xfe                   // movq         %rdi, %r14
 	LONG $0x10fe8348                           // cmpq         $16, %rsi
-	LONG $0xfcbf830f; WORD $0xffff             // jae          LBB24_29, $-833(%rip)
-	LONG $0xfffe0ae9; BYTE $0xff               // jmp          LBB24_49, $-502(%rip)
+	LONG $0xfcbf830f; WORD $0xffff             // jae          LBB23_29, $-833(%rip)
+	LONG $0xfffe0ae9; BYTE $0xff               // jmp          LBB23_49, $-502(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 2, 0x90
 
-	// .set L24_0_set_61, LBB24_61-LJTI24_0
-	// .set L24_0_set_66, LBB24_66-LJTI24_0
-	// .set L24_0_set_57, LBB24_57-LJTI24_0
-	// .set L24_0_set_54, LBB24_54-LJTI24_0
-LJTI24_0:
-	LONG $0xfffffe7f // .long L24_0_set_61
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffe7f // .long L24_0_set_61
-	LONG $0xfffffe92 // .long L24_0_set_57
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffed4 // .long L24_0_set_66
-	LONG $0xfffffe31 // .long L24_0_set_54
+	// .set L23_0_set_61, LBB23_61-LJTI23_0
+	// .set L23_0_set_66, LBB23_66-LJTI23_0
+	// .set L23_0_set_57, LBB23_57-LJTI23_0
+	// .set L23_0_set_54, LBB23_54-LJTI23_0
+LJTI23_0:
+	LONG $0xfffffe7f // .long L23_0_set_61
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffe7f // .long L23_0_set_61
+	LONG $0xfffffe92 // .long L23_0_set_57
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffed4 // .long L23_0_set_66
+	LONG $0xfffffe31 // .long L23_0_set_54
 
 	// .p2align 4, 0x90
 _skip_positive:
@@ -8039,19 +7799,19 @@ _skip_positive:
 	WORD $0x8948; BYTE $0xc7       // movq         %rax, %rdi
 	LONG $0xfffa5ae8; BYTE $0xff   // callq        _do_skip_number, $-1446(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x000f880f; WORD $0x0000 // js           LBB25_1, $15(%rip)
+	LONG $0x000f880f; WORD $0x0000 // js           LBB24_1, $15(%rip)
 	WORD $0x8b49; BYTE $0x0e       // movq         (%r14), %rcx
 	WORD $0x0148; BYTE $0xc1       // addq         %rax, %rcx
 	LONG $0xffc18348               // addq         $-1, %rcx
-	LONG $0x000011e9; BYTE $0x00   // jmp          LBB25_3, $17(%rip)
+	LONG $0x000011e9; BYTE $0x00   // jmp          LBB24_3, $17(%rip)
 
-LBB25_1:
+LBB24_1:
 	WORD $0x8b49; BYTE $0x0e                   // movq         (%r14), %rcx
 	WORD $0x2948; BYTE $0xc1                   // subq         %rax, %rcx
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0xfec3c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rbx
 
-LBB25_3:
+LBB24_3:
 	WORD $0x8949; BYTE $0x0e       // movq         %rcx, (%r14)
 	WORD $0x8948; BYTE $0xd8       // movq         %rbx, %rax
 	BYTE $0x5b                     // popq         %rbx
@@ -8077,22 +7837,22 @@ _skip_number:
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x2948; BYTE $0xc6       // subq         %rax, %rsi
-	LONG $0x003b840f; WORD $0x0000 // je           LBB26_6, $59(%rip)
+	LONG $0x003b840f; WORD $0x0000 // je           LBB25_6, $59(%rip)
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0x000c830f; WORD $0x0000 // jae          LBB26_3, $12(%rip)
+	LONG $0x000c830f; WORD $0x0000 // jae          LBB25_3, $12(%rip)
 	WORD $0x038a                   // movb         (%rbx), %al
 	WORD $0xd004                   // addb         $-48, %al
 	WORD $0x093c                   // cmpb         $9, %al
-	LONG $0x0038870f; WORD $0x0000 // ja           LBB26_8, $56(%rip)
+	LONG $0x0038870f; WORD $0x0000 // ja           LBB25_8, $56(%rip)
 
-LBB26_3:
+LBB25_3:
 	WORD $0x8948; BYTE $0xdf       // movq         %rbx, %rdi
 	LONG $0xfff9d1e8; BYTE $0xff   // callq        _do_skip_number, $-1583(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0021880f; WORD $0x0000 // js           LBB26_7, $33(%rip)
+	LONG $0x0021880f; WORD $0x0000 // js           LBB25_7, $33(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 
-LBB26_5:
+LBB25_5:
 	WORD $0x294c; BYTE $0xe3 // subq         %r12, %rbx
 	WORD $0x8949; BYTE $0x1e // movq         %rbx, (%r14)
 	WORD $0x894c; BYTE $0xf8 // movq         %r15, %rax
@@ -8103,18 +7863,30 @@ LBB26_5:
 	BYTE $0x5d               // popq         %rbp
 	BYTE $0xc3               // retq
 
-LBB26_6:
+LBB25_6:
 	LONG $0xffc7c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r15
-	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB26_5, $-30(%rip)
+	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB25_5, $-30(%rip)
 
-LBB26_7:
+LBB25_7:
 	WORD $0xf748; BYTE $0xd0 // notq         %rax
 	WORD $0x0148; BYTE $0xc3 // addq         %rax, %rbx
 
-LBB26_8:
+LBB25_8:
 	LONG $0xfec7c749; WORD $0xffff; BYTE $0xff // movq         $-2, %r15
-	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB26_5, $-48(%rip)
+	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB25_5, $-48(%rip)
 	LONG $0x90909090; BYTE $0x90               // .p2align 4, 0x90
+
+_skip_one:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
+	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
+	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
+	BYTE $0x5d                                 // popq         %rbp
+	LONG $0xfff003e9; BYTE $0xff               // jmp          _fsm_exec, $-4093(%rip)
+	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
 _validate_one:
 	BYTE $0x55                                                                                                   // pushq        %rbp
@@ -8126,15 +7898,1453 @@ _validate_one:
 	LONG $0x000020b9; BYTE $0x00                                                                                 // movl         $32, %ecx
 	WORD $0x8948; BYTE $0xc7                                                                                     // movq         %rax, %rdi
 	BYTE $0x5d                                                                                                   // popq         %rbp
-	LONG $0xffefcee9; BYTE $0xff                                                                                 // jmp          _fsm_exec, $-4146(%rip)
+	LONG $0xffefdee9; BYTE $0xff                                                                                 // jmp          _fsm_exec, $-4130(%rip)
 	QUAD $0x0000000000000000; QUAD $0x0000000000000000; QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 5, 0x00
 
 LCPI28_0:
+	QUAD $0x2c2c2c2c2c2c2c2c; QUAD $0x2c2c2c2c2c2c2c2c // .space 16, ',,,,,,,,,,,,,,,,'
+	QUAD $0x2c2c2c2c2c2c2c2c; QUAD $0x2c2c2c2c2c2c2c2c // .space 16, ',,,,,,,,,,,,,,,,'
+
+LCPI28_1:
+	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
+	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
+
+LCPI28_2:
+	QUAD $0x5d5d5d5d5d5d5d5d; QUAD $0x5d5d5d5d5d5d5d5d // .space 16, ']]]]]]]]]]]]]]]]'
+	QUAD $0x5d5d5d5d5d5d5d5d; QUAD $0x5d5d5d5d5d5d5d5d // .space 16, ']]]]]]]]]]]]]]]]'
+
+LCPI28_6:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI28_7:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+LCPI28_8:
+	QUAD $0x7b7b7b7b7b7b7b7b; QUAD $0x7b7b7b7b7b7b7b7b // .space 16, '{{{{{{{{{{{{{{{{'
+	QUAD $0x7b7b7b7b7b7b7b7b; QUAD $0x7b7b7b7b7b7b7b7b // .space 16, '{{{{{{{{{{{{{{{{'
+
+LCPI28_9:
+	QUAD $0x7d7d7d7d7d7d7d7d; QUAD $0x7d7d7d7d7d7d7d7d // .space 16, '}}}}}}}}}}}}}}}}'
+	QUAD $0x7d7d7d7d7d7d7d7d; QUAD $0x7d7d7d7d7d7d7d7d // .space 16, '}}}}}}}}}}}}}}}}'
+
+LCPI28_10:
+	QUAD $0x5b5b5b5b5b5b5b5b; QUAD $0x5b5b5b5b5b5b5b5b // .space 16, '[[[[[[[[[[[[[[[['
+	QUAD $0x5b5b5b5b5b5b5b5b; QUAD $0x5b5b5b5b5b5b5b5b // .space 16, '[[[[[[[[[[[[[[[['
+
+	// .p2align 4, 0x00
+LCPI28_3:
+	QUAD $0x2c2c2c2c2c2c2c2c; QUAD $0x2c2c2c2c2c2c2c2c // .space 16, ',,,,,,,,,,,,,,,,'
+
+LCPI28_4:
+	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
+
+LCPI28_5:
+	QUAD $0x5d5d5d5d5d5d5d5d; QUAD $0x5d5d5d5d5d5d5d5d // .space 16, ']]]]]]]]]]]]]]]]'
+
+	// .p2align 4, 0x90
+_skip_one_fast:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x5741                               // pushq        %r15
+	WORD $0x5641                               // pushq        %r14
+	WORD $0x5541                               // pushq        %r13
+	WORD $0x5441                               // pushq        %r12
+	BYTE $0x53                                 // pushq        %rbx
+	LONG $0xe0e48348                           // andq         $-32, %rsp
+	LONG $0x80ec8148; WORD $0x0000; BYTE $0x00 // subq         $128, %rsp
+	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xff                   // movq         %rdi, %r15
+	LONG $0xffdacde8; BYTE $0xff               // callq        _advance_ns, $-9523(%rip)
+	WORD $0x8b49; BYTE $0x16                   // movq         (%r14), %rdx
+	LONG $0xff628d4c                           // leaq         $-1(%rdx), %r12
+	WORD $0xbe0f; BYTE $0xc8                   // movsbl       %al, %ecx
+	WORD $0xf983; BYTE $0x7b                   // cmpl         $123, %ecx
+	LONG $0x0177870f; WORD $0x0000             // ja           LBB28_23, $375(%rip)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0x20358d48; WORD $0x0009; BYTE $0x00 // leaq         $2336(%rip), %rsi  /* LJTI28_0(%rip) */
+	LONG $0x8e0c6348                           // movslq       (%rsi,%rcx,4), %rcx
+	WORD $0x0148; BYTE $0xf1                   // addq         %rsi, %rcx
+	JMP  CX
+
+LBB28_2:
+	WORD $0x8b49; BYTE $0x07                                 // movq         (%r15), %rax
+	LONG $0x08778b49                                         // movq         $8(%r15), %rsi
+	WORD $0x8948; BYTE $0xf1                                 // movq         %rsi, %rcx
+	WORD $0x2948; BYTE $0xd1                                 // subq         %rdx, %rcx
+	LONG $0x20f98348                                         // cmpq         $32, %rcx
+	LONG $0x0848820f; WORD $0x0000                           // jb           LBB28_89, $2120(%rip)
+	WORD $0x8948; BYTE $0xd1                                 // movq         %rdx, %rcx
+	WORD $0xf748; BYTE $0xd9                                 // negq         %rcx
+	QUAD $0xfffffe5e056ffdc5                                 // vmovdqa      $-418(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffffe760d6ffdc5                                 // vmovdqa      $-394(%rip), %ymm1  /* LCPI28_1(%rip) */
+	QUAD $0xfffffe8e156ffdc5                                 // vmovdqa      $-370(%rip), %ymm2  /* LCPI28_2(%rip) */
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB28_4:
+	LONG $0x1c6ffec5; BYTE $0x10   // vmovdqu      (%rax,%rdx), %ymm3
+	LONG $0xe074e5c5               // vpcmpeqb     %ymm0, %ymm3, %ymm4
+	LONG $0xd9dbe5c5               // vpand        %ymm1, %ymm3, %ymm3
+	LONG $0xda74e5c5               // vpcmpeqb     %ymm2, %ymm3, %ymm3
+	LONG $0xdcebe5c5               // vpor         %ymm4, %ymm3, %ymm3
+	LONG $0xfbd7fdc5               // vpmovmskb    %ymm3, %edi
+	WORD $0xff85                   // testl        %edi, %edi
+	LONG $0x00cb850f; WORD $0x0000 // jne          LBB28_18, $203(%rip)
+	LONG $0x20c28348               // addq         $32, %rdx
+	LONG $0x0e3c8d48               // leaq         (%rsi,%rcx), %rdi
+	LONG $0xe0c78348               // addq         $-32, %rdi
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0x1fff8348               // cmpq         $31, %rdi
+	LONG $0xffc5870f; WORD $0xffff // ja           LBB28_4, $-59(%rip)
+	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
+	WORD $0x2948; BYTE $0xca       // subq         %rcx, %rdx
+	WORD $0x0148; BYTE $0xce       // addq         %rcx, %rsi
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	LONG $0x10f98348               // cmpq         $16, %rcx
+	LONG $0x0055820f; WORD $0x0000 // jb           LBB28_10, $85(%rip)
+
+LBB28_7:
+	WORD $0x8948; BYTE $0xc6 // movq         %rax, %rsi
+	WORD $0x2948; BYTE $0xd6 // subq         %rdx, %rsi
+	QUAD $0xfffffee1056ff9c5 // vmovdqa      $-287(%rip), %xmm0  /* LCPI28_3(%rip) */
+	QUAD $0xfffffee90d6ff9c5 // vmovdqa      $-279(%rip), %xmm1  /* LCPI28_4(%rip) */
+	QUAD $0xfffffef1156ff9c5 // vmovdqa      $-271(%rip), %xmm2  /* LCPI28_5(%rip) */
+	BYTE $0x90               // .p2align 4, 0x90
+
+LBB28_8:
+	LONG $0x1a6ffac5               // vmovdqu      (%rdx), %xmm3
+	LONG $0xe074e1c5               // vpcmpeqb     %xmm0, %xmm3, %xmm4
+	LONG $0xd9dbe1c5               // vpand        %xmm1, %xmm3, %xmm3
+	LONG $0xda74e1c5               // vpcmpeqb     %xmm2, %xmm3, %xmm3
+	LONG $0xdcebe1c5               // vpor         %xmm4, %xmm3, %xmm3
+	LONG $0xfbd7f9c5               // vpmovmskb    %xmm3, %edi
+	WORD $0xff85                   // testl        %edi, %edi
+	LONG $0x0760850f; WORD $0x0000 // jne          LBB28_88, $1888(%rip)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0xf0c18348               // addq         $-16, %rcx
+	LONG $0xf0c68348               // addq         $-16, %rsi
+	LONG $0x0ff98348               // cmpq         $15, %rcx
+	LONG $0xffca870f; WORD $0xffff // ja           LBB28_8, $-54(%rip)
+
+LBB28_10:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x0035840f; WORD $0x0000 // je           LBB28_17, $53(%rip)
+	LONG $0x0a3c8d48               // leaq         (%rdx,%rcx), %rdi
+	WORD $0xf631                   // xorl         %esi, %esi
+
+LBB28_12:
+	LONG $0x321cb60f               // movzbl       (%rdx,%rsi), %ebx
+	WORD $0xfb80; BYTE $0x2c       // cmpb         $44, %bl
+	LONG $0x076c840f; WORD $0x0000 // je           LBB28_90, $1900(%rip)
+	WORD $0xfb80; BYTE $0x7d       // cmpb         $125, %bl
+	LONG $0x0763840f; WORD $0x0000 // je           LBB28_90, $1891(%rip)
+	WORD $0xfb80; BYTE $0x5d       // cmpb         $93, %bl
+	LONG $0x075a840f; WORD $0x0000 // je           LBB28_90, $1882(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x3948; BYTE $0xf1       // cmpq         %rsi, %rcx
+	LONG $0xffd4850f; WORD $0xffff // jne          LBB28_12, $-44(%rip)
+	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
+
+LBB28_17:
+	WORD $0x2948; BYTE $0xc2     // subq         %rax, %rdx
+	LONG $0x0003fde9; BYTE $0x00 // jmp          LBB28_60, $1021(%rip)
+
+LBB28_18:
+	WORD $0xbc0f; BYTE $0xc7 // bsfl         %edi, %eax
+	WORD $0x2948; BYTE $0xc8 // subq         %rcx, %rax
+
+LBB28_19:
+	WORD $0x8949; BYTE $0x06 // movq         %rax, (%r14)
+
+LBB28_20:
+	WORD $0x894c; BYTE $0xe0 // movq         %r12, %rax
+
+LBB28_21:
+	LONG $0xd8658d48         // leaq         $-40(%rbp), %rsp
+	BYTE $0x5b               // popq         %rbx
+	WORD $0x5c41             // popq         %r12
+	WORD $0x5d41             // popq         %r13
+	WORD $0x5e41             // popq         %r14
+	WORD $0x5f41             // popq         %r15
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	BYTE $0xc3               // retq
+
+LBB28_22:
+	LONG $0x03c28348               // addq         $3, %rdx
+	LONG $0x08573b49               // cmpq         $8(%r15), %rdx
+	LONG $0xffe0830f; WORD $0xffff // jae          LBB28_21, $-32(%rip)
+	LONG $0x0003cce9; BYTE $0x00   // jmp          LBB28_60, $972(%rip)
+
+LBB28_23:
+	WORD $0x894d; BYTE $0x26                   // movq         %r12, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xffffcce9; BYTE $0xff               // jmp          LBB28_21, $-52(%rip)
+
+LBB28_24:
+	WORD $0x8b49; BYTE $0x0f                           // movq         (%r15), %rcx
+	LONG $0x08578b4d                                   // movq         $8(%r15), %r10
+	LONG $0x244c8948; BYTE $0x18                       // movq         %rcx, $24(%rsp)
+	LONG $0x110c8d4c                                   // leaq         (%rcx,%rdx), %r9
+	WORD $0x2949; BYTE $0xd2                           // subq         %rdx, %r10
+	LONG $0x20fa8349                                   // cmpq         $32, %r10
+	LONG $0x06c5820f; WORD $0x0000                     // jb           LBB28_33, $1733(%rip)
+	WORD $0xf631                                       // xorl         %esi, %esi
+	QUAD $0xfffffd4d056ffdc5                           // vmovdqa      $-691(%rip), %ymm0  /* LCPI28_6(%rip) */
+	QUAD $0xfffffd650d6ffdc5                           // vmovdqa      $-667(%rip), %ymm1  /* LCPI28_7(%rip) */
+	WORD $0xdb31                                       // xorl         %ebx, %ebx
+	WORD $0x3145; BYTE $0xff                           // xorl         %r15d, %r15d
+	LONG $0x000069e9; BYTE $0x00                       // jmp          LBB28_26, $105(%rip)
+	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB28_29:
+	WORD $0x8944; BYTE $0xf9                   // movl         %r15d, %ecx
+	WORD $0xd1f7                               // notl         %ecx
+	WORD $0xf921                               // andl         %edi, %ecx
+	LONG $0x09048d44                           // leal         (%rcx,%rcx), %r8d
+	WORD $0x0945; BYTE $0xf8                   // orl          %r15d, %r8d
+	WORD $0x8945; BYTE $0xc5                   // movl         %r8d, %r13d
+	WORD $0xf741; BYTE $0xd5                   // notl         %r13d
+	WORD $0x2141; BYTE $0xfd                   // andl         %edi, %r13d
+	LONG $0xaae58141; WORD $0xaaaa; BYTE $0xaa // andl         $-1431655766, %r13d
+	WORD $0x3145; BYTE $0xff                   // xorl         %r15d, %r15d
+	WORD $0x0141; BYTE $0xcd                   // addl         %ecx, %r13d
+	LONG $0xc7920f41                           // setb         %r15b
+	WORD $0x0145; BYTE $0xed                   // addl         %r13d, %r13d
+	LONG $0x55f58141; WORD $0x5555; BYTE $0x55 // xorl         $1431655765, %r13d
+	WORD $0x2145; BYTE $0xc5                   // andl         %r8d, %r13d
+	WORD $0xf741; BYTE $0xd5                   // notl         %r13d
+	WORD $0x2145; BYTE $0xeb                   // andl         %r13d, %r11d
+	WORD $0x854d; BYTE $0xdb                   // testq        %r11, %r11
+	LONG $0x004d850f; WORD $0x0000             // jne          LBB28_87, $77(%rip)
+
+LBB28_30:
+	LONG $0x20c38348               // addq         $32, %rbx
+	LONG $0x320c8d49               // leaq         (%r10,%rsi), %rcx
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0xe0c68348               // addq         $-32, %rsi
+	LONG $0x1ff98348               // cmpq         $31, %rcx
+	LONG $0x0631860f; WORD $0x0000 // jbe          LBB28_31, $1585(%rip)
+
+LBB28_26:
+	LONG $0x6f7ec1c4; WORD $0x1914 // vmovdqu      (%r9,%rbx), %ymm2
+	LONG $0xd874edc5               // vpcmpeqb     %ymm0, %ymm2, %ymm3
+	LONG $0xdbd77dc5               // vpmovmskb    %ymm3, %r11d
+	LONG $0xd174edc5               // vpcmpeqb     %ymm1, %ymm2, %ymm2
+	LONG $0xfad7fdc5               // vpmovmskb    %ymm2, %edi
+	WORD $0xff85                   // testl        %edi, %edi
+	LONG $0xff84850f; WORD $0xffff // jne          LBB28_29, $-124(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0xff7b850f; WORD $0xffff // jne          LBB28_29, $-133(%rip)
+	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
+	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
+	LONG $0xffb3840f; WORD $0xffff // je           LBB28_30, $-77(%rip)
+
+LBB28_87:
+	LONG $0xc3bc0f41             // bsfl         %r11d, %eax
+	WORD $0x0148; BYTE $0xd0     // addq         %rdx, %rax
+	WORD $0x0148; BYTE $0xd8     // addq         %rbx, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xfffedee9; BYTE $0xff // jmp          LBB28_19, $-290(%rip)
+
+LBB28_34:
+	LONG $0x084f8b49             // movq         $8(%r15), %rcx
+	WORD $0x2948; BYTE $0xd1     // subq         %rdx, %rcx
+	WORD $0x0349; BYTE $0x17     // addq         (%r15), %rdx
+	WORD $0x3145; BYTE $0xc9     // xorl         %r9d, %r9d
+	QUAD $0xfffffc97056ffdc5     // vmovdqa      $-873(%rip), %ymm0  /* LCPI28_7(%rip) */
+	QUAD $0xfffffc6f0d6ffdc5     // vmovdqa      $-913(%rip), %ymm1  /* LCPI28_6(%rip) */
+	LONG $0xd276e9c5             // vpcmpeqd     %xmm2, %xmm2, %xmm2
+	QUAD $0xfffffce31d6ffdc5     // vmovdqa      $-797(%rip), %ymm3  /* LCPI28_10(%rip) */
+	QUAD $0xfffffc3b256ffdc5     // vmovdqa      $-965(%rip), %ymm4  /* LCPI28_2(%rip) */
+	LONG $0x573041c4; BYTE $0xc9 // vxorps       %xmm9, %xmm9, %xmm9
+	WORD $0x3145; BYTE $0xd2     // xorl         %r10d, %r10d
+	WORD $0x3145; BYTE $0xdb     // xorl         %r11d, %r11d
+	WORD $0xf631                 // xorl         %esi, %esi
+	LONG $0x00001ce9; BYTE $0x00 // jmp          LBB28_36, $28(%rip)
+
+LBB28_35:
+	LONG $0x3ffdc149             // sarq         $63, %r13
+	LONG $0xb80f49f3; BYTE $0xc8 // popcntq      %r8, %rcx
+	WORD $0x0149; BYTE $0xcb     // addq         %rcx, %r11
+	LONG $0x40c28348             // addq         $64, %rdx
+	LONG $0x244c8b48; BYTE $0x18 // movq         $24(%rsp), %rcx
+	LONG $0xc0c18348             // addq         $-64, %rcx
+	WORD $0x894d; BYTE $0xe9     // movq         %r13, %r9
+
+LBB28_36:
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x18   // movq         %rcx, $24(%rsp)
+	LONG $0x012b8c0f; WORD $0x0000 // jl           LBB28_43, $299(%rip)
+
+LBB28_37:
+	LONG $0x3a6ffec5                           // vmovdqu      (%rdx), %ymm7
+	LONG $0x726ffec5; BYTE $0x20               // vmovdqu      $32(%rdx), %ymm6
+	LONG $0xc07445c5                           // vpcmpeqb     %ymm0, %ymm7, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xc8               // vpmovmskb    %ymm8, %ecx
+	LONG $0xc0744dc5                           // vpcmpeqb     %ymm0, %ymm6, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xf8               // vpmovmskb    %ymm8, %edi
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xf9                   // orq          %rdi, %rcx
+	WORD $0x8948; BYTE $0xcf                   // movq         %rcx, %rdi
+	WORD $0x094c; BYTE $0xd7                   // orq          %r10, %rdi
+	LONG $0x000f850f; WORD $0x0000             // jne          LBB28_39, $15(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	WORD $0x3145; BYTE $0xd2                   // xorl         %r10d, %r10d
+	LONG $0x000046e9; BYTE $0x00               // jmp          LBB28_40, $70(%rip)
+
+LBB28_39:
+	WORD $0x894c; BYTE $0xd7               // movq         %r10, %rdi
+	WORD $0xf748; BYTE $0xd7               // notq         %rdi
+	WORD $0x2148; BYTE $0xcf               // andq         %rcx, %rdi
+	LONG $0x3f2c8d4c                       // leaq         (%rdi,%rdi), %r13
+	WORD $0x094d; BYTE $0xd5               // orq          %r10, %r13
+	WORD $0x894d; BYTE $0xe8               // movq         %r13, %r8
+	WORD $0xf749; BYTE $0xd0               // notq         %r8
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2148; BYTE $0xd9               // andq         %rbx, %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	WORD $0x3145; BYTE $0xd2               // xorl         %r10d, %r10d
+	WORD $0x0148; BYTE $0xf9               // addq         %rdi, %rcx
+	LONG $0xc2920f41                       // setb         %r10b
+	WORD $0x0148; BYTE $0xc9               // addq         %rcx, %rcx
+	QUAD $0x555555555555bf48; WORD $0x5555 // movabsq      $6148914691236517205, %rdi
+	WORD $0x3148; BYTE $0xf9               // xorq         %rdi, %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+
+LBB28_40:
+	LONG $0xc1744dc5                           // vpcmpeqb     %ymm1, %ymm6, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xf8               // vpmovmskb    %ymm8, %edi
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	LONG $0xc17445c5                           // vpcmpeqb     %ymm1, %ymm7, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xd8               // vpmovmskb    %ymm8, %ebx
+	WORD $0x0948; BYTE $0xfb                   // orq          %rdi, %rbx
+	WORD $0x2148; BYTE $0xcb                   // andq         %rcx, %rbx
+	LONG $0x6ef9e1c4; BYTE $0xeb               // vmovq        %rbx, %xmm5
+	LONG $0x4451e3c4; WORD $0x00ea             // vpclmulqdq   $0, %xmm2, %xmm5, %xmm5
+	LONG $0x7ef9c1c4; BYTE $0xed               // vmovq        %xmm5, %r13
+	WORD $0x314d; BYTE $0xcd                   // xorq         %r9, %r13
+	LONG $0xeb74c5c5                           // vpcmpeqb     %ymm3, %ymm7, %ymm5
+	LONG $0xc5d77dc5                           // vpmovmskb    %ymm5, %r8d
+	LONG $0xeb74cdc5                           // vpcmpeqb     %ymm3, %ymm6, %ymm5
+	LONG $0xfdd7fdc5                           // vpmovmskb    %ymm5, %edi
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x0949; BYTE $0xf8                   // orq          %rdi, %r8
+	WORD $0x894d; BYTE $0xe9                   // movq         %r13, %r9
+	WORD $0xf749; BYTE $0xd1                   // notq         %r9
+	WORD $0x214d; BYTE $0xc8                   // andq         %r9, %r8
+	LONG $0xec74c5c5                           // vpcmpeqb     %ymm4, %ymm7, %ymm5
+	LONG $0xddd7fdc5                           // vpmovmskb    %ymm5, %ebx
+	LONG $0xec74cdc5                           // vpcmpeqb     %ymm4, %ymm6, %ymm5
+	LONG $0xfdd7fdc5                           // vpmovmskb    %ymm5, %edi
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xfb                   // orq          %rdi, %rbx
+	WORD $0x214c; BYTE $0xcb                   // andq         %r9, %rbx
+	LONG $0xfee3840f; WORD $0xffff             // je           LBB28_35, $-285(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
+
+LBB28_41:
+	LONG $0xff4b8d48               // leaq         $-1(%rbx), %rcx
+	WORD $0x8948; BYTE $0xcf       // movq         %rcx, %rdi
+	WORD $0x214c; BYTE $0xc7       // andq         %r8, %rdi
+	LONG $0xb80f48f3; BYTE $0xff   // popcntq      %rdi, %rdi
+	WORD $0x014c; BYTE $0xdf       // addq         %r11, %rdi
+	WORD $0x3948; BYTE $0xf7       // cmpq         %rsi, %rdi
+	LONG $0x0420860f; WORD $0x0000 // jbe          LBB28_86, $1056(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x2148; BYTE $0xcb       // andq         %rcx, %rbx
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_41, $-40(%rip)
+	LONG $0xfffeaae9; BYTE $0xff   // jmp          LBB28_35, $-342(%rip)
+
+LBB28_43:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x04838e0f; WORD $0x0000 // jle          LBB28_91, $1155(%rip)
+	LONG $0x4c297cc5; WORD $0x4024 // vmovaps      %ymm9, $64(%rsp)
+	LONG $0x4c297cc5; WORD $0x2024 // vmovaps      %ymm9, $32(%rsp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0xfeac820f; WORD $0xffff // jb           LBB28_37, $-340(%rip)
+	LONG $0x247c8348; WORD $0x2018 // cmpq         $32, $24(%rsp)
+	LONG $0x00218c0f; WORD $0x0000 // jl           LBB28_47, $33(%rip)
+	LONG $0x2a6ffec5               // vmovdqu      (%rdx), %ymm5
+	LONG $0x6c7ffdc5; WORD $0x2024 // vmovdqa      %ymm5, $32(%rsp)
+	LONG $0x20c28348               // addq         $32, %rdx
+	LONG $0x244c8b48; BYTE $0x18   // movq         $24(%rsp), %rcx
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0x247c8d48; BYTE $0x40   // leaq         $64(%rsp), %rdi
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB28_48, $10(%rip)
+
+LBB28_47:
+	LONG $0x247c8d48; BYTE $0x20 // leaq         $32(%rsp), %rdi
+	LONG $0x244c8b48; BYTE $0x18 // movq         $24(%rsp), %rcx
+
+LBB28_48:
+	LONG $0x10f98348               // cmpq         $16, %rcx
+	LONG $0x00268c0f; WORD $0x0000 // jl           LBB28_50, $38(%rip)
+
+LBB28_49:
+	LONG $0x2a6ffac5               // vmovdqu      (%rdx), %xmm5
+	LONG $0x2f7ffac5               // vmovdqu      %xmm5, (%rdi)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c78348               // addq         $16, %rdi
+	LONG $0xf0598d48               // leaq         $-16(%rcx), %rbx
+	LONG $0x1ff98348               // cmpq         $31, %rcx
+	WORD $0x8948; BYTE $0xd9       // movq         %rbx, %rcx
+	LONG $0xffdf8f0f; WORD $0xffff // jg           LBB28_49, $-33(%rip)
+	LONG $0x000003e9; BYTE $0x00   // jmp          LBB28_51, $3(%rip)
+
+LBB28_50:
+	WORD $0x8948; BYTE $0xcb // movq         %rcx, %rbx
+
+LBB28_51:
+	LONG $0x08fb8348               // cmpq         $8, %rbx
+	LONG $0x004e8c0f; WORD $0x0000 // jl           LBB28_52, $78(%rip)
+	WORD $0x8b48; BYTE $0x0a       // movq         (%rdx), %rcx
+	WORD $0x8948; BYTE $0x0f       // movq         %rcx, (%rdi)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c78348               // addq         $8, %rdi
+	LONG $0xf8c38348               // addq         $-8, %rbx
+	LONG $0x04fb8348               // cmpq         $4, %rbx
+	LONG $0x003c8d0f; WORD $0x0000 // jge          LBB28_56, $60(%rip)
+
+LBB28_53:
+	LONG $0x02fb8348               // cmpq         $2, %rbx
+	LONG $0x004c8c0f; WORD $0x0000 // jl           LBB28_54, $76(%rip)
+
+LBB28_57:
+	WORD $0xb70f; BYTE $0x0a       // movzwl       (%rdx), %ecx
+	WORD $0x8966; BYTE $0x0f       // movw         %cx, (%rdi)
+	LONG $0x02c28348               // addq         $2, %rdx
+	LONG $0x02c78348               // addq         $2, %rdi
+	LONG $0xfec38348               // addq         $-2, %rbx
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0x003a8f0f; WORD $0x0000 // jg           LBB28_58, $58(%rip)
+	LONG $0xfffdeae9; BYTE $0xff   // jmp          LBB28_37, $-534(%rip)
+
+LBB28_52:
+	LONG $0x04fb8348               // cmpq         $4, %rbx
+	LONG $0xffc48c0f; WORD $0xffff // jl           LBB28_53, $-60(%rip)
+
+LBB28_56:
+	WORD $0x0a8b                   // movl         (%rdx), %ecx
+	WORD $0x0f89                   // movl         %ecx, (%rdi)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c78348               // addq         $4, %rdi
+	LONG $0xfcc38348               // addq         $-4, %rbx
+	LONG $0x02fb8348               // cmpq         $2, %rbx
+	LONG $0xffb48d0f; WORD $0xffff // jge          LBB28_57, $-76(%rip)
+
+LBB28_54:
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0xfdb58e0f; WORD $0xffff // jle          LBB28_37, $-587(%rip)
+
+LBB28_58:
+	WORD $0x098a                 // movb         (%rcx), %cl
+	WORD $0x0f88                 // movb         %cl, (%rdi)
+	LONG $0x24548d48; BYTE $0x20 // leaq         $32(%rsp), %rdx
+	LONG $0xfffda7e9; BYTE $0xff // jmp          LBB28_37, $-601(%rip)
+
+LBB28_59:
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x08573b49               // cmpq         $8(%r15), %rdx
+	LONG $0xfc0f830f; WORD $0xffff // jae          LBB28_21, $-1009(%rip)
+
+LBB28_60:
+	WORD $0x8949; BYTE $0x16     // movq         %rdx, (%r14)
+	LONG $0xfffc04e9; BYTE $0xff // jmp          LBB28_20, $-1020(%rip)
+
+LBB28_61:
+	LONG $0x084f8b49             // movq         $8(%r15), %rcx
+	WORD $0x2948; BYTE $0xd1     // subq         %rdx, %rcx
+	WORD $0x0349; BYTE $0x17     // addq         (%r15), %rdx
+	WORD $0x3145; BYTE $0xc9     // xorl         %r9d, %r9d
+	QUAD $0xfffff9ba056ffdc5     // vmovdqa      $-1606(%rip), %ymm0  /* LCPI28_7(%rip) */
+	QUAD $0xfffff9920d6ffdc5     // vmovdqa      $-1646(%rip), %ymm1  /* LCPI28_6(%rip) */
+	LONG $0xd276e9c5             // vpcmpeqd     %xmm2, %xmm2, %xmm2
+	QUAD $0xfffff9c61d6ffdc5     // vmovdqa      $-1594(%rip), %ymm3  /* LCPI28_8(%rip) */
+	QUAD $0xfffff9de256ffdc5     // vmovdqa      $-1570(%rip), %ymm4  /* LCPI28_9(%rip) */
+	LONG $0x573041c4; BYTE $0xc9 // vxorps       %xmm9, %xmm9, %xmm9
+	WORD $0x3145; BYTE $0xd2     // xorl         %r10d, %r10d
+	WORD $0x3145; BYTE $0xdb     // xorl         %r11d, %r11d
+	WORD $0xf631                 // xorl         %esi, %esi
+	LONG $0x00001ce9; BYTE $0x00 // jmp          LBB28_63, $28(%rip)
+
+LBB28_62:
+	LONG $0x3ffdc149             // sarq         $63, %r13
+	LONG $0xb80f49f3; BYTE $0xc8 // popcntq      %r8, %rcx
+	WORD $0x0149; BYTE $0xcb     // addq         %rcx, %r11
+	LONG $0x40c28348             // addq         $64, %rdx
+	LONG $0x244c8b48; BYTE $0x18 // movq         $24(%rsp), %rcx
+	LONG $0xc0c18348             // addq         $-64, %rcx
+	WORD $0x894d; BYTE $0xe9     // movq         %r13, %r9
+
+LBB28_63:
+	LONG $0x40f98348               // cmpq         $64, %rcx
+	LONG $0x244c8948; BYTE $0x18   // movq         %rcx, $24(%rsp)
+	LONG $0x012e8c0f; WORD $0x0000 // jl           LBB28_70, $302(%rip)
+
+LBB28_64:
+	LONG $0x3a6ffec5                           // vmovdqu      (%rdx), %ymm7
+	LONG $0x726ffec5; BYTE $0x20               // vmovdqu      $32(%rdx), %ymm6
+	LONG $0xc07445c5                           // vpcmpeqb     %ymm0, %ymm7, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xc8               // vpmovmskb    %ymm8, %ecx
+	LONG $0xc0744dc5                           // vpcmpeqb     %ymm0, %ymm6, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xf8               // vpmovmskb    %ymm8, %edi
+	LONG $0x20e7c148                           // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xf9                   // orq          %rdi, %rcx
+	WORD $0x8948; BYTE $0xcf                   // movq         %rcx, %rdi
+	WORD $0x094c; BYTE $0xd7                   // orq          %r10, %rdi
+	LONG $0x000f850f; WORD $0x0000             // jne          LBB28_66, $15(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	WORD $0x3145; BYTE $0xd2                   // xorl         %r10d, %r10d
+	LONG $0x000046e9; BYTE $0x00               // jmp          LBB28_67, $70(%rip)
+
+LBB28_66:
+	WORD $0x894c; BYTE $0xd7               // movq         %r10, %rdi
+	WORD $0xf748; BYTE $0xd7               // notq         %rdi
+	WORD $0x2148; BYTE $0xcf               // andq         %rcx, %rdi
+	LONG $0x3f2c8d4c                       // leaq         (%rdi,%rdi), %r13
+	WORD $0x094d; BYTE $0xd5               // orq          %r10, %r13
+	WORD $0x894d; BYTE $0xe8               // movq         %r13, %r8
+	WORD $0xf749; BYTE $0xd0               // notq         %r8
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2148; BYTE $0xd9               // andq         %rbx, %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	WORD $0x3145; BYTE $0xd2               // xorl         %r10d, %r10d
+	WORD $0x0148; BYTE $0xf9               // addq         %rdi, %rcx
+	LONG $0xc2920f41                       // setb         %r10b
+	WORD $0x0148; BYTE $0xc9               // addq         %rcx, %rcx
+	QUAD $0x555555555555bf48; WORD $0x5555 // movabsq      $6148914691236517205, %rdi
+	WORD $0x3148; BYTE $0xf9               // xorq         %rdi, %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+
+LBB28_67:
+	LONG $0xc1744dc5                                                     // vpcmpeqb     %ymm1, %ymm6, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xf8                                         // vpmovmskb    %ymm8, %edi
+	LONG $0x20e7c148                                                     // shlq         $32, %rdi
+	LONG $0xc17445c5                                                     // vpcmpeqb     %ymm1, %ymm7, %ymm8
+	LONG $0xd77dc1c4; BYTE $0xd8                                         // vpmovmskb    %ymm8, %ebx
+	WORD $0x0948; BYTE $0xfb                                             // orq          %rdi, %rbx
+	WORD $0x2148; BYTE $0xcb                                             // andq         %rcx, %rbx
+	LONG $0x6ef9e1c4; BYTE $0xeb                                         // vmovq        %rbx, %xmm5
+	LONG $0x4451e3c4; WORD $0x00ea                                       // vpclmulqdq   $0, %xmm2, %xmm5, %xmm5
+	LONG $0x7ef9c1c4; BYTE $0xed                                         // vmovq        %xmm5, %r13
+	WORD $0x314d; BYTE $0xcd                                             // xorq         %r9, %r13
+	LONG $0xeb74c5c5                                                     // vpcmpeqb     %ymm3, %ymm7, %ymm5
+	LONG $0xc5d77dc5                                                     // vpmovmskb    %ymm5, %r8d
+	LONG $0xeb74cdc5                                                     // vpcmpeqb     %ymm3, %ymm6, %ymm5
+	LONG $0xfdd7fdc5                                                     // vpmovmskb    %ymm5, %edi
+	LONG $0x20e7c148                                                     // shlq         $32, %rdi
+	WORD $0x0949; BYTE $0xf8                                             // orq          %rdi, %r8
+	WORD $0x894d; BYTE $0xe9                                             // movq         %r13, %r9
+	WORD $0xf749; BYTE $0xd1                                             // notq         %r9
+	WORD $0x214d; BYTE $0xc8                                             // andq         %r9, %r8
+	LONG $0xec74c5c5                                                     // vpcmpeqb     %ymm4, %ymm7, %ymm5
+	LONG $0xddd7fdc5                                                     // vpmovmskb    %ymm5, %ebx
+	LONG $0xec74cdc5                                                     // vpcmpeqb     %ymm4, %ymm6, %ymm5
+	LONG $0xfdd7fdc5                                                     // vpmovmskb    %ymm5, %edi
+	LONG $0x20e7c148                                                     // shlq         $32, %rdi
+	WORD $0x0948; BYTE $0xfb                                             // orq          %rdi, %rbx
+	WORD $0x214c; BYTE $0xcb                                             // andq         %r9, %rbx
+	LONG $0xfee3840f; WORD $0xffff                                       // je           LBB28_62, $-285(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB28_68:
+	LONG $0xff4b8d48               // leaq         $-1(%rbx), %rcx
+	WORD $0x8948; BYTE $0xcf       // movq         %rcx, %rdi
+	WORD $0x214c; BYTE $0xc7       // andq         %r8, %rdi
+	LONG $0xb80f48f3; BYTE $0xff   // popcntq      %rdi, %rdi
+	WORD $0x014c; BYTE $0xdf       // addq         %r11, %rdi
+	WORD $0x3948; BYTE $0xf7       // cmpq         %rsi, %rdi
+	LONG $0x0140860f; WORD $0x0000 // jbe          LBB28_86, $320(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	WORD $0x2148; BYTE $0xcb       // andq         %rcx, %rbx
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_68, $-40(%rip)
+	LONG $0xfffea7e9; BYTE $0xff   // jmp          LBB28_62, $-345(%rip)
+
+LBB28_70:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x01a38e0f; WORD $0x0000 // jle          LBB28_91, $419(%rip)
+	LONG $0x4c297cc5; WORD $0x4024 // vmovaps      %ymm9, $64(%rsp)
+	LONG $0x4c297cc5; WORD $0x2024 // vmovaps      %ymm9, $32(%rsp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0xfea9820f; WORD $0xffff // jb           LBB28_64, $-343(%rip)
+	LONG $0x247c8348; WORD $0x2018 // cmpq         $32, $24(%rsp)
+	LONG $0x00218c0f; WORD $0x0000 // jl           LBB28_74, $33(%rip)
+	LONG $0x2a6ffec5               // vmovdqu      (%rdx), %ymm5
+	LONG $0x6c7ffdc5; WORD $0x2024 // vmovdqa      %ymm5, $32(%rsp)
+	LONG $0x20c28348               // addq         $32, %rdx
+	LONG $0x244c8b48; BYTE $0x18   // movq         $24(%rsp), %rcx
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0x247c8d48; BYTE $0x40   // leaq         $64(%rsp), %rdi
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB28_75, $10(%rip)
+
+LBB28_74:
+	LONG $0x247c8d48; BYTE $0x20 // leaq         $32(%rsp), %rdi
+	LONG $0x244c8b48; BYTE $0x18 // movq         $24(%rsp), %rcx
+
+LBB28_75:
+	LONG $0x10f98348               // cmpq         $16, %rcx
+	LONG $0x00268c0f; WORD $0x0000 // jl           LBB28_77, $38(%rip)
+
+LBB28_76:
+	LONG $0x2a6ffac5               // vmovdqu      (%rdx), %xmm5
+	LONG $0x2f7ffac5               // vmovdqu      %xmm5, (%rdi)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c78348               // addq         $16, %rdi
+	LONG $0xf0598d48               // leaq         $-16(%rcx), %rbx
+	LONG $0x1ff98348               // cmpq         $31, %rcx
+	WORD $0x8948; BYTE $0xd9       // movq         %rbx, %rcx
+	LONG $0xffdf8f0f; WORD $0xffff // jg           LBB28_76, $-33(%rip)
+	LONG $0x000003e9; BYTE $0x00   // jmp          LBB28_78, $3(%rip)
+
+LBB28_77:
+	WORD $0x8948; BYTE $0xcb // movq         %rcx, %rbx
+
+LBB28_78:
+	LONG $0x08fb8348               // cmpq         $8, %rbx
+	LONG $0x004e8c0f; WORD $0x0000 // jl           LBB28_79, $78(%rip)
+	WORD $0x8b48; BYTE $0x0a       // movq         (%rdx), %rcx
+	WORD $0x8948; BYTE $0x0f       // movq         %rcx, (%rdi)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c78348               // addq         $8, %rdi
+	LONG $0xf8c38348               // addq         $-8, %rbx
+	LONG $0x04fb8348               // cmpq         $4, %rbx
+	LONG $0x003c8d0f; WORD $0x0000 // jge          LBB28_83, $60(%rip)
+
+LBB28_80:
+	LONG $0x02fb8348               // cmpq         $2, %rbx
+	LONG $0x004c8c0f; WORD $0x0000 // jl           LBB28_81, $76(%rip)
+
+LBB28_84:
+	WORD $0xb70f; BYTE $0x0a       // movzwl       (%rdx), %ecx
+	WORD $0x8966; BYTE $0x0f       // movw         %cx, (%rdi)
+	LONG $0x02c28348               // addq         $2, %rdx
+	LONG $0x02c78348               // addq         $2, %rdi
+	LONG $0xfec38348               // addq         $-2, %rbx
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0x003a8f0f; WORD $0x0000 // jg           LBB28_85, $58(%rip)
+	LONG $0xfffde7e9; BYTE $0xff   // jmp          LBB28_64, $-537(%rip)
+
+LBB28_79:
+	LONG $0x04fb8348               // cmpq         $4, %rbx
+	LONG $0xffc48c0f; WORD $0xffff // jl           LBB28_80, $-60(%rip)
+
+LBB28_83:
+	WORD $0x0a8b                   // movl         (%rdx), %ecx
+	WORD $0x0f89                   // movl         %ecx, (%rdi)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c78348               // addq         $4, %rdi
+	LONG $0xfcc38348               // addq         $-4, %rbx
+	LONG $0x02fb8348               // cmpq         $2, %rbx
+	LONG $0xffb48d0f; WORD $0xffff // jge          LBB28_84, $-76(%rip)
+
+LBB28_81:
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	LONG $0x24548d48; BYTE $0x20   // leaq         $32(%rsp), %rdx
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0xfdb28e0f; WORD $0xffff // jle          LBB28_64, $-590(%rip)
+
+LBB28_85:
+	WORD $0x098a                 // movb         (%rcx), %cl
+	WORD $0x0f88                 // movb         %cl, (%rdi)
+	LONG $0x24548d48; BYTE $0x20 // leaq         $32(%rsp), %rdx
+	LONG $0xfffda4e9; BYTE $0xff // jmp          LBB28_64, $-604(%rip)
+
+LBB28_86:
+	LONG $0x08478b49                           // movq         $8(%r15), %rax
+	LONG $0xcbbc0f48                           // bsfq         %rbx, %rcx
+	LONG $0x244c2b48; BYTE $0x18               // subq         $24(%rsp), %rcx
+	WORD $0x0148; BYTE $0xc8                   // addq         %rcx, %rax
+	LONG $0x01c08348                           // addq         $1, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0x084f8b49                           // movq         $8(%r15), %rcx
+	WORD $0x3948; BYTE $0xc8                   // cmpq         %rcx, %rax
+	LONG $0xc1470f48                           // cmovaq       %rcx, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xe0470f4c                           // cmovaq       %rax, %r12
+	LONG $0xfff905e9; BYTE $0xff               // jmp          LBB28_20, $-1787(%rip)
+
+LBB28_88:
+	LONG $0xc7bc0f66             // bsfw         %di, %ax
+	WORD $0xb70f; BYTE $0xc0     // movzwl       %ax, %eax
+	WORD $0x2948; BYTE $0xf0     // subq         %rsi, %rax
+	LONG $0xfff8f3e9; BYTE $0xff // jmp          LBB28_19, $-1805(%rip)
+
+LBB28_31:
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x003d850f; WORD $0x0000 // jne          LBB28_92, $61(%rip)
+	WORD $0x0149; BYTE $0xd9       // addq         %rbx, %r9
+	WORD $0x0149; BYTE $0xf2       // addq         %rsi, %r10
+
+LBB28_33:
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0x0071850f; WORD $0x0000 // jne          LBB28_96, $113(%rip)
+	LONG $0xfff8dce9; BYTE $0xff   // jmp          LBB28_21, $-1828(%rip)
+
+LBB28_89:
+	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
+	LONG $0x10f98348               // cmpq         $16, %rcx
+	LONG $0xf828830f; WORD $0xffff // jae          LBB28_7, $-2008(%rip)
+	LONG $0xfff878e9; BYTE $0xff   // jmp          LBB28_10, $-1928(%rip)
+
+LBB28_90:
+	WORD $0x2948; BYTE $0xc2     // subq         %rax, %rdx
+	WORD $0x0148; BYTE $0xf2     // addq         %rsi, %rdx
+	LONG $0xfffcb0e9; BYTE $0xff // jmp          LBB28_60, $-848(%rip)
+
+LBB28_91:
+	LONG $0x084f8b49             // movq         $8(%r15), %rcx
+	WORD $0x8949; BYTE $0x0e     // movq         %rcx, (%r14)
+	LONG $0xfff8b3e9; BYTE $0xff // jmp          LBB28_21, $-1869(%rip)
+
+LBB28_92:
+	WORD $0x3949; BYTE $0xda       // cmpq         %rbx, %r10
+	LONG $0xf8aa840f; WORD $0xffff // je           LBB28_21, $-1878(%rip)
+	WORD $0x0149; BYTE $0xd9       // addq         %rbx, %r9
+	LONG $0x01c18349               // addq         $1, %r9
+	WORD $0xf748; BYTE $0xd3       // notq         %rbx
+	WORD $0x0149; BYTE $0xda       // addq         %rbx, %r10
+	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
+	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_96, $36(%rip)
+	LONG $0xfff88fe9; BYTE $0xff   // jmp          LBB28_21, $-1905(%rip)
+
+LBB28_94:
+	LONG $0xfec1c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rcx
+	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
+	WORD $0x0149; BYTE $0xc1                   // addq         %rax, %r9
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xca                   // addq         %rcx, %r10
+	LONG $0xf870840f; WORD $0xffff             // je           LBB28_21, $-1936(%rip)
+
+LBB28_96:
+	LONG $0x01b60f41                           // movzbl       (%r9), %eax
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0xffd5840f; WORD $0xffff             // je           LBB28_94, $-43(%rip)
+	WORD $0x223c                               // cmpb         $34, %al
+	LONG $0x0024840f; WORD $0x0000             // je           LBB28_99, $36(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
+	WORD $0x0149; BYTE $0xc1                   // addq         %rax, %r9
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xca                   // addq         %rcx, %r10
+	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_96, $-51(%rip)
+	LONG $0xfff838e9; BYTE $0xff               // jmp          LBB28_21, $-1992(%rip)
+
+LBB28_99:
+	LONG $0x244c2b4c; BYTE $0x18 // subq         $24(%rsp), %r9
+	LONG $0x01c18349             // addq         $1, %r9
+	WORD $0x894d; BYTE $0x0e     // movq         %r9, (%r14)
+	LONG $0xfff824e9; BYTE $0xff // jmp          LBB28_20, $-2012(%rip)
+	WORD $0x9090; BYTE $0x90     // .p2align 2, 0x90
+
+	// .set L28_0_set_21, LBB28_21-LJTI28_0
+	// .set L28_0_set_23, LBB28_23-LJTI28_0
+	// .set L28_0_set_24, LBB28_24-LJTI28_0
+	// .set L28_0_set_2, LBB28_2-LJTI28_0
+	// .set L28_0_set_34, LBB28_34-LJTI28_0
+	// .set L28_0_set_59, LBB28_59-LJTI28_0
+	// .set L28_0_set_22, LBB28_22-LJTI28_0
+	// .set L28_0_set_61, LBB28_61-LJTI28_0
+LJTI28_0:
+	LONG $0xfffff824                           // .long L28_0_set_21
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff858                           // .long L28_0_set_24
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff6e9                           // .long L28_0_set_2
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff940                           // .long L28_0_set_34
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffffc07                           // .long L28_0_set_59
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff836                           // .long L28_0_set_22
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff836                           // .long L28_0_set_22
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffff849                           // .long L28_0_set_23
+	LONG $0xfffffc1d                           // .long L28_0_set_61
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
+
+_get_by_path:
+	BYTE $0x55                     // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5       // movq         %rsp, %rbp
+	WORD $0x5741                   // pushq        %r15
+	WORD $0x5641                   // pushq        %r14
+	WORD $0x5541                   // pushq        %r13
+	WORD $0x5441                   // pushq        %r12
+	BYTE $0x53                     // pushq        %rbx
+	LONG $0x28ec8348               // subq         $40, %rsp
+	WORD $0x8949; BYTE $0xf6       // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
+	LONG $0x08428b48               // movq         $8(%rdx), %rax
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x06ad840f; WORD $0x0000 // je           LBB29_88, $1709(%rip)
+	WORD $0x8b4c; BYTE $0x2a       // movq         (%rdx), %r13
+	LONG $0x04e0c148               // shlq         $4, %rax
+	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
+	LONG $0xb0458948               // movq         %rax, $-80(%rbp)
+
+LBB29_2:
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xffcf53e8; BYTE $0xff   // callq        _advance_ns, $-12461(%rip)
+	LONG $0x004d8b49               // movq         (%r13), %rcx
+	WORD $0x498a; BYTE $0x17       // movb         $23(%rcx), %cl
+	WORD $0xe180; BYTE $0x1f       // andb         $31, %cl
+	WORD $0xf980; BYTE $0x18       // cmpb         $24, %cl
+	LONG $0x0620850f; WORD $0x0000 // jne          LBB29_82, $1568(%rip)
+	WORD $0x7b3c                   // cmpb         $123, %al
+	LONG $0xc06d894c               // movq         %r13, $-64(%rbp)
+	LONG $0x0685850f; WORD $0x0000 // jne          LBB29_89, $1669(%rip)
+	LONG $0x90909090               // .p2align 4, 0x90
+
+LBB29_4:
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xffcf25e8; BYTE $0xff   // callq        _advance_ns, $-12507(%rip)
+	WORD $0x223c                   // cmpb         $34, %al
+	LONG $0x066e850f; WORD $0x0000 // jne          LBB29_89, $1646(%rip)
+	LONG $0x08458b49               // movq         $8(%r13), %rax
+	WORD $0x8b48; BYTE $0x08       // movq         (%rax), %rcx
+	LONG $0xc84d8948               // movq         %rcx, $-56(%rbp)
+	LONG $0x08788b4c               // movq         $8(%rax), %r15
+	QUAD $0xffffffffb845c748       // movq         $-1, $-72(%rbp)
+	WORD $0x8b4d; BYTE $0x2e       // movq         (%r14), %r13
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xee       // movq         %r13, %rsi
+	LONG $0xb8558d48               // leaq         $-72(%rbp), %rdx
+	LONG $0x001b94e8; BYTE $0x00   // callq        _advance_string_default, $7060(%rip)
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x0656880f; WORD $0x0000 // js           LBB29_91, $1622(%rip)
+	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
+	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
+	LONG $0xfff98348               // cmpq         $-1, %rcx
+	LONG $0x0009840f; WORD $0x0000 // je           LBB29_8, $9(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x01da8e0f; WORD $0x0000 // jle          LBB29_34, $474(%rip)
+
+LBB29_8:
+	WORD $0x894c; BYTE $0xe9       // movq         %r13, %rcx
+	WORD $0xf748; BYTE $0xd1       // notq         %rcx
+	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
+	WORD $0x394c; BYTE $0xf8       // cmpq         %r15, %rax
+	LONG $0x005f850f; WORD $0x0000 // jne          LBB29_12, $95(%rip)
+	LONG $0x242c034d               // addq         (%r12), %r13
+	WORD $0xc931                   // xorl         %ecx, %ecx
+	WORD $0x894c; BYTE $0xeb       // movq         %r13, %rbx
+	LONG $0xc84d8b4c               // movq         $-56(%rbp), %r9
+	WORD $0x894c; BYTE $0xcf       // movq         %r9, %rdi
+	WORD $0x894c; BYTE $0xf8       // movq         %r15, %rax
+	WORD $0x894c; BYTE $0xca       // movq         %r9, %rdx
+	WORD $0x894c; BYTE $0xee       // movq         %r13, %rsi
+	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB29_10:
+	LONG $0x20f88348               // cmpq         $32, %rax
+	LONG $0x0046820f; WORD $0x0000 // jb           LBB29_13, $70(%rip)
+	LONG $0x066ffec5               // vmovdqu      (%rsi), %ymm0
+	LONG $0x0274fdc5               // vpcmpeqb     (%rdx), %ymm0, %ymm0
+	LONG $0xc0d77dc5               // vpmovmskb    %ymm0, %r8d
+	LONG $0x20c68348               // addq         $32, %rsi
+	LONG $0x20c28348               // addq         $32, %rdx
+	LONG $0xe0c08348               // addq         $-32, %rax
+	LONG $0x20c78348               // addq         $32, %rdi
+	LONG $0x20c38348               // addq         $32, %rbx
+	LONG $0x20c18348               // addq         $32, %rcx
+	LONG $0xfff88341               // cmpl         $-1, %r8d
+	LONG $0xffc8840f; WORD $0xffff // je           LBB29_10, $-56(%rip)
+	LONG $0x000090e9; BYTE $0x00   // jmp          LBB29_19, $144(%rip)
+	WORD $0x9090; BYTE $0x90       // .p2align 4, 0x90
+
+LBB29_12:
+	WORD $0xdb31                         // xorl         %ebx, %ebx
+	LONG $0x00011ce9; BYTE $0x00         // jmp          LBB29_30, $284(%rip)
+	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_13:
+	LONG $0x0fffe381; WORD $0x0000                         // andl         $4095, %ebx
+	LONG $0x0fe0fb81; WORD $0x0000                         // cmpl         $4064, %ebx
+	LONG $0x003e870f; WORD $0x0000                         // ja           LBB29_17, $62(%rip)
+	LONG $0x0fffe781; WORD $0x0000                         // andl         $4095, %edi
+	LONG $0x0fe1ff81; WORD $0x0000                         // cmpl         $4065, %edi
+	LONG $0x002c830f; WORD $0x0000                         // jae          LBB29_17, $44(%rip)
+	LONG $0x066ffec5                                       // vmovdqu      (%rsi), %ymm0
+	LONG $0x0274fdc5                                       // vpcmpeqb     (%rdx), %ymm0, %ymm0
+	LONG $0xc8d7fdc5                                       // vpmovmskb    %ymm0, %ecx
+	WORD $0xf983; BYTE $0xff                               // cmpl         $-1, %ecx
+	LONG $0x00cc840f; WORD $0x0000                         // je           LBB29_28, $204(%rip)
+	WORD $0xd1f7                                           // notl         %ecx
+	WORD $0xbc0f; BYTE $0xc9                               // bsfl         %ecx, %ecx
+	LONG $0x000092e9; BYTE $0x00                           // jmp          LBB29_24, $146(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_17:
+	LONG $0x10f88348                           // cmpq         $16, %rax
+	LONG $0x002a820f; WORD $0x0000             // jb           LBB29_20, $42(%rip)
+	LONG $0x6f7ac1c4; WORD $0x0d44; BYTE $0x00 // vmovdqu      (%r13,%rcx), %xmm0
+	LONG $0x7479c1c4; WORD $0x0904             // vpcmpeqb     (%r9,%rcx), %xmm0, %xmm0
+	LONG $0xd0d7f9c5                           // vpmovmskb    %xmm0, %edx
+	LONG $0xf0c08348                           // addq         $-16, %rax
+	LONG $0x10c18348                           // addq         $16, %rcx
+	LONG $0xfffa8366                           // cmpw         $-1, %dx
+	LONG $0xffd3840f; WORD $0xffff             // je           LBB29_17, $-45(%rip)
+
+LBB29_19:
+	WORD $0xc031                 // xorl         %eax, %eax
+	LONG $0x00008ce9; BYTE $0x00 // jmp          LBB29_29, $140(%rip)
+
+LBB29_20:
+	WORD $0x8944; BYTE $0xea                   // movl         %r13d, %edx
+	WORD $0xca01                               // addl         %ecx, %edx
+	LONG $0x0fffe281; WORD $0x0000             // andl         $4095, %edx
+	LONG $0x0ff0fa81; WORD $0x0000             // cmpl         $4080, %edx
+	LONG $0x0049870f; WORD $0x0000             // ja           LBB29_26, $73(%rip)
+	LONG $0x09148d41                           // leal         (%r9,%rcx), %edx
+	LONG $0x0fffe281; WORD $0x0000             // andl         $4095, %edx
+	LONG $0x0ff1fa81; WORD $0x0000             // cmpl         $4081, %edx
+	LONG $0x0033830f; WORD $0x0000             // jae          LBB29_26, $51(%rip)
+	LONG $0x6f7ac1c4; WORD $0x0d44; BYTE $0x00 // vmovdqu      (%r13,%rcx), %xmm0
+	LONG $0x7479c1c4; WORD $0x0904             // vpcmpeqb     (%r9,%rcx), %xmm0, %xmm0
+	LONG $0xc8d7f9c5                           // vpmovmskb    %xmm0, %ecx
+	LONG $0xfff98366                           // cmpw         $-1, %cx
+	LONG $0x0039840f; WORD $0x0000             // je           LBB29_28, $57(%rip)
+	WORD $0xd1f7                               // notl         %ecx
+	LONG $0xc9bc0f66                           // bsfw         %cx, %cx
+	WORD $0xb70f; BYTE $0xc9                   // movzwl       %cx, %ecx
+
+LBB29_24:
+	WORD $0x3948; BYTE $0xc8     // cmpq         %rcx, %rax
+	WORD $0x960f; BYTE $0xc0     // setbe        %al
+	LONG $0x000030e9; BYTE $0x00 // jmp          LBB29_29, $48(%rip)
+
+	// .p2align 4, 0x90
+LBB29_25:
+	LONG $0x01c18348 // addq         $1, %rcx
+
+LBB29_26:
+	WORD $0x3949; BYTE $0xcf       // cmpq         %rcx, %r15
+	LONG $0x0018840f; WORD $0x0000 // je           LBB29_28, $24(%rip)
+	LONG $0x44b60f41; WORD $0x000d // movzbl       (%r13,%rcx), %eax
+	LONG $0x09043a41               // cmpb         (%r9,%rcx), %al
+	WORD $0x940f; BYTE $0xc0       // sete         %al
+	LONG $0xffe0840f; WORD $0xffff // je           LBB29_25, $-32(%rip)
+	LONG $0x00000be9; BYTE $0x00   // jmp          LBB29_29, $11(%rip)
+
+LBB29_28:
+	WORD $0x01b0                         // movb         $1, %al
+	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_29:
+	WORD $0xb60f; BYTE $0xd8 // movzbl       %al, %ebx
+
+LBB29_30:
+	LONG $0xc06d8b4c // movq         $-64(%rbp), %r13
+
+LBB29_31:
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	WORD $0xf8c5; BYTE $0x77       // vzeroupper
+	LONG $0xffcd2be8; BYTE $0xff   // callq        _advance_ns, $-13013(%rip)
+	WORD $0x3a3c                   // cmpb         $58, %al
+	LONG $0x0474850f; WORD $0x0000 // jne          LBB29_89, $1140(%rip)
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0x044a850f; WORD $0x0000 // jne          LBB29_87, $1098(%rip)
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xfff21fe8; BYTE $0xff   // callq        _skip_one_fast, $-3553(%rip)
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xffcd04e8; BYTE $0xff   // callq        _advance_ns, $-13052(%rip)
+	WORD $0x2c3c                   // cmpb         $44, %al
+	LONG $0xfdcc840f; WORD $0xffff // je           LBB29_4, $-564(%rip)
+	LONG $0x000448e9; BYTE $0x00   // jmp          LBB29_89, $1096(%rip)
+
+LBB29_34:
+	QUAD $0x00000000d045c748       // movq         $0, $-48(%rbp)
+	LONG $0x24048b4d               // movq         (%r12), %r8
+	LONG $0x28148d4f               // leaq         (%r8,%r13), %r10
+	LONG $0x000c8d4d               // leaq         (%r8,%rax), %r9
+	LONG $0xffc18349               // addq         $-1, %r9
+	LONG $0xffc08348               // addq         $-1, %rax
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	LONG $0x391c8d4e               // leaq         (%rcx,%r15), %r11
+	WORD $0x3949; BYTE $0xc5       // cmpq         %rax, %r13
+	LONG $0x03888d0f; WORD $0x0000 // jge          LBB29_78, $904(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0xc06d8b4c               // movq         $-64(%rbp), %r13
+	LONG $0x037f8e0f; WORD $0x0000 // jle          LBB29_79, $895(%rip)
+
+LBB29_36:
+	WORD $0x8a41; BYTE $0x02                   // movb         (%r10), %al
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0x0059850f; WORD $0x0000             // jne          LBB29_41, $89(%rip)
+	WORD $0x894c; BYTE $0xcb                   // movq         %r9, %rbx
+	WORD $0x294c; BYTE $0xd3                   // subq         %r10, %rbx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x8548; BYTE $0xdb                   // testq        %rbx, %rbx
+	LONG $0x043b8e0f; WORD $0x0000             // jle          LBB29_94, $1083(%rip)
+	LONG $0x4ab60f41; BYTE $0x01               // movzbl       $1(%r10), %ecx
+	LONG $0x00158d48; WORD $0x0091; BYTE $0x00 // leaq         $37120(%rip), %rdx  /* __UnquoteTab(%rip) */
+	WORD $0x148a; BYTE $0x11                   // movb         (%rcx,%rdx), %dl
+	WORD $0xfa80; BYTE $0xff                   // cmpb         $-1, %dl
+	LONG $0x0048840f; WORD $0x0000             // je           LBB29_43, $72(%rip)
+	WORD $0xd284                               // testb        %dl, %dl
+	LONG $0x0407840f; WORD $0x0000             // je           LBB29_92, $1031(%rip)
+	WORD $0x5588; BYTE $0xd0                   // movb         %dl, $-48(%rbp)
+	LONG $0x02c28349                           // addq         $2, %r10
+	LONG $0x000001bb; BYTE $0x00               // movl         $1, %ebx
+	LONG $0x2b048d48                           // leaq         (%rbx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xc85d394c                           // cmpq         %r11, $-56(%rbp)
+	LONG $0x0138820f; WORD $0x0000             // jb           LBB29_54, $312(%rip)
+	LONG $0x0002f2e9; BYTE $0x00               // jmp          LBB29_62, $754(%rip)
+
+LBB29_41:
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	WORD $0x013a                   // cmpb         (%rcx), %al
+	LONG $0x0326850f; WORD $0x0000 // jne          LBB29_81, $806(%rip)
+	LONG $0x01c28349               // addq         $1, %r10
+	LONG $0x01c18348               // addq         $1, %rcx
+	LONG $0xc84d8948               // movq         %rcx, $-56(%rbp)
+	LONG $0x0002e2e9; BYTE $0x00   // jmp          LBB29_64, $738(%rip)
+
+LBB29_43:
+	LONG $0x04fb8348                           // cmpq         $4, %rbx
+	LONG $0x03cd8c0f; WORD $0x0000             // jl           LBB29_93, $973(%rip)
+	LONG $0x027a8d4d                           // leaq         $2(%r10), %r15
+	LONG $0x02728b41                           // movl         $2(%r10), %esi
+	WORD $0xf289                               // movl         %esi, %edx
+	WORD $0xd2f7                               // notl         %edx
+	LONG $0xcfd08e8d; WORD $0xcfcf             // leal         $-808464432(%rsi), %ecx
+	LONG $0x8080e281; WORD $0x8080             // andl         $-2139062144, %edx
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	WORD $0xca85                               // testl        %ecx, %edx
+	LONG $0x038a850f; WORD $0x0000             // jne          LBB29_96, $906(%rip)
+	LONG $0x19198e8d; WORD $0x1919             // leal         $421075225(%rsi), %ecx
+	WORD $0xf109                               // orl          %esi, %ecx
+	LONG $0x8080c1f7; WORD $0x8080             // testl        $-2139062144, %ecx
+	LONG $0x0376850f; WORD $0x0000             // jne          LBB29_96, $886(%rip)
+	WORD $0xf189                               // movl         %esi, %ecx
+	LONG $0x7f7fe181; WORD $0x7f7f             // andl         $2139062143, %ecx
+	LONG $0xc0c0c0bf; BYTE $0xc0               // movl         $-1061109568, %edi
+	WORD $0xcf29                               // subl         %ecx, %edi
+	LONG $0x46a98d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rcx), %r13d
+	WORD $0xd721                               // andl         %edx, %edi
+	WORD $0x8544; BYTE $0xef                   // testl        %r13d, %edi
+	LONG $0x0355850f; WORD $0x0000             // jne          LBB29_96, $853(%rip)
+	LONG $0xe0e0e0bf; BYTE $0xe0               // movl         $-522133280, %edi
+	WORD $0xcf29                               // subl         %ecx, %edi
+	LONG $0x3939c181; WORD $0x3939             // addl         $960051513, %ecx
+	WORD $0xfa21                               // andl         %edi, %edx
+	WORD $0xca85                               // testl        %ecx, %edx
+	LONG $0x0361850f; WORD $0x0000             // jne          LBB29_95, $865(%rip)
+	WORD $0xce0f                               // bswapl       %esi
+	WORD $0xf089                               // movl         %esi, %eax
+	WORD $0xe8c1; BYTE $0x04                   // shrl         $4, %eax
+	WORD $0xd0f7                               // notl         %eax
+	LONG $0x01010125; BYTE $0x01               // andl         $16843009, %eax
+	WORD $0x048d; BYTE $0xc0                   // leal         (%rax,%rax,8), %eax
+	LONG $0x0f0fe681; WORD $0x0f0f             // andl         $252645135, %esi
+	WORD $0xc601                               // addl         %eax, %esi
+	WORD $0xf289                               // movl         %esi, %edx
+	WORD $0xeac1; BYTE $0x04                   // shrl         $4, %edx
+	WORD $0xf209                               // orl          %esi, %edx
+	WORD $0xd089                               // movl         %edx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xca                   // movzbl       %dl, %ecx
+	WORD $0xc109                               // orl          %eax, %ecx
+	LONG $0x067a8d4d                           // leaq         $6(%r10), %r15
+	WORD $0xf983; BYTE $0x7f                   // cmpl         $127, %ecx
+	LONG $0xc06d8b4c                           // movq         $-64(%rbp), %r13
+	LONG $0x00af860f; WORD $0x0000             // jbe          LBB29_66, $175(%rip)
+	LONG $0x07fff981; WORD $0x0000             // cmpl         $2047, %ecx
+	LONG $0x00b0860f; WORD $0x0000             // jbe          LBB29_67, $176(%rip)
+	WORD $0xd689                               // movl         %edx, %esi
+	LONG $0x0000e681; WORD $0x00f8             // andl         $16252928, %esi
+	LONG $0x0000fe81; WORD $0x00d8             // cmpl         $14155776, %esi
+	LONG $0x00ba840f; WORD $0x0000             // je           LBB29_68, $186(%rip)
+	WORD $0xe8c1; BYTE $0x0c                   // shrl         $12, %eax
+	WORD $0xe00c                               // orb          $-32, %al
+	WORD $0x4588; BYTE $0xd0                   // movb         %al, $-48(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd1                   // movb         %cl, $-47(%rbp)
+	WORD $0xe280; BYTE $0x3f                   // andb         $63, %dl
+	WORD $0xca80; BYTE $0x80                   // orb          $-128, %dl
+	WORD $0x5588; BYTE $0xd2                   // movb         %dl, $-46(%rbp)
+	LONG $0x000003bb; BYTE $0x00               // movl         $3, %ebx
+	WORD $0xc289                               // movl         %eax, %edx
+
+LBB29_52:
+	WORD $0x894d; BYTE $0xfa       // movq         %r15, %r10
+	LONG $0x2b048d48               // leaq         (%rbx,%rbp), %rax
+	LONG $0xd0c08348               // addq         $-48, %rax
+	LONG $0xc85d394c               // cmpq         %r11, $-56(%rbp)
+	LONG $0x01bf830f; WORD $0x0000 // jae          LBB29_62, $447(%rip)
+
+LBB29_54:
+	LONG $0xd04d8d48               // leaq         $-48(%rbp), %rcx
+	WORD $0x3948; BYTE $0xc8       // cmpq         %rcx, %rax
+	LONG $0x01b2860f; WORD $0x0000 // jbe          LBB29_62, $434(%rip)
+	LONG $0xc8758b48               // movq         $-56(%rbp), %rsi
+	WORD $0x1638                   // cmpb         %dl, (%rsi)
+	LONG $0x01a6850f; WORD $0x0000 // jne          LBB29_62, $422(%rip)
+	LONG $0x01c68348               // addq         $1, %rsi
+	LONG $0xd1558d48               // leaq         $-47(%rbp), %rdx
+
+LBB29_57:
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	LONG $0xc8758948               // movq         %rsi, $-56(%rbp)
+	WORD $0x394c; BYTE $0xde       // cmpq         %r11, %rsi
+	LONG $0x0192830f; WORD $0x0000 // jae          LBB29_63, $402(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x0189830f; WORD $0x0000 // jae          LBB29_63, $393(%rip)
+	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
+	WORD $0xb60f; BYTE $0x1a       // movzbl       (%rdx), %ebx
+	LONG $0x01728d48               // leaq         $1(%rdx), %rsi
+	LONG $0x01518d48               // leaq         $1(%rcx), %rdx
+	WORD $0x193a                   // cmpb         (%rcx), %bl
+	LONG $0xffd0840f; WORD $0xffff // je           LBB29_57, $-48(%rip)
+	LONG $0x00016de9; BYTE $0x00   // jmp          LBB29_63, $365(%rip)
+
+LBB29_66:
+	WORD $0x5588; BYTE $0xd0     // movb         %dl, $-48(%rbp)
+	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
+	LONG $0xffff88e9; BYTE $0xff // jmp          LBB29_52, $-120(%rip)
+
+LBB29_67:
+	WORD $0xe9c1; BYTE $0x06     // shrl         $6, %ecx
+	WORD $0xc980; BYTE $0xc0     // orb          $-64, %cl
+	WORD $0x4d88; BYTE $0xd0     // movb         %cl, $-48(%rbp)
+	WORD $0xe280; BYTE $0x3f     // andb         $63, %dl
+	WORD $0xca80; BYTE $0x80     // orb          $-128, %dl
+	WORD $0x5588; BYTE $0xd1     // movb         %dl, $-47(%rbp)
+	LONG $0x000002bb; BYTE $0x00 // movl         $2, %ebx
+	WORD $0xca89                 // movl         %ecx, %edx
+	LONG $0xffff6ae9; BYTE $0xff // jmp          LBB29_52, $-150(%rip)
+
+LBB29_68:
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0x06fb8348                           // cmpq         $6, %rbx
+	LONG $0x02368c0f; WORD $0x0000             // jl           LBB29_95, $566(%rip)
+	LONG $0xdbfff981; WORD $0x0000             // cmpl         $56319, %ecx
+	LONG $0x022a870f; WORD $0x0000             // ja           LBB29_95, $554(%rip)
+	LONG $0x5c3f8041                           // cmpb         $92, (%r15)
+	LONG $0x0220850f; WORD $0x0000             // jne          LBB29_95, $544(%rip)
+	LONG $0x077a8041; BYTE $0x75               // cmpb         $117, $7(%r10)
+	LONG $0x0215850f; WORD $0x0000             // jne          LBB29_95, $533(%rip)
+	LONG $0x087a8d4d                           // leaq         $8(%r10), %r15
+	LONG $0x08528b41                           // movl         $8(%r10), %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	LONG $0xcfd0b28d; WORD $0xcfcf             // leal         $-808464432(%rdx), %esi
+	LONG $0x8080e381; WORD $0x8080             // andl         $-2139062144, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x01d2850f; WORD $0x0000             // jne          LBB29_96, $466(%rip)
+	LONG $0x1919b28d; WORD $0x1919             // leal         $421075225(%rdx), %esi
+	WORD $0xd609                               // orl          %edx, %esi
+	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
+	LONG $0x01be850f; WORD $0x0000             // jne          LBB29_96, $446(%rip)
+	WORD $0xd689                               // movl         %edx, %esi
+	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
+	LONG $0xc0c0c0bf; BYTE $0xc0               // movl         $-1061109568, %edi
+	WORD $0xf729                               // subl         %esi, %edi
+	LONG $0x46ae8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r13d
+	WORD $0xdf21                               // andl         %ebx, %edi
+	WORD $0x8544; BYTE $0xef                   // testl        %r13d, %edi
+	LONG $0x019d850f; WORD $0x0000             // jne          LBB29_96, $413(%rip)
+	LONG $0xe0e0e0bf; BYTE $0xe0               // movl         $-522133280, %edi
+	WORD $0xf729                               // subl         %esi, %edi
+	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
+	WORD $0xfb21                               // andl         %edi, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x0186850f; WORD $0x0000             // jne          LBB29_96, $390(%rip)
+	WORD $0xca0f                               // bswapl       %edx
+	WORD $0xd689                               // movl         %edx, %esi
+	WORD $0xeec1; BYTE $0x04                   // shrl         $4, %esi
+	WORD $0xd6f7                               // notl         %esi
+	LONG $0x0101e681; WORD $0x0101             // andl         $16843009, %esi
+	WORD $0x348d; BYTE $0xf6                   // leal         (%rsi,%rsi,8), %esi
+	LONG $0x0f0fe281; WORD $0x0f0f             // andl         $252645135, %edx
+	WORD $0xf201                               // addl         %esi, %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xebc1; BYTE $0x04                   // shrl         $4, %ebx
+	WORD $0xd309                               // orl          %edx, %ebx
+	WORD $0xda89                               // movl         %ebx, %edx
+	LONG $0x0000e281; WORD $0x00fc             // andl         $16515072, %edx
+	LONG $0x0000fa81; WORD $0x00dc             // cmpl         $14417920, %edx
+	LONG $0x0174850f; WORD $0x0000             // jne          LBB29_95, $372(%rip)
+	WORD $0xd889                               // movl         %ebx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xd3                   // movzbl       %bl, %edx
+	WORD $0xc209                               // orl          %eax, %edx
+	WORD $0xe1c1; BYTE $0x0a                   // shll         $10, %ecx
+	WORD $0x048d; BYTE $0x0a                   // leal         (%rdx,%rcx), %eax
+	WORD $0xd101                               // addl         %edx, %ecx
+	LONG $0x2400c181; WORD $0xfca0             // addl         $-56613888, %ecx
+	WORD $0xca89                               // movl         %ecx, %edx
+	WORD $0xeac1; BYTE $0x12                   // shrl         $18, %edx
+	WORD $0xca80; BYTE $0xf0                   // orb          $-16, %dl
+	WORD $0x5588; BYTE $0xd0                   // movb         %dl, $-48(%rbp)
+	WORD $0xce89                               // movl         %ecx, %esi
+	WORD $0xeec1; BYTE $0x0c                   // shrl         $12, %esi
+	LONG $0x3fe68040                           // andb         $63, %sil
+	LONG $0x80ce8040                           // orb          $-128, %sil
+	LONG $0xd1758840                           // movb         %sil, $-47(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd2                   // movb         %cl, $-46(%rbp)
+	WORD $0x3f24                               // andb         $63, %al
+	WORD $0x800c                               // orb          $-128, %al
+	WORD $0x4588; BYTE $0xd3                   // movb         %al, $-45(%rbp)
+	LONG $0x0cc28349                           // addq         $12, %r10
+	LONG $0x000004bb; BYTE $0x00               // movl         $4, %ebx
+	LONG $0xc06d8b4c                           // movq         $-64(%rbp), %r13
+	LONG $0x2b048d48                           // leaq         (%rbx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xc85d394c                           // cmpq         %r11, $-56(%rbp)
+	LONG $0xfe41820f; WORD $0xffff             // jb           LBB29_54, $-447(%rip)
+
+LBB29_62:
+	LONG $0xd04d8d48 // leaq         $-48(%rbp), %rcx
+
+LBB29_63:
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x0033850f; WORD $0x0000 // jne          LBB29_81, $51(%rip)
+
+LBB29_64:
+	WORD $0x394d; BYTE $0xca       // cmpq         %r9, %r10
+	LONG $0x0013830f; WORD $0x0000 // jae          LBB29_79, $19(%rip)
+	LONG $0xc85d394c               // cmpq         %r11, $-56(%rbp)
+	LONG $0xfc8a820f; WORD $0xffff // jb           LBB29_36, $-886(%rip)
+	LONG $0x000004e9; BYTE $0x00   // jmp          LBB29_79, $4(%rip)
+
+LBB29_78:
+	LONG $0xc06d8b4c // movq         $-64(%rbp), %r13
+
+LBB29_79:
+	WORD $0x314d; BYTE $0xca     // xorq         %r9, %r10
+	LONG $0xc8458b48             // movq         $-56(%rbp), %rax
+	WORD $0x314c; BYTE $0xd8     // xorq         %r11, %rax
+	WORD $0xdb31                 // xorl         %ebx, %ebx
+	WORD $0x094c; BYTE $0xd0     // orq          %r10, %rax
+	WORD $0x940f; BYTE $0xc3     // sete         %bl
+	LONG $0xfffbeee9; BYTE $0xff // jmp          LBB29_31, $-1042(%rip)
+
+LBB29_81:
+	WORD $0xdb31                 // xorl         %ebx, %ebx
+	LONG $0xfffbe7e9; BYTE $0xff // jmp          LBB29_31, $-1049(%rip)
+
+	// .p2align 4, 0x90
+LBB29_82:
+	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
+	LONG $0x0068850f; WORD $0x0000 // jne          LBB29_89, $104(%rip)
+	WORD $0x5b3c                   // cmpb         $91, %al
+	LONG $0x0060850f; WORD $0x0000 // jne          LBB29_89, $96(%rip)
+	LONG $0x08458b49               // movq         $8(%r13), %rax
+	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
+	LONG $0x01c38348               // addq         $1, %rbx
+	LONG $0x90909090               // .p2align 4, 0x90
+
+LBB29_85:
+	LONG $0xffc38348               // addq         $-1, %rbx
+	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
+	LONG $0x00238e0f; WORD $0x0000 // jle          LBB29_87, $35(%rip)
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xffedf8e8; BYTE $0xff   // callq        _skip_one_fast, $-4616(%rip)
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
+	LONG $0xffc8dde8; BYTE $0xff   // callq        _advance_ns, $-14115(%rip)
+	WORD $0x2c3c                   // cmpb         $44, %al
+	LONG $0xffd5840f; WORD $0xffff // je           LBB29_85, $-43(%rip)
+	LONG $0x000021e9; BYTE $0x00   // jmp          LBB29_89, $33(%rip)
+
+	// .p2align 4, 0x90
+LBB29_87:
+	LONG $0x10c58349               // addq         $16, %r13
+	LONG $0xb0458b48               // movq         $-80(%rbp), %rax
+	WORD $0x3949; BYTE $0xc5       // cmpq         %rax, %r13
+	LONG $0xf961850f; WORD $0xffff // jne          LBB29_2, $-1695(%rip)
+
+LBB29_88:
+	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6     // movq         %r14, %rsi
+	LONG $0xffedc4e8; BYTE $0xff // callq        _skip_one_fast, $-4668(%rip)
+	LONG $0x00000be9; BYTE $0x00 // jmp          LBB29_90, $11(%rip)
+
+LBB29_89:
+	LONG $0xff068349                           // addq         $-1, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_90:
+	LONG $0x28c48348 // addq         $40, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB29_91:
+	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB29_90, $-35(%rip)
+
+LBB29_96:
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000017e9; BYTE $0x00               // jmp          LBB29_95, $23(%rip)
+
+LBB29_92:
+	LONG $0x01c28349                           // addq         $1, %r10
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB29_94, $4(%rip)
+
+LBB29_93:
+	LONG $0x01c28349 // addq         $1, %r10
+
+LBB29_94:
+	WORD $0x894d; BYTE $0xd7 // movq         %r10, %r15
+
+LBB29_95:
+	WORD $0x294d; BYTE $0xc7                                                     // subq         %r8, %r15
+	WORD $0x894d; BYTE $0x3e                                                     // movq         %r15, (%r14)
+	LONG $0xffffafe9; BYTE $0xff                                                 // jmp          LBB29_90, $-81(%rip)
+	QUAD $0x0000000000000000; QUAD $0x0000000000000000; WORD $0x0000; BYTE $0x00 // .p2align 5, 0x00
+
+LCPI30_0:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 
 	// .p2align 4, 0x00
-LCPI28_1:
+LCPI30_1:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 
 	// .p2align 4, 0x90
@@ -8152,34 +9362,34 @@ _f32toa:
 	WORD $0xe9c1; BYTE $0x17                   // shrl         $23, %ecx
 	WORD $0xb60f; BYTE $0xd1                   // movzbl       %cl, %edx
 	LONG $0x00fffa81; WORD $0x0000             // cmpl         $255, %edx
-	LONG $0x0e3f840f; WORD $0x0000             // je           LBB28_1, $3647(%rip)
+	LONG $0x0e3f840f; WORD $0x0000             // je           LBB30_1, $3647(%rip)
 	WORD $0x07c6; BYTE $0x2d                   // movb         $45, (%rdi)
 	WORD $0x8941; BYTE $0xc2                   // movl         %eax, %r10d
 	LONG $0x1feac141                           // shrl         $31, %r10d
 	LONG $0x170c8d4e                           // leaq         (%rdi,%r10), %r9
 	LONG $0xffffffa9; BYTE $0x7f               // testl        $2147483647, %eax
-	LONG $0x01a9840f; WORD $0x0000             // je           LBB28_3, $425(%rip)
+	LONG $0x01a9840f; WORD $0x0000             // je           LBB30_3, $425(%rip)
 	LONG $0x7fffff25; BYTE $0x00               // andl         $8388607, %eax
 	WORD $0xd285                               // testl        %edx, %edx
-	LONG $0x0e20840f; WORD $0x0000             // je           LBB28_5, $3616(%rip)
+	LONG $0x0e20840f; WORD $0x0000             // je           LBB30_5, $3616(%rip)
 	LONG $0x00988d44; WORD $0x8000; BYTE $0x00 // leal         $8388608(%rax), %r11d
 	LONG $0x6a828d44; WORD $0xffff; BYTE $0xff // leal         $-150(%rdx), %r8d
 	WORD $0x4a8d; BYTE $0x81                   // leal         $-127(%rdx), %ecx
 	WORD $0xf983; BYTE $0x17                   // cmpl         $23, %ecx
-	LONG $0x001c870f; WORD $0x0000             // ja           LBB28_10, $28(%rip)
+	LONG $0x001c870f; WORD $0x0000             // ja           LBB30_10, $28(%rip)
 	LONG $0x000096b9; BYTE $0x00               // movl         $150, %ecx
 	WORD $0xd129                               // subl         %edx, %ecx
 	LONG $0xffc6c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rsi
 	WORD $0xd348; BYTE $0xe6                   // shlq         %cl, %rsi
 	WORD $0xd6f7                               // notl         %esi
 	WORD $0x8544; BYTE $0xde                   // testl        %r11d, %esi
-	LONG $0x0326840f; WORD $0x0000             // je           LBB28_12, $806(%rip)
+	LONG $0x0326840f; WORD $0x0000             // je           LBB30_12, $806(%rip)
 
-LBB28_10:
+LBB30_10:
 	LONG $0xc84d894c // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948 // movq         %rdi, $-48(%rbp)
 
-LBB28_6:
+LBB30_6:
 	WORD $0x8945; BYTE $0xdf                   // movl         %r11d, %r15d
 	LONG $0x01e78341                           // andl         $1, %r15d
 	WORD $0xc085                               // testl        %eax, %eax
@@ -8204,7 +9414,7 @@ LBB28_6:
 	WORD $0x2944; BYTE $0xf2                   // subl         %r14d, %edx
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xe0d3                               // shll         %cl, %eax
-	LONG $0xc5358d48; WORD $0x00b2; BYTE $0x00 // leaq         $45765(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
+	LONG $0x25358d48; WORD $0x00b6; BYTE $0x00 // leaq         $46629(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
 	LONG $0xd62c8b4c                           // movq         (%rsi,%rdx,8), %r13
 	WORD $0xf749; BYTE $0xe5                   // mulq         %r13
 	WORD $0x8949; BYTE $0xd0                   // movq         %rdx, %r8
@@ -8234,7 +9444,7 @@ LBB28_6:
 	WORD $0x0145; BYTE $0xfc                   // addl         %r15d, %r12d
 	WORD $0x2944; BYTE $0xf9                   // subl         %r15d, %ecx
 	WORD $0xfb83; BYTE $0x28                   // cmpl         $40, %ebx
-	LONG $0x0042820f; WORD $0x0000             // jb           LBB28_31, $66(%rip)
+	LONG $0x0042820f; WORD $0x0000             // jb           LBB30_31, $66(%rip)
 	WORD $0x8944; BYTE $0xc8                   // movl         %r9d, %eax
 	LONG $0xcccccdba; BYTE $0xcc               // movl         $3435973837, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -8251,9 +9461,9 @@ LBB28_6:
 	WORD $0x3948; BYTE $0xfe                   // cmpq         %rdi, %rsi
 	LONG $0xc0960f41                           // setbe        %r8b
 	WORD $0x3845; BYTE $0xc3                   // cmpb         %r8b, %r11b
-	LONG $0x00b7840f; WORD $0x0000             // je           LBB28_8, $183(%rip)
+	LONG $0x00b7840f; WORD $0x0000             // je           LBB30_8, $183(%rip)
 
-LBB28_31:
+LBB30_31:
 	WORD $0x894d; BYTE $0xc8       // movq         %r9, %r8
 	LONG $0x02e8c149               // shrq         $2, %r8
 	WORD $0x8944; BYTE $0xca       // movl         %r9d, %edx
@@ -8264,84 +9474,84 @@ LBB28_31:
 	WORD $0xcf39                   // cmpl         %ecx, %edi
 	WORD $0x960f; BYTE $0xc0       // setbe        %al
 	WORD $0x3040; BYTE $0xf0       // xorb         %sil, %al
-	LONG $0x0048840f; WORD $0x0000 // je           LBB28_32, $72(%rip)
+	LONG $0x0048840f; WORD $0x0000 // je           LBB30_32, $72(%rip)
 	WORD $0xca83; BYTE $0x02       // orl          $2, %edx
 	LONG $0x000001b8; BYTE $0x00   // movl         $1, %eax
 	WORD $0xd339                   // cmpl         %edx, %ebx
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
-	LONG $0x000e870f; WORD $0x0000 // ja           LBB28_35, $14(%rip)
+	LONG $0x000e870f; WORD $0x0000 // ja           LBB30_35, $14(%rip)
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	LONG $0x02e9c041               // shrb         $2, %r9b
 	WORD $0x2041; BYTE $0xc1       // andb         %al, %r9b
 	LONG $0xc1b60f41               // movzbl       %r9b, %eax
 
-LBB28_35:
+LBB30_35:
 	WORD $0x0144; BYTE $0xc0       // addl         %r8d, %eax
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x0030830f; WORD $0x0000 // jae          LBB28_37, $48(%rip)
-	LONG $0x000075e9; BYTE $0x00   // jmp          LBB28_40, $117(%rip)
+	LONG $0x0030830f; WORD $0x0000 // jae          LBB30_37, $48(%rip)
+	LONG $0x000075e9; BYTE $0x00   // jmp          LBB30_40, $117(%rip)
 
-LBB28_3:
+LBB30_3:
 	LONG $0x3001c641             // movb         $48, (%r9)
 	WORD $0x2941; BYTE $0xf9     // subl         %edi, %r9d
 	LONG $0x01c18341             // addl         $1, %r9d
 	WORD $0x8944; BYTE $0xc8     // movl         %r9d, %eax
-	LONG $0x000748e9; BYTE $0x00 // jmp          LBB28_153, $1864(%rip)
+	LONG $0x000748e9; BYTE $0x00 // jmp          LBB30_153, $1864(%rip)
 
-LBB28_32:
+LBB30_32:
 	WORD $0xf939                   // cmpl         %edi, %ecx
 	LONG $0xffd88341               // sbbl         $-1, %r8d
 	WORD $0x8944; BYTE $0xc0       // movl         %r8d, %eax
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x004a820f; WORD $0x0000 // jb           LBB28_40, $74(%rip)
+	LONG $0x004a820f; WORD $0x0000 // jb           LBB30_40, $74(%rip)
 
-LBB28_37:
+LBB30_37:
 	LONG $0x0006bd41; WORD $0x0000 // movl         $6, %r13d
 	LONG $0x0f42403d; BYTE $0x00   // cmpl         $1000000, %eax
-	LONG $0x0077820f; WORD $0x0000 // jb           LBB28_45, $119(%rip)
+	LONG $0x0077820f; WORD $0x0000 // jb           LBB30_45, $119(%rip)
 	LONG $0x0007bd41; WORD $0x0000 // movl         $7, %r13d
 	LONG $0x9896803d; BYTE $0x00   // cmpl         $10000000, %eax
-	LONG $0x0066820f; WORD $0x0000 // jb           LBB28_45, $102(%rip)
+	LONG $0x0066820f; WORD $0x0000 // jb           LBB30_45, $102(%rip)
 	LONG $0xf5e1003d; BYTE $0x05   // cmpl         $100000000, %eax
 	LONG $0x0009bd41; WORD $0x0000 // movl         $9, %r13d
-	LONG $0x000052e9; BYTE $0x00   // jmp          LBB28_44, $82(%rip)
+	LONG $0x000052e9; BYTE $0x00   // jmp          LBB30_44, $82(%rip)
 
-LBB28_8:
+LBB30_8:
 	WORD $0x8844; BYTE $0xc0       // movb         %r8b, %al
 	WORD $0xd001                   // addl         %edx, %eax
 	LONG $0x01c68341               // addl         $1, %r14d
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0xffb6830f; WORD $0xffff // jae          LBB28_37, $-74(%rip)
+	LONG $0xffb6830f; WORD $0xffff // jae          LBB30_37, $-74(%rip)
 
-LBB28_40:
+LBB30_40:
 	LONG $0x0001bd41; WORD $0x0000 // movl         $1, %r13d
 	WORD $0xf883; BYTE $0x0a       // cmpl         $10, %eax
-	LONG $0x002f820f; WORD $0x0000 // jb           LBB28_45, $47(%rip)
+	LONG $0x002f820f; WORD $0x0000 // jb           LBB30_45, $47(%rip)
 	LONG $0x0002bd41; WORD $0x0000 // movl         $2, %r13d
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0x0020820f; WORD $0x0000 // jb           LBB28_45, $32(%rip)
+	LONG $0x0020820f; WORD $0x0000 // jb           LBB30_45, $32(%rip)
 	LONG $0x0003bd41; WORD $0x0000 // movl         $3, %r13d
 	LONG $0x0003e83d; BYTE $0x00   // cmpl         $1000, %eax
-	LONG $0x000f820f; WORD $0x0000 // jb           LBB28_45, $15(%rip)
+	LONG $0x000f820f; WORD $0x0000 // jb           LBB30_45, $15(%rip)
 	LONG $0x0027103d; BYTE $0x00   // cmpl         $10000, %eax
 	LONG $0x0005bd41; WORD $0x0000 // movl         $5, %r13d
 
-LBB28_44:
+LBB30_44:
 	LONG $0x00dd8341 // sbbl         $0, %r13d
 
-LBB28_45:
+LBB30_45:
 	LONG $0x2e0c8d47                           // leal         (%r14,%r13), %r9d
 	LONG $0x2e0c8d43                           // leal         (%r14,%r13), %ecx
 	WORD $0xc183; BYTE $0x05                   // addl         $5, %ecx
 	WORD $0xf983; BYTE $0x1b                   // cmpl         $27, %ecx
-	LONG $0x006d820f; WORD $0x0000             // jb           LBB28_70, $109(%rip)
+	LONG $0x006d820f; WORD $0x0000             // jb           LBB30_70, $109(%rip)
 	WORD $0x8944; BYTE $0xea                   // movl         %r13d, %edx
 	LONG $0x140c8d49                           // leaq         (%r12,%rdx), %rcx
 	LONG $0x01c18348                           // addq         $1, %rcx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x00ca820f; WORD $0x0000             // jb           LBB28_47, $202(%rip)
+	LONG $0x00ca820f; WORD $0x0000             // jb           LBB30_47, $202(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdeaf0f48                           // imulq        %rsi, %rbx
@@ -8349,27 +9559,27 @@ LBB28_45:
 	LONG $0xf0c36944; WORD $0xffd8; BYTE $0xff // imull        $-10000, %ebx, %r8d
 	WORD $0x0141; BYTE $0xc0                   // addl         %eax, %r8d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0x0348840f; WORD $0x0000             // je           LBB28_49, $840(%rip)
+	LONG $0x0348840f; WORD $0x0000             // je           LBB30_49, $840(%rip)
 	WORD $0x8944; BYTE $0xc0                   // movl         %r8d, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
-	LONG $0x2a358d48; WORD $0x003d; BYTE $0x00 // leaq         $15658(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x8a358d48; WORD $0x0040; BYTE $0x00 // leaq         $16522(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x3cb70f42; BYTE $0x46               // movzwl       (%rsi,%r8,2), %edi
 	LONG $0xfe798966                           // movw         %di, $-2(%rcx)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0xfc418966                           // movw         %ax, $-4(%rcx)
 	WORD $0x3145; BYTE $0xc0                   // xorl         %r8d, %r8d
-	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB28_51, $794(%rip)
+	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB30_51, $794(%rip)
 
-LBB28_70:
+LBB30_70:
 	WORD $0x8945; BYTE $0xe8                   // movl         %r13d, %r8d
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
-	LONG $0x0120880f; WORD $0x0000             // js           LBB28_71, $288(%rip)
+	LONG $0x0120880f; WORD $0x0000             // js           LBB30_71, $288(%rip)
 	LONG $0x04148d4b                           // leaq         (%r12,%r8), %rdx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x017b820f; WORD $0x0000             // jb           LBB28_124, $379(%rip)
+	LONG $0x017b820f; WORD $0x0000             // jb           LBB30_124, $379(%rip)
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0xb71759be; BYTE $0xd1               // movl         $3518437209, %esi
 	LONG $0xf1af0f48                           // imulq        %rcx, %rsi
@@ -8380,7 +9590,7 @@ LBB28_70:
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf86b; BYTE $0x64                   // imull        $100, %eax, %edi
 	WORD $0xf929                               // subl         %edi, %ecx
-	LONG $0xc83d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15560(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0x283d8d48; WORD $0x0040; BYTE $0x00 // leaq         $16424(%rip), %rdi  /* _Digits(%rip) */
 	LONG $0x4f0cb70f                           // movzwl       (%rdi,%rcx,2), %ecx
 	LONG $0xfe4a8966                           // movw         %cx, $-2(%rdx)
 	LONG $0xfc4a8d48                           // leaq         $-4(%rdx), %rcx
@@ -8389,41 +9599,41 @@ LBB28_70:
 	WORD $0xf089                               // movl         %esi, %eax
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64                   // cmpl         $100, %eax
-	LONG $0x013a830f; WORD $0x0000             // jae          LBB28_128, $314(%rip)
+	LONG $0x013a830f; WORD $0x0000             // jae          LBB30_128, $314(%rip)
 
-LBB28_127:
+LBB30_127:
 	WORD $0xc389                 // movl         %eax, %ebx
-	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB28_130, $364(%rip)
+	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB30_130, $364(%rip)
 
-LBB28_47:
+LBB30_47:
 	WORD $0x3145; BYTE $0xc0       // xorl         %r8d, %r8d
 	WORD $0xc389                   // movl         %eax, %ebx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x02a2830f; WORD $0x0000 // jae          LBB28_54, $674(%rip)
+	LONG $0x02a2830f; WORD $0x0000 // jae          LBB30_54, $674(%rip)
 
-LBB28_53:
+LBB30_53:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB28_56, $740(%rip)
+	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB30_56, $740(%rip)
 
-LBB28_12:
+LBB30_12:
 	WORD $0xd341; BYTE $0xeb                   // shrl         %cl, %r11d
 	LONG $0xa0fb8141; WORD $0x0186; BYTE $0x00 // cmpl         $100000, %r11d
-	LONG $0x01c0820f; WORD $0x0000             // jb           LBB28_18, $448(%rip)
+	LONG $0x01c0820f; WORD $0x0000             // jb           LBB30_18, $448(%rip)
 	LONG $0x000006b9; BYTE $0x00               // movl         $6, %ecx
 	LONG $0x40fb8141; WORD $0x0f42; BYTE $0x00 // cmpl         $1000000, %r11d
-	LONG $0x0022820f; WORD $0x0000             // jb           LBB28_16, $34(%rip)
+	LONG $0x0022820f; WORD $0x0000             // jb           LBB30_16, $34(%rip)
 	LONG $0x000007b9; BYTE $0x00               // movl         $7, %ecx
 	LONG $0x80fb8141; WORD $0x9896; BYTE $0x00 // cmpl         $10000000, %r11d
-	LONG $0x0010820f; WORD $0x0000             // jb           LBB28_16, $16(%rip)
+	LONG $0x0010820f; WORD $0x0000             // jb           LBB30_16, $16(%rip)
 	LONG $0x00fb8141; WORD $0xf5e1; BYTE $0x05 // cmpl         $100000000, %r11d
 	LONG $0x000009b9; BYTE $0x00               // movl         $9, %ecx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 
-LBB28_16:
+LBB30_16:
 	WORD $0x014c; BYTE $0xc9 // addq         %r9, %rcx
 
-LBB28_17:
+LBB30_17:
 	WORD $0x8944; BYTE $0xd8                   // movl         %r11d, %eax
 	LONG $0xb71759ba; BYTE $0xd1               // movl         $3518437209, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -8434,7 +9644,7 @@ LBB28_17:
 	LONG $0x25eec148                           // shrq         $37, %rsi
 	WORD $0xde6b; BYTE $0x64                   // imull        $100, %esi, %ebx
 	WORD $0xd829                               // subl         %ebx, %eax
-	LONG $0x0e1d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15374(%rip), %rbx  /* _Digits(%rip) */
+	LONG $0x6e1d8d48; WORD $0x003f; BYTE $0x00 // leaq         $16238(%rip), %rbx  /* _Digits(%rip) */
 	LONG $0x4304b70f                           // movzwl       (%rbx,%rax,2), %eax
 	LONG $0xfe418966                           // movw         %ax, $-2(%rcx)
 	LONG $0x7304b70f                           // movzwl       (%rbx,%rsi,2), %eax
@@ -8443,22 +9653,22 @@ LBB28_17:
 	LONG $0xfcc18348                           // addq         $-4, %rcx
 	WORD $0x8941; BYTE $0xd3                   // movl         %edx, %r11d
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0175830f; WORD $0x0000             // jae          LBB28_25, $373(%rip)
-	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB28_27, $439(%rip)
+	LONG $0x0175830f; WORD $0x0000             // jae          LBB30_25, $373(%rip)
+	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB30_27, $439(%rip)
 
-LBB28_71:
+LBB30_71:
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x062e8f0f; WORD $0x0000             // jg           LBB28_84, $1582(%rip)
+	LONG $0x062e8f0f; WORD $0x0000             // jg           LBB30_84, $1582(%rip)
 	LONG $0x04c74166; WORD $0x3024; BYTE $0x2e // movw         $11824, (%r12)
 	LONG $0x02c48349                           // addq         $2, %r12
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x061a890f; WORD $0x0000             // jns          LBB28_84, $1562(%rip)
+	LONG $0x061a890f; WORD $0x0000             // jns          LBB30_84, $1562(%rip)
 	WORD $0x8945; BYTE $0xeb                   // movl         %r13d, %r11d
 	WORD $0xf741; BYTE $0xd3                   // notl         %r11d
 	WORD $0x2945; BYTE $0xf3                   // subl         %r14d, %r11d
 	WORD $0xc931                               // xorl         %ecx, %ecx
 	LONG $0x7ffb8341                           // cmpl         $127, %r11d
-	LONG $0x05e4820f; WORD $0x0000             // jb           LBB28_82, $1508(%rip)
+	LONG $0x05e4820f; WORD $0x0000             // jb           LBB30_82, $1508(%rip)
 	WORD $0x894c; BYTE $0xe7                   // movq         %r12, %rdi
 	LONG $0x01c38349                           // addq         $1, %r11
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
@@ -8470,22 +9680,22 @@ LBB28_71:
 	WORD $0x8945; BYTE $0xe7                   // movl         %r12d, %r15d
 	LONG $0x03e78341                           // andl         $3, %r15d
 	LONG $0x80fa8148; WORD $0x0001; BYTE $0x00 // cmpq         $384, %rdx
-	LONG $0x04aa830f; WORD $0x0000             // jae          LBB28_76, $1194(%rip)
+	LONG $0x04aa830f; WORD $0x0000             // jae          LBB30_76, $1194(%rip)
 	WORD $0xd231                               // xorl         %edx, %edx
-	LONG $0x000554e9; BYTE $0x00               // jmp          LBB28_78, $1364(%rip)
+	LONG $0x000554e9; BYTE $0x00               // jmp          LBB30_78, $1364(%rip)
 
-LBB28_124:
+LBB30_124:
 	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0xfec6820f; WORD $0xffff // jb           LBB28_127, $-314(%rip)
+	LONG $0xfec6820f; WORD $0xffff // jb           LBB30_127, $-314(%rip)
 
-LBB28_128:
+LBB30_128:
 	LONG $0xffc18348                           // addq         $-1, %rcx
-	LONG $0x601d8d4c; WORD $0x003b; BYTE $0x00 // leaq         $15200(%rip), %r11  /* _Digits(%rip) */
+	LONG $0xc01d8d4c; WORD $0x003e; BYTE $0x00 // leaq         $16064(%rip), %r11  /* _Digits(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_129:
+LBB30_129:
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0x1fde6948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rsi, %rbx
 	LONG $0x25ebc148                           // shrq         $37, %rbx
@@ -8497,29 +9707,29 @@ LBB28_129:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x00270f3d; BYTE $0x00               // cmpl         $9999, %eax
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_129, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_129, $-46(%rip)
 
-LBB28_130:
+LBB30_130:
 	WORD $0x634d; BYTE $0xf1                   // movslq       %r9d, %r14
 	WORD $0xfb83; BYTE $0x0a                   // cmpl         $10, %ebx
-	LONG $0x0023820f; WORD $0x0000             // jb           LBB28_132, $35(%rip)
+	LONG $0x0023820f; WORD $0x0000             // jb           LBB30_132, $35(%rip)
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0x1d0d8d48; WORD $0x003b; BYTE $0x00 // leaq         $15133(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x7d0d8d48; WORD $0x003e; BYTE $0x00 // leaq         $15997(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
 	WORD $0x014d; BYTE $0xf4                   // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0                   // cmpq         %r14, %r8
-	LONG $0x00188c0f; WORD $0x0000             // jl           LBB28_134, $24(%rip)
-	LONG $0x000413e9; BYTE $0x00               // jmp          LBB28_151, $1043(%rip)
+	LONG $0x00188c0f; WORD $0x0000             // jl           LBB30_134, $24(%rip)
+	LONG $0x000413e9; BYTE $0x00               // jmp          LBB30_151, $1043(%rip)
 
-LBB28_132:
+LBB30_132:
 	WORD $0xc380; BYTE $0x30       // addb         $48, %bl
 	LONG $0x241c8841               // movb         %bl, (%r12)
 	WORD $0x014d; BYTE $0xf4       // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0       // cmpq         %r14, %r8
-	LONG $0x04008d0f; WORD $0x0000 // jge          LBB28_151, $1024(%rip)
+	LONG $0x04008d0f; WORD $0x0000 // jge          LBB30_151, $1024(%rip)
 
-LBB28_134:
+LBB30_134:
 	LONG $0x2a048d4b                           // leaq         (%r10,%r13), %rax
 	LONG $0x000c8d49                           // leaq         (%r8,%rax), %rcx
 	LONG $0x01c18348                           // addq         $1, %rcx
@@ -8529,35 +9739,35 @@ LBB28_134:
 	WORD $0x014c; BYTE $0xc0                   // addq         %r8, %rax
 	WORD $0x2949; BYTE $0xc6                   // subq         %rax, %r14
 	LONG $0x10fe8349                           // cmpq         $16, %r14
-	LONG $0x03ca820f; WORD $0x0000             // jb           LBB28_150, $970(%rip)
+	LONG $0x03ca820f; WORD $0x0000             // jb           LBB30_150, $970(%rip)
 	LONG $0x80fe8149; WORD $0x0000; BYTE $0x00 // cmpq         $128, %r14
-	LONG $0x01ff830f; WORD $0x0000             // jae          LBB28_140, $511(%rip)
+	LONG $0x01ff830f; WORD $0x0000             // jae          LBB30_140, $511(%rip)
 	WORD $0x3145; BYTE $0xc9                   // xorl         %r9d, %r9d
-	LONG $0x00033ce9; BYTE $0x00               // jmp          LBB28_137, $828(%rip)
+	LONG $0x00033ce9; BYTE $0x00               // jmp          LBB30_137, $828(%rip)
 
-LBB28_18:
+LBB30_18:
 	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0021820f; WORD $0x0000             // jb           LBB28_21, $33(%rip)
+	LONG $0x0021820f; WORD $0x0000             // jb           LBB30_21, $33(%rip)
 	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0012820f; WORD $0x0000             // jb           LBB28_21, $18(%rip)
+	LONG $0x0012820f; WORD $0x0000             // jb           LBB30_21, $18(%rip)
 	LONG $0x000003b8; BYTE $0x00               // movl         $3, %eax
 	LONG $0xe8fb8141; WORD $0x0003; BYTE $0x00 // cmpl         $1000, %r11d
-	LONG $0x0356830f; WORD $0x0000             // jae          LBB28_23, $854(%rip)
+	LONG $0x0356830f; WORD $0x0000             // jae          LBB30_23, $854(%rip)
 
-LBB28_21:
+LBB30_21:
 	WORD $0x014c; BYTE $0xc8       // addq         %r9, %rax
 	WORD $0x8948; BYTE $0xc1       // movq         %rax, %rcx
 	LONG $0x64fb8341               // cmpl         $100, %r11d
-	LONG $0x0047820f; WORD $0x0000 // jb           LBB28_27, $71(%rip)
+	LONG $0x0047820f; WORD $0x0000 // jb           LBB30_27, $71(%rip)
 
-LBB28_25:
+LBB30_25:
 	LONG $0xffc18348                           // addq         $-1, %rcx
-	LONG $0x6a058d4c; WORD $0x003a; BYTE $0x00 // leaq         $14954(%rip), %r8  /* _Digits(%rip) */
+	LONG $0xca058d4c; WORD $0x003d; BYTE $0x00 // leaq         $15818(%rip), %r8  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; WORD $0x9090     // .p2align 4, 0x90
 
-LBB28_26:
+LBB30_26:
 	WORD $0x8944; BYTE $0xde                   // movl         %r11d, %esi
 	WORD $0x8944; BYTE $0xdb                   // movl         %r11d, %ebx
 	LONG $0x1fdb694c; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rbx, %r11
@@ -8569,38 +9779,38 @@ LBB28_26:
 	LONG $0xff518966                           // movw         %dx, $-1(%rcx)
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffe81; WORD $0x0000             // cmpl         $9999, %esi
-	LONG $0xffce870f; WORD $0xffff             // ja           LBB28_26, $-50(%rip)
+	LONG $0xffce870f; WORD $0xffff             // ja           LBB30_26, $-50(%rip)
 
-LBB28_27:
+LBB30_27:
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0019820f; WORD $0x0000             // jb           LBB28_29, $25(%rip)
+	LONG $0x0019820f; WORD $0x0000             // jb           LBB30_29, $25(%rip)
 	WORD $0x8944; BYTE $0xd9                   // movl         %r11d, %ecx
-	LONG $0x1a158d48; WORD $0x003a; BYTE $0x00 // leaq         $14874(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x7a158d48; WORD $0x003d; BYTE $0x00 // leaq         $15738(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x09894166                           // movw         %cx, (%r9)
 	WORD $0xf829                               // subl         %edi, %eax
-	LONG $0x000321e9; BYTE $0x00               // jmp          LBB28_153, $801(%rip)
+	LONG $0x000321e9; BYTE $0x00               // jmp          LBB30_153, $801(%rip)
 
-LBB28_29:
+LBB30_29:
 	LONG $0x30c38041             // addb         $48, %r11b
 	WORD $0x8845; BYTE $0x19     // movb         %r11b, (%r9)
 	WORD $0xf829                 // subl         %edi, %eax
-	LONG $0x000313e9; BYTE $0x00 // jmp          LBB28_153, $787(%rip)
+	LONG $0x000313e9; BYTE $0x00 // jmp          LBB30_153, $787(%rip)
 
-LBB28_49:
+LBB30_49:
 	LONG $0x0004b841; WORD $0x0000 // movl         $4, %r8d
 
-LBB28_51:
+LBB30_51:
 	LONG $0xfcc18348               // addq         $-4, %rcx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xfd5e820f; WORD $0xffff // jb           LBB28_53, $-674(%rip)
+	LONG $0xfd5e820f; WORD $0xffff // jb           LBB30_53, $-674(%rip)
 
-LBB28_54:
+LBB30_54:
 	LONG $0xffc18348                                                     // addq         $-1, %rcx
-	LONG $0xdf1d8d4c; WORD $0x0039; BYTE $0x00                           // leaq         $14815(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x3f1d8d4c; WORD $0x003d; BYTE $0x00                           // leaq         $15679(%rip), %r11  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_55:
+LBB30_55:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -8612,83 +9822,83 @@ LBB28_55:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd1870f; WORD $0xffff             // ja           LBB28_55, $-47(%rip)
+	LONG $0xffd1870f; WORD $0xffff             // ja           LBB30_55, $-47(%rip)
 
-LBB28_56:
+LBB30_56:
 	LONG $0x244c8d49; BYTE $0x01               // leaq         $1(%r12), %rcx
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001f820f; WORD $0x0000             // jb           LBB28_58, $31(%rip)
+	LONG $0x001f820f; WORD $0x0000             // jb           LBB30_58, $31(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
-	LONG $0x8a3d8d48; WORD $0x0039; BYTE $0x00 // leaq         $14730(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0xea3d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15594(%rip), %rdi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x77                   // movb         (%rdi,%rsi,2), %al
 	LONG $0x01775c8a                           // movb         $1(%rdi,%rsi,2), %bl
 	LONG $0x24448841; BYTE $0x01               // movb         %al, $1(%r12)
 	LONG $0x245c8841; BYTE $0x02               // movb         %bl, $2(%r12)
-	LONG $0x000004e9; BYTE $0x00               // jmp          LBB28_59, $4(%rip)
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB30_59, $4(%rip)
 
-LBB28_58:
+LBB30_58:
 	WORD $0x3004 // addb         $48, %al
 	WORD $0x0188 // movb         %al, (%rcx)
 
-LBB28_59:
+LBB30_59:
 	WORD $0x294d; BYTE $0xc2     // subq         %r8, %r10
 	WORD $0x014d; BYTE $0xea     // addq         %r13, %r10
 	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
 	WORD $0x294c; BYTE $0xc3     // subq         %r8, %rbx
 	WORD $0x9090                 // .p2align 4, 0x90
 
-LBB28_60:
+LBB30_60:
 	LONG $0xffc38348               // addq         $-1, %rbx
 	LONG $0x123c8041; BYTE $0x30   // cmpb         $48, (%r10,%rdx)
 	LONG $0xff528d4d               // leaq         $-1(%r10), %r10
-	LONG $0xffed840f; WORD $0xffff // je           LBB28_60, $-19(%rip)
+	LONG $0xffed840f; WORD $0xffff // je           LBB30_60, $-19(%rip)
 	LONG $0x24048841               // movb         %al, (%r12)
 	WORD $0x0148; BYTE $0xd3       // addq         %rdx, %rbx
 	LONG $0x02fb8348               // cmpq         $2, %rbx
-	LONG $0x00468c0f; WORD $0x0000 // jl           LBB28_62, $70(%rip)
+	LONG $0x00468c0f; WORD $0x0000 // jl           LBB30_62, $70(%rip)
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x02c08348               // addq         $2, %rax
 	WORD $0x01c6; BYTE $0x2e       // movb         $46, (%rcx)
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00438e0f; WORD $0x0000 // jle          LBB28_65, $67(%rip)
+	LONG $0x00438e0f; WORD $0x0000 // jle          LBB30_65, $67(%rip)
 
-LBB28_66:
+LBB30_66:
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0x2b0140c6               // movb         $43, $1(%rax)
 	WORD $0x8944; BYTE $0xc9       // movl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0x00448c0f; WORD $0x0000 // jl           LBB28_69, $68(%rip)
+	LONG $0x00448c0f; WORD $0x0000 // jl           LBB30_69, $68(%rip)
 
-LBB28_68:
+LBB30_68:
 	WORD $0x6348; BYTE $0xc9                   // movslq       %ecx, %rcx
-	LONG $0x07158d48; WORD $0x0039; BYTE $0x00 // leaq         $14599(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x67158d48; WORD $0x003c; BYTE $0x00 // leaq         $15463(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x02488966                           // movw         %cx, $2(%rax)
 	LONG $0x04c08348                           // addq         $4, %rax
-	LONG $0x000209e9; BYTE $0x00               // jmp          LBB28_152, $521(%rip)
+	LONG $0x000209e9; BYTE $0x00               // jmp          LBB30_152, $521(%rip)
 
-LBB28_62:
+LBB30_62:
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB28_66, $-67(%rip)
+	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB30_66, $-67(%rip)
 
-LBB28_65:
+LBB30_65:
 	LONG $0x2d0140c6               // movb         $45, $1(%rax)
 	LONG $0x000001b9; BYTE $0x00   // movl         $1, %ecx
 	WORD $0x2944; BYTE $0xc9       // subl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB28_68, $-68(%rip)
+	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB30_68, $-68(%rip)
 
-LBB28_69:
+LBB30_69:
 	WORD $0xc180; BYTE $0x30     // addb         $48, %cl
 	WORD $0x4888; BYTE $0x02     // movb         %cl, $2(%rax)
 	LONG $0x03c08348             // addq         $3, %rax
-	LONG $0x0001d1e9; BYTE $0x00 // jmp          LBB28_152, $465(%rip)
+	LONG $0x0001d1e9; BYTE $0x00 // jmp          LBB30_152, $465(%rip)
 
-LBB28_140:
+LBB30_140:
 	WORD $0x894d; BYTE $0xf1       // movq         %r14, %r9
 	LONG $0x80e18349               // andq         $-128, %r9
 	LONG $0x80418d49               // leaq         $-128(%r9), %rax
@@ -8698,21 +9908,21 @@ LBB28_140:
 	WORD $0x8941; BYTE $0xdb       // movl         %ebx, %r11d
 	LONG $0x03e38341               // andl         $3, %r11d
 	LONG $0x01803d48; WORD $0x0000 // cmpq         $384, %rax
-	LONG $0x0007830f; WORD $0x0000 // jae          LBB28_142, $7(%rip)
+	LONG $0x0007830f; WORD $0x0000 // jae          LBB30_142, $7(%rip)
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	LONG $0x0000afe9; BYTE $0x00   // jmp          LBB28_144, $175(%rip)
+	LONG $0x0000afe9; BYTE $0x00   // jmp          LBB30_144, $175(%rip)
 
-LBB28_142:
+LBB30_142:
 	LONG $0x02048d4b               // leaq         (%r10,%r8), %rax
 	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
 	LONG $0x01e00548; WORD $0x0000 // addq         $480, %rax
 	LONG $0xfce38348               // andq         $-4, %rbx
 	WORD $0xf748; BYTE $0xdb       // negq         %rbx
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	QUAD $0xfffff810056ffdc5       // vmovdqa      $-2032(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff810056ffdc5       // vmovdqa      $-2032(%rip), %ymm0  /* LCPI30_0(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_143:
+LBB30_143:
 	QUAD $0xfffe2008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-480(%rax,%rcx)
 	QUAD $0xfffe4008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-448(%rax,%rcx)
 	QUAD $0xfffe6008847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-416(%rax,%rcx)
@@ -8731,36 +9941,36 @@ LBB28_143:
 	LONG $0x047ffec5; BYTE $0x08               // vmovdqu      %ymm0, (%rax,%rcx)
 	LONG $0x00c18148; WORD $0x0002; BYTE $0x00 // addq         $512, %rcx
 	LONG $0x04c38348                           // addq         $4, %rbx
-	LONG $0xff6f850f; WORD $0xffff             // jne          LBB28_143, $-145(%rip)
+	LONG $0xff6f850f; WORD $0xffff             // jne          LBB30_143, $-145(%rip)
 
-LBB28_144:
+LBB30_144:
 	WORD $0x854d; BYTE $0xdb               // testq        %r11, %r11
-	LONG $0x004a840f; WORD $0x0000         // je           LBB28_147, $74(%rip)
+	LONG $0x004a840f; WORD $0x0000         // je           LBB30_147, $74(%rip)
 	WORD $0x014c; BYTE $0xd1               // addq         %r10, %rcx
 	WORD $0x014c; BYTE $0xc1               // addq         %r8, %rcx
 	LONG $0x29048d4a                       // leaq         (%rcx,%r13), %rax
 	LONG $0x60c08348                       // addq         $96, %rax
 	LONG $0x07e3c149                       // shlq         $7, %r11
 	WORD $0xc931                           // xorl         %ecx, %ecx
-	QUAD $0xfffff75a056ffdc5               // vmovdqa      $-2214(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff75a056ffdc5               // vmovdqa      $-2214(%rip), %ymm0  /* LCPI30_0(%rip) */
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_146:
+LBB30_146:
 	LONG $0x447ffec5; WORD $0xa008 // vmovdqu      %ymm0, $-96(%rax,%rcx)
 	LONG $0x447ffec5; WORD $0xc008 // vmovdqu      %ymm0, $-64(%rax,%rcx)
 	LONG $0x447ffec5; WORD $0xe008 // vmovdqu      %ymm0, $-32(%rax,%rcx)
 	LONG $0x047ffec5; BYTE $0x08   // vmovdqu      %ymm0, (%rax,%rcx)
 	LONG $0x80e98348               // subq         $-128, %rcx
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0xffdc850f; WORD $0xffff // jne          LBB28_146, $-36(%rip)
+	LONG $0xffdc850f; WORD $0xffff // jne          LBB30_146, $-36(%rip)
 
-LBB28_147:
+LBB30_147:
 	WORD $0x394d; BYTE $0xce       // cmpq         %r9, %r14
-	LONG $0x0093840f; WORD $0x0000 // je           LBB28_151, $147(%rip)
+	LONG $0x0093840f; WORD $0x0000 // je           LBB30_151, $147(%rip)
 	LONG $0x70c6f641               // testb        $112, %r14b
-	LONG $0x0071840f; WORD $0x0000 // je           LBB28_149, $113(%rip)
+	LONG $0x0071840f; WORD $0x0000 // je           LBB30_149, $113(%rip)
 
-LBB28_137:
+LBB30_137:
 	WORD $0x894c; BYTE $0xf0       // movq         %r14, %rax
 	LONG $0xf0e08348               // andq         $-16, %rax
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
@@ -8770,45 +9980,45 @@ LBB28_137:
 	WORD $0x8948; BYTE $0xc1       // movq         %rax, %rcx
 	WORD $0x294c; BYTE $0xc9       // subq         %r9, %rcx
 	WORD $0xdb31                   // xorl         %ebx, %ebx
-	QUAD $0xfffff716056ff9c5       // vmovdqa      $-2282(%rip), %xmm0  /* LCPI28_1(%rip) */
+	QUAD $0xfffff716056ff9c5       // vmovdqa      $-2282(%rip), %xmm0  /* LCPI30_1(%rip) */
 	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_138:
+LBB30_138:
 	LONG $0x7f7ac1c4; WORD $0x1a04 // vmovdqu      %xmm0, (%r10,%rbx)
 	LONG $0x10c38348               // addq         $16, %rbx
 	WORD $0x3948; BYTE $0xd9       // cmpq         %rbx, %rcx
-	LONG $0xffed850f; WORD $0xffff // jne          LBB28_138, $-19(%rip)
+	LONG $0xffed850f; WORD $0xffff // jne          LBB30_138, $-19(%rip)
 	WORD $0x3949; BYTE $0xc6       // cmpq         %rax, %r14
-	LONG $0x0034850f; WORD $0x0000 // jne          LBB28_150, $52(%rip)
-	LONG $0x00003fe9; BYTE $0x00   // jmp          LBB28_151, $63(%rip)
+	LONG $0x0034850f; WORD $0x0000 // jne          LBB30_150, $52(%rip)
+	LONG $0x00003fe9; BYTE $0x00   // jmp          LBB30_151, $63(%rip)
 
-LBB28_23:
+LBB30_23:
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
 	WORD $0x894c; BYTE $0xc9                   // movq         %r9, %rcx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 	LONG $0x05c18348                           // addq         $5, %rcx
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
-	LONG $0xfad2830f; WORD $0xffff             // jae          LBB28_17, $-1326(%rip)
+	LONG $0xfad2830f; WORD $0xffff             // jae          LBB30_17, $-1326(%rip)
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
-	LONG $0xfffc93e9; BYTE $0xff               // jmp          LBB28_25, $-877(%rip)
+	LONG $0xfffc93e9; BYTE $0xff               // jmp          LBB30_25, $-877(%rip)
 
-LBB28_149:
+LBB30_149:
 	WORD $0x014c; BYTE $0xca     // addq         %r9, %rdx
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_150:
+LBB30_150:
 	WORD $0x02c6; BYTE $0x30       // movb         $48, (%rdx)
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0x394c; BYTE $0xe2       // cmpq         %r12, %rdx
-	LONG $0xfff0820f; WORD $0xffff // jb           LBB28_150, $-16(%rip)
+	LONG $0xfff0820f; WORD $0xffff // jb           LBB30_150, $-16(%rip)
 
-LBB28_151:
+LBB30_151:
 	WORD $0x894c; BYTE $0xe0 // movq         %r12, %rax
 
-LBB28_152:
+LBB30_152:
 	WORD $0x2944; BYTE $0xe8 // subl         %r13d, %eax
 
-LBB28_153:
+LBB30_153:
 	LONG $0x10c48348         // addq         $16, %rsp
 	BYTE $0x5b               // popq         %rbx
 	WORD $0x5c41             // popq         %r12
@@ -8819,16 +10029,16 @@ LBB28_153:
 	WORD $0xf8c5; BYTE $0x77 // vzeroupper
 	BYTE $0xc3               // retq
 
-LBB28_76:
+LBB30_76:
 	LONG $0xd0558b48                           // movq         $-48(%rbp), %rdx
 	LONG $0x121c8d49                           // leaq         (%r10,%rdx), %rbx
 	LONG $0xe2c38148; WORD $0x0001; BYTE $0x00 // addq         $482, %rbx
 	LONG $0xfce48349                           // andq         $-4, %r12
 	WORD $0xf749; BYTE $0xdc                   // negq         %r12
 	WORD $0xd231                               // xorl         %edx, %edx
-	QUAD $0xfffff658056ffdc5                   // vmovdqa      $-2472(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff658056ffdc5                   // vmovdqa      $-2472(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_77:
+LBB30_77:
 	QUAD $0xfffe2013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-480(%rbx,%rdx)
 	QUAD $0xfffe4013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-448(%rbx,%rdx)
 	QUAD $0xfffe6013847ffec5; BYTE $0xff       // vmovdqu      %ymm0, $-416(%rbx,%rdx)
@@ -8847,94 +10057,94 @@ LBB28_77:
 	LONG $0x047ffec5; BYTE $0x13               // vmovdqu      %ymm0, (%rbx,%rdx)
 	LONG $0x00c28148; WORD $0x0002; BYTE $0x00 // addq         $512, %rdx
 	LONG $0x04c48349                           // addq         $4, %r12
-	LONG $0xff6f850f; WORD $0xffff             // jne          LBB28_77, $-145(%rip)
+	LONG $0xff6f850f; WORD $0xffff             // jne          LBB30_77, $-145(%rip)
 
-LBB28_78:
+LBB30_78:
 	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0040840f; WORD $0x0000 // je           LBB28_81, $64(%rip)
+	LONG $0x0040840f; WORD $0x0000 // je           LBB30_81, $64(%rip)
 	WORD $0x014c; BYTE $0xd2       // addq         %r10, %rdx
 	LONG $0xd0758b48               // movq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xf2       // addq         %rsi, %rdx
 	LONG $0x62c28348               // addq         $98, %rdx
 	LONG $0x07e7c149               // shlq         $7, %r15
 	WORD $0xf631                   // xorl         %esi, %esi
-	QUAD $0xfffff5a2056ffdc5       // vmovdqa      $-2654(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff5a2056ffdc5       // vmovdqa      $-2654(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_80:
+LBB30_80:
 	LONG $0x447ffec5; WORD $0xa032 // vmovdqu      %ymm0, $-96(%rdx,%rsi)
 	LONG $0x447ffec5; WORD $0xc032 // vmovdqu      %ymm0, $-64(%rdx,%rsi)
 	LONG $0x447ffec5; WORD $0xe032 // vmovdqu      %ymm0, $-32(%rdx,%rsi)
 	LONG $0x047ffec5; BYTE $0x32   // vmovdqu      %ymm0, (%rdx,%rsi)
 	LONG $0x80ee8348               // subq         $-128, %rsi
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0xffdc850f; WORD $0xffff // jne          LBB28_80, $-36(%rip)
+	LONG $0xffdc850f; WORD $0xffff // jne          LBB30_80, $-36(%rip)
 
-LBB28_81:
+LBB30_81:
 	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
 	WORD $0x0149; BYTE $0xcc       // addq         %rcx, %r12
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0x0021840f; WORD $0x0000 // je           LBB28_84, $33(%rip)
+	LONG $0x0021840f; WORD $0x0000 // je           LBB30_84, $33(%rip)
 
-LBB28_82:
+LBB30_82:
 	WORD $0x0144; BYTE $0xc9               // addl         %r9d, %ecx
 	WORD $0xd9f7                           // negl         %ecx
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_83:
+LBB30_83:
 	LONG $0x2404c641; BYTE $0x30   // movb         $48, (%r12)
 	LONG $0x01c48349               // addq         $1, %r12
 	WORD $0xc183; BYTE $0xff       // addl         $-1, %ecx
-	LONG $0xffee850f; WORD $0xffff // jne          LBB28_83, $-18(%rip)
+	LONG $0xffee850f; WORD $0xffff // jne          LBB30_83, $-18(%rip)
 
-LBB28_84:
+LBB30_84:
 	LONG $0x043c8d4f                           // leaq         (%r12,%r8), %r15
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x0050820f; WORD $0x0000             // jb           LBB28_85, $80(%rip)
+	LONG $0x0050820f; WORD $0x0000             // jb           LBB30_85, $80(%rip)
 	WORD $0xc289                               // movl         %eax, %edx
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdaaf0f48                           // imulq        %rdx, %rbx
 	LONG $0x2debc148                           // shrq         $45, %rbx
 	LONG $0xd8f0d369; WORD $0xffff             // imull        $-10000, %ebx, %edx
 	WORD $0xc201                               // addl         %eax, %edx
-	LONG $0x004b840f; WORD $0x0000             // je           LBB28_87, $75(%rip)
+	LONG $0x004b840f; WORD $0x0000             // je           LBB30_87, $75(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0xf229                               // subl         %esi, %edx
-	LONG $0x69358d48; WORD $0x0035; BYTE $0x00 // leaq         $13673(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xc9358d48; WORD $0x0038; BYTE $0x00 // leaq         $14537(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x5614b70f                           // movzwl       (%rsi,%rdx,2), %edx
 	LONG $0x57894166; BYTE $0xfe               // movw         %dx, $-2(%r15)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0x47894166; BYTE $0xfc               // movw         %ax, $-4(%r15)
 	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB28_89, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB30_89, $30(%rip)
 
-LBB28_85:
+LBB30_85:
 	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
 	WORD $0x894c; BYTE $0xfa       // movq         %r15, %rdx
 	WORD $0xc389                   // movl         %eax, %ebx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x001a830f; WORD $0x0000 // jae          LBB28_92, $26(%rip)
+	LONG $0x001a830f; WORD $0x0000 // jae          LBB30_92, $26(%rip)
 
-LBB28_91:
+LBB30_91:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x000055e9; BYTE $0x00 // jmp          LBB28_94, $85(%rip)
+	LONG $0x000055e9; BYTE $0x00 // jmp          LBB30_94, $85(%rip)
 
-LBB28_87:
+LBB30_87:
 	LONG $0x0004bb41; WORD $0x0000 // movl         $4, %r11d
 
-LBB28_89:
+LBB30_89:
 	LONG $0xfc578d49               // leaq         $-4(%r15), %rdx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xffe6820f; WORD $0xffff // jb           LBB28_91, $-26(%rip)
+	LONG $0xffe6820f; WORD $0xffff // jb           LBB30_91, $-26(%rip)
 
-LBB28_92:
+LBB30_92:
 	LONG $0xffc28348                           // addq         $-1, %rdx
-	LONG $0x19358d48; WORD $0x0035; BYTE $0x00 // leaq         $13593(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x79358d48; WORD $0x0038; BYTE $0x00 // leaq         $14457(%rip), %rsi  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB28_93:
+LBB30_93:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -8946,24 +10156,24 @@ LBB28_93:
 	LONG $0xfec28348                           // addq         $-2, %rdx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_93, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_93, $-46(%rip)
 
-LBB28_94:
+LBB30_94:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001a820f; WORD $0x0000             // jb           LBB28_96, $26(%rip)
+	LONG $0x001a820f; WORD $0x0000             // jb           LBB30_96, $26(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xd00d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13520(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x300d8d48; WORD $0x0038; BYTE $0x00 // leaq         $14384(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x894d; BYTE $0xe2                   // movq         %r12, %r10
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
-	LONG $0x000009e9; BYTE $0x00               // jmp          LBB28_97, $9(%rip)
+	LONG $0x000009e9; BYTE $0x00               // jmp          LBB30_97, $9(%rip)
 
-LBB28_96:
+LBB30_96:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x894d; BYTE $0xe2 // movq         %r12, %r10
 	LONG $0x24048841         // movb         %al, (%r12)
 
-LBB28_97:
+LBB30_97:
 	WORD $0x294d; BYTE $0xdf     // subq         %r11, %r15
 	WORD $0x294d; BYTE $0xd8     // subq         %r11, %r8
 	LONG $0x01c08349             // addq         $1, %r8
@@ -8981,51 +10191,51 @@ LBB28_97:
 	WORD $0x8944; BYTE $0xe6     // movl         %r12d, %esi
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_98:
+LBB30_98:
 	WORD $0xc180; BYTE $0x03       // addb         $3, %cl
 	WORD $0xc683; BYTE $0x01       // addl         $1, %esi
 	LONG $0x1f7c8041; WORD $0x30ff // cmpb         $48, $-1(%r15,%rbx)
 	LONG $0xff5b8d48               // leaq         $-1(%rbx), %rbx
-	LONG $0xffea840f; WORD $0xffff // je           LBB28_98, $-22(%rip)
+	LONG $0xffea840f; WORD $0xffff // je           LBB30_98, $-22(%rip)
 	LONG $0x1f048d49               // leaq         (%r15,%rbx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00458e0f; WORD $0x0000 // jle          LBB28_100, $69(%rip)
+	LONG $0x00458e0f; WORD $0x0000 // jle          LBB30_100, $69(%rip)
 	WORD $0x2945; BYTE $0xdd       // subl         %r11d, %r13d
 	LONG $0x2b3c8d42               // leal         (%rbx,%r13), %edi
 	WORD $0xc783; BYTE $0x01       // addl         $1, %edi
 	WORD $0x3941; BYTE $0xf9       // cmpl         %edi, %r9d
-	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB28_102, $59(%rip)
+	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB30_102, $59(%rip)
 	WORD $0xc283; BYTE $0xff       // addl         $-1, %edx
 	WORD $0x6348; BYTE $0xc2       // movslq       %edx, %rax
 	LONG $0x18348d48               // leaq         (%rax,%rbx), %rsi
 	LONG $0x01c68348               // addq         $1, %rsi
 	WORD $0xf685                   // testl        %esi, %esi
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
-	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB28_120, $245(%rip)
+	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB30_120, $245(%rip)
 	WORD $0x8941; BYTE $0xf0       // movl         %esi, %r8d
 	LONG $0xff508d49               // leaq         $-1(%r8), %rdx
 	LONG $0x03fa8348               // cmpq         $3, %rdx
-	LONG $0x007b830f; WORD $0x0000 // jae          LBB28_121, $123(%rip)
+	LONG $0x007b830f; WORD $0x0000 // jae          LBB30_121, $123(%rip)
 	WORD $0xd231                   // xorl         %edx, %edx
-	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB28_117, $160(%rip)
+	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB30_117, $160(%rip)
 
-LBB28_100:
+LBB30_100:
 	LONG $0xd06d8b4c             // movq         $-48(%rbp), %r13
-	LONG $0xfffd1ee9; BYTE $0xff // jmp          LBB28_152, $-738(%rip)
+	LONG $0xfffd1ee9; BYTE $0xff // jmp          LBB30_152, $-738(%rip)
 
-LBB28_102:
+LBB30_102:
 	WORD $0x8945; BYTE $0xf6                   // movl         %r14d, %r14d
 	WORD $0x2949; BYTE $0xde                   // subq         %rbx, %r14
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0xfd0b8e0f; WORD $0xffff             // jle          LBB28_152, $-757(%rip)
+	LONG $0xfd0b8e0f; WORD $0xffff             // jle          LBB30_152, $-757(%rip)
 	WORD $0x8945; BYTE $0xe3                   // movl         %r12d, %r11d
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
 	WORD $0x2948; BYTE $0xd9                   // subq         %rbx, %rcx
 	WORD $0xd231                               // xorl         %edx, %edx
 	WORD $0xf983; BYTE $0x7f                   // cmpl         $127, %ecx
-	LONG $0x0204820f; WORD $0x0000             // jb           LBB28_112, $516(%rip)
+	LONG $0x0204820f; WORD $0x0000             // jb           LBB30_112, $516(%rip)
 	WORD $0x2949; BYTE $0xdb                   // subq         %rbx, %r11
 	WORD $0x8941; BYTE $0xc9                   // movl         %ecx, %r9d
 	LONG $0x01c18349                           // addq         $1, %r9
@@ -9041,28 +10251,28 @@ LBB28_102:
 	LONG $0x07e8c149                           // shrq         $7, %r8
 	LONG $0x01c08349                           // addq         $1, %r8
 	LONG $0x80f98148; WORD $0x0001; BYTE $0x00 // cmpq         $384, %rcx
-	LONG $0x0085830f; WORD $0x0000             // jae          LBB28_106, $133(%rip)
+	LONG $0x0085830f; WORD $0x0000             // jae          LBB30_106, $133(%rip)
 	WORD $0xc931                               // xorl         %ecx, %ecx
-	LONG $0x00013fe9; BYTE $0x00               // jmp          LBB28_108, $319(%rip)
+	LONG $0x00013fe9; BYTE $0x00               // jmp          LBB30_108, $319(%rip)
 
-LBB28_121:
+LBB30_121:
 	WORD $0xe683; BYTE $0xfc // andl         $-4, %esi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xd231             // xorl         %edx, %edx
 	QUAD $0x9090909090909090 // .p2align 4, 0x90
 
-LBB28_122:
+LBB30_122:
 	LONG $0x173c8d49               // leaq         (%r15,%rdx), %rdi
 	LONG $0xfd3b448b               // movl         $-3(%rbx,%rdi), %eax
 	LONG $0xfe3b4489               // movl         %eax, $-2(%rbx,%rdi)
 	LONG $0xfcc28348               // addq         $-4, %rdx
 	WORD $0x3948; BYTE $0xd6       // cmpq         %rdx, %rsi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_122, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_122, $-25(%rip)
 	WORD $0xf748; BYTE $0xda       // negq         %rdx
 
-LBB28_117:
+LBB30_117:
 	LONG $0x03c0f641                     // testb        $3, %r8b
-	LONG $0x0033840f; WORD $0x0000       // je           LBB28_120, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000       // je           LBB30_120, $51(%rip)
 	WORD $0xb60f; BYTE $0xf9             // movzbl       %cl, %edi
 	WORD $0xe783; BYTE $0x03             // andl         $3, %edi
 	WORD $0xf748; BYTE $0xdf             // negq         %rdi
@@ -9071,22 +10281,22 @@ LBB28_117:
 	WORD $0xd231                         // xorl         %edx, %edx
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_119:
+LBB30_119:
 	LONG $0x11348d48               // leaq         (%rcx,%rdx), %rsi
 	LONG $0x3304b60f               // movzbl       (%rbx,%rsi), %eax
 	LONG $0x01334488               // movb         %al, $1(%rbx,%rsi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0x3948; BYTE $0xd7       // cmpq         %rdx, %rdi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_119, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_119, $-25(%rip)
 
-LBB28_120:
+LBB30_120:
 	WORD $0x6349; BYTE $0xc1     // movslq       %r9d, %rax
 	LONG $0x0204c641; BYTE $0x2e // movb         $46, (%r10,%rax)
 	LONG $0x1f048d49             // leaq         (%r15,%rbx), %rax
 	LONG $0x02c08348             // addq         $2, %rax
-	LONG $0xfffc35e9; BYTE $0xff // jmp          LBB28_152, $-971(%rip)
+	LONG $0xfffc35e9; BYTE $0xff // jmp          LBB30_152, $-971(%rip)
 
-LBB28_106:
+LBB30_106:
 	WORD $0x8944; BYTE $0xde // movl         %r11d, %esi
 	LONG $0x01c68348         // addq         $1, %rsi
 	LONG $0x80e68348         // andq         $-128, %rsi
@@ -9096,9 +10306,9 @@ LBB28_106:
 	LONG $0xfce68348         // andq         $-4, %rsi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xc931             // xorl         %ecx, %ecx
-	QUAD $0xfffff29a056ffdc5 // vmovdqa      $-3430(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff29a056ffdc5 // vmovdqa      $-3430(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_107:
+LBB30_107:
 	LONG $0x0f3c8d49                           // leaq         (%r15,%rcx), %rdi
 	LONG $0x447ffec5; WORD $0x013b             // vmovdqu      %ymm0, $1(%rbx,%rdi)
 	LONG $0x447ffec5; WORD $0x213b             // vmovdqu      %ymm0, $33(%rbx,%rdi)
@@ -9118,12 +10328,12 @@ LBB28_107:
 	QUAD $0x0001e13b847ffec5; BYTE $0x00       // vmovdqu      %ymm0, $481(%rbx,%rdi)
 	LONG $0x00c18148; WORD $0x0002; BYTE $0x00 // addq         $512, %rcx
 	LONG $0x04c68348                           // addq         $4, %rsi
-	LONG $0xff67850f; WORD $0xffff             // jne          LBB28_107, $-153(%rip)
+	LONG $0xff67850f; WORD $0xffff             // jne          LBB30_107, $-153(%rip)
 
-LBB28_108:
+LBB30_108:
 	WORD $0x0148; BYTE $0xd8                   // addq         %rbx, %rax
 	LONG $0x03c0f641                           // testb        $3, %r8b
-	LONG $0x005c840f; WORD $0x0000             // je           LBB28_111, $92(%rip)
+	LONG $0x005c840f; WORD $0x0000             // je           LBB30_111, $92(%rip)
 	LONG $0x01c38341                           // addl         $1, %r11d
 	LONG $0x80e38141; WORD $0x0001; BYTE $0x00 // andl         $384, %r11d
 	LONG $0x80c38341                           // addl         $-128, %r11d
@@ -9135,9 +10345,9 @@ LBB28_108:
 	WORD $0x014c; BYTE $0xf9                   // addq         %r15, %rcx
 	LONG $0x61c18348                           // addq         $97, %rcx
 	WORD $0xf631                               // xorl         %esi, %esi
-	QUAD $0xfffff1c0056ffdc5                   // vmovdqa      $-3648(%rip), %ymm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff1c0056ffdc5                   // vmovdqa      $-3648(%rip), %ymm0  /* LCPI30_0(%rip) */
 
-LBB28_110:
+LBB30_110:
 	LONG $0x313c8d48               // leaq         (%rcx,%rsi), %rdi
 	LONG $0x447ffec5; WORD $0xa03b // vmovdqu      %ymm0, $-96(%rbx,%rdi)
 	LONG $0x447ffec5; WORD $0xc03b // vmovdqu      %ymm0, $-64(%rbx,%rdi)
@@ -9145,31 +10355,31 @@ LBB28_110:
 	LONG $0x047ffec5; BYTE $0x3b   // vmovdqu      %ymm0, (%rbx,%rdi)
 	LONG $0x80ee8348               // subq         $-128, %rsi
 	WORD $0x3949; BYTE $0xf0       // cmpq         %rsi, %r8
-	LONG $0xffd8850f; WORD $0xffff // jne          LBB28_110, $-40(%rip)
+	LONG $0xffd8850f; WORD $0xffff // jne          LBB30_110, $-40(%rip)
 
-LBB28_111:
+LBB30_111:
 	WORD $0x3949; BYTE $0xd1                                             // cmpq         %rdx, %r9
-	LONG $0xfb02840f; WORD $0xffff                                       // je           LBB28_152, $-1278(%rip)
+	LONG $0xfb02840f; WORD $0xffff                                       // je           LBB30_152, $-1278(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_112:
+LBB30_112:
 	WORD $0x00c6; BYTE $0x30       // movb         $48, (%rax)
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0xc283; BYTE $0x01       // addl         $1, %edx
 	WORD $0x3944; BYTE $0xf2       // cmpl         %r14d, %edx
-	LONG $0xffed8c0f; WORD $0xffff // jl           LBB28_112, $-19(%rip)
-	LONG $0xfffadbe9; BYTE $0xff   // jmp          LBB28_152, $-1317(%rip)
+	LONG $0xffed8c0f; WORD $0xffff // jl           LBB30_112, $-19(%rip)
+	LONG $0xfffadbe9; BYTE $0xff   // jmp          LBB30_152, $-1317(%rip)
 
-LBB28_1:
+LBB30_1:
 	WORD $0xc031                 // xorl         %eax, %eax
-	LONG $0xfffad7e9; BYTE $0xff // jmp          LBB28_153, $-1321(%rip)
+	LONG $0xfffad7e9; BYTE $0xff // jmp          LBB30_153, $-1321(%rip)
 
-LBB28_5:
+LBB30_5:
 	LONG $0xc84d894c                                   // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948                                   // movq         %rdi, $-48(%rbp)
 	LONG $0xff6bb841; WORD $0xffff                     // movl         $-149, %r8d
 	WORD $0x8941; BYTE $0xc3                           // movl         %eax, %r11d
-	LONG $0xfff208e9; BYTE $0xff                       // jmp          LBB28_6, $-3576(%rip)
+	LONG $0xfff208e9; BYTE $0xff                       // jmp          LBB30_6, $-3576(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 _format_significand:
@@ -9181,25 +10391,25 @@ _format_significand:
 	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
 	WORD $0x8948; BYTE $0xf8       // movq         %rdi, %rax
 	LONG $0x20e8c148               // shrq         $32, %rax
-	LONG $0x001c850f; WORD $0x0000 // jne          LBB29_2, $28(%rip)
+	LONG $0x001c850f; WORD $0x0000 // jne          LBB31_2, $28(%rip)
 	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
 	WORD $0x894d; BYTE $0xc6       // movq         %r8, %r14
 	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0x00e3830f; WORD $0x0000 // jae          LBB29_8, $227(%rip)
+	LONG $0x00e3830f; WORD $0x0000 // jae          LBB31_8, $227(%rip)
 
-LBB29_7:
+LBB31_7:
 	WORD $0xd789                 // movl         %edx, %edi
-	LONG $0x000132e9; BYTE $0x00 // jmp          LBB29_10, $306(%rip)
+	LONG $0x000132e9; BYTE $0x00 // jmp          LBB31_10, $306(%rip)
 
-LBB29_2:
+LBB31_2:
 	QUAD $0x77118461cefdb948; WORD $0xabcc     // movabsq      $-6067343680855748867, %rcx
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	WORD $0xf748; BYTE $0xe1                   // mulq         %rcx
 	LONG $0x1aeac148                           // shrq         $26, %rdx
 	LONG $0x1f00ca69; WORD $0xfa0a             // imull        $-100000000, %edx, %ecx
 	WORD $0xf901                               // addl         %edi, %ecx
-	LONG $0x00a4840f; WORD $0x0000             // je           LBB29_3, $164(%rip)
+	LONG $0x00a4840f; WORD $0x0000             // je           LBB31_3, $164(%rip)
 	WORD $0xc889                               // movl         %ecx, %eax
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
 	LONG $0xc1af0f49                           // imulq        %r9, %rax
@@ -9225,7 +10435,7 @@ LBB29_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0xe30d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12515(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x430d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13379(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -9237,21 +10447,21 @@ LBB29_2:
 	WORD $0x3145; BYTE $0xc9                   // xorl         %r9d, %r9d
 	LONG $0xf8708d4d                           // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000             // cmpl         $10000, %edx
-	LONG $0xff38820f; WORD $0xffff             // jb           LBB29_7, $-200(%rip)
-	LONG $0x000016e9; BYTE $0x00               // jmp          LBB29_8, $22(%rip)
+	LONG $0xff38820f; WORD $0xffff             // jb           LBB31_7, $-200(%rip)
+	LONG $0x000016e9; BYTE $0x00               // jmp          LBB31_8, $22(%rip)
 
-LBB29_3:
+LBB31_3:
 	LONG $0x0008b941; WORD $0x0000 // movl         $8, %r9d
 	LONG $0xf8708d4d               // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0xff1d820f; WORD $0xffff // jb           LBB29_7, $-227(%rip)
+	LONG $0xff1d820f; WORD $0xffff // jb           LBB31_7, $-227(%rip)
 
-LBB29_8:
+LBB31_8:
 	LONG $0x1759ba41; WORD $0xd1b7             // movl         $3518437209, %r10d
-	LONG $0x811d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12417(%rip), %r11  /* _Digits(%rip) */
+	LONG $0xe11d8d4c; WORD $0x0033; BYTE $0x00 // leaq         $13281(%rip), %r11  /* _Digits(%rip) */
 	BYTE $0x90                                 // .p2align 4, 0x90
 
-LBB29_9:
+LBB31_9:
 	WORD $0xd789                               // movl         %edx, %edi
 	LONG $0xfaaf0f49                           // imulq        %r10, %rdi
 	LONG $0x2defc148                           // shrq         $45, %rdi
@@ -9268,22 +10478,22 @@ LBB29_9:
 	LONG $0xfcc68349                           // addq         $-4, %r14
 	LONG $0xe0fffa81; WORD $0x05f5             // cmpl         $99999999, %edx
 	WORD $0xfa89                               // movl         %edi, %edx
-	LONG $0xffb8870f; WORD $0xffff             // ja           LBB29_9, $-72(%rip)
+	LONG $0xffb8870f; WORD $0xffff             // ja           LBB31_9, $-72(%rip)
 
-LBB29_10:
+LBB31_10:
 	WORD $0xff83; BYTE $0x64       // cmpl         $100, %edi
-	LONG $0x0020830f; WORD $0x0000 // jae          LBB29_11, $32(%rip)
+	LONG $0x0020830f; WORD $0x0000 // jae          LBB31_11, $32(%rip)
 	WORD $0xff83; BYTE $0x0a       // cmpl         $10, %edi
-	LONG $0x004d820f; WORD $0x0000 // jb           LBB29_14, $77(%rip)
+	LONG $0x004d820f; WORD $0x0000 // jb           LBB31_14, $77(%rip)
 
-LBB29_13:
+LBB31_13:
 	WORD $0xf889                               // movl         %edi, %eax
-	LONG $0x1d0d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12317(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x7d0d8d48; WORD $0x0033; BYTE $0x00 // leaq         $13181(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x46894166; BYTE $0xfe               // movw         %ax, $-2(%r14)
-	LONG $0x00003de9; BYTE $0x00               // jmp          LBB29_15, $61(%rip)
+	LONG $0x00003de9; BYTE $0x00               // jmp          LBB31_15, $61(%rip)
 
-LBB29_11:
+LBB31_11:
 	WORD $0xb70f; BYTE $0xc7                   // movzwl       %di, %eax
 	WORD $0xe8c1; BYTE $0x02                   // shrl         $2, %eax
 	LONG $0x147bc069; WORD $0x0000             // imull        $5243, %eax, %eax
@@ -9291,19 +10501,19 @@ LBB29_11:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xcf29                               // subl         %ecx, %edi
 	WORD $0xb70f; BYTE $0xcf                   // movzwl       %di, %ecx
-	LONG $0xf1158d48; WORD $0x002f; BYTE $0x00 // leaq         $12273(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x51158d48; WORD $0x0033; BYTE $0x00 // leaq         $13137(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4e894166; BYTE $0xfe               // movw         %cx, $-2(%r14)
 	LONG $0xfec68349                           // addq         $-2, %r14
 	WORD $0xc789                               // movl         %eax, %edi
 	WORD $0xff83; BYTE $0x0a                   // cmpl         $10, %edi
-	LONG $0xffb3830f; WORD $0xffff             // jae          LBB29_13, $-77(%rip)
+	LONG $0xffb3830f; WORD $0xffff             // jae          LBB31_13, $-77(%rip)
 
-LBB29_14:
+LBB31_14:
 	LONG $0x30c78040         // addb         $48, %dil
 	WORD $0x8840; BYTE $0x3e // movb         %dil, (%rsi)
 
-LBB29_15:
+LBB31_15:
 	WORD $0x294d; BYTE $0xc8                   // subq         %r9, %r8
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
 	BYTE $0x5b                                 // popq         %rbx
@@ -9320,45 +10530,45 @@ _left_shift:
 	BYTE $0x53                                 // pushq        %rbx
 	WORD $0xf189                               // movl         %esi, %ecx
 	LONG $0x68f16b4c                           // imulq        $104, %rcx, %r14
-	LONG $0x9a158d48; WORD $0x0089; BYTE $0x00 // leaq         $35226(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
+	LONG $0xfa158d48; WORD $0x008c; BYTE $0x00 // leaq         $36090(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
 	LONG $0x16048b45                           // movl         (%r14,%rdx), %r8d
 	WORD $0x8b4c; BYTE $0x1f                   // movq         (%rdi), %r11
 	LONG $0x104f634c                           // movslq       $16(%rdi), %r9
 	WORD $0x8945; BYTE $0xca                   // movl         %r9d, %r10d
 	WORD $0x854d; BYTE $0xc9                   // testq        %r9, %r9
-	LONG $0x004c840f; WORD $0x0000             // je           LBB30_1, $76(%rip)
+	LONG $0x004c840f; WORD $0x0000             // je           LBB32_1, $76(%rip)
 	LONG $0x16348d49                           // leaq         (%r14,%rdx), %rsi
 	LONG $0x04c68348                           // addq         $4, %rsi
 	WORD $0xdb31                               // xorl         %ebx, %ebx
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB30_3:
+LBB32_3:
 	LONG $0x1e04b60f               // movzbl       (%rsi,%rbx), %eax
 	WORD $0xc084                   // testb        %al, %al
-	LONG $0x0041840f; WORD $0x0000 // je           LBB30_10, $65(%rip)
+	LONG $0x0041840f; WORD $0x0000 // je           LBB32_10, $65(%rip)
 	LONG $0x1b043841               // cmpb         %al, (%r11,%rbx)
-	LONG $0x01ba850f; WORD $0x0000 // jne          LBB30_5, $442(%rip)
+	LONG $0x01ba850f; WORD $0x0000 // jne          LBB32_5, $442(%rip)
 	LONG $0x01c38348               // addq         $1, %rbx
 	WORD $0x3949; BYTE $0xd9       // cmpq         %rbx, %r9
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB30_3, $-35(%rip)
+	LONG $0xffdd850f; WORD $0xffff // jne          LBB32_3, $-35(%rip)
 	WORD $0x8944; BYTE $0xce       // movl         %r9d, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB30_9, $21(%rip)
-	LONG $0x000014e9; BYTE $0x00   // jmp          LBB30_10, $20(%rip)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB32_9, $21(%rip)
+	LONG $0x000014e9; BYTE $0x00   // jmp          LBB32_10, $20(%rip)
 
-LBB30_1:
+LBB32_1:
 	WORD $0xf631                   // xorl         %esi, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0004840f; WORD $0x0000 // je           LBB30_10, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB32_10, $4(%rip)
 
-LBB30_9:
+LBB32_9:
 	LONG $0xffc08341 // addl         $-1, %r8d
 
-LBB30_10:
+LBB32_10:
 	WORD $0x8545; BYTE $0xd2                                             // testl        %r10d, %r10d
-	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB30_25, $162(%rip)
+	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB32_25, $162(%rip)
 	LONG $0x10048d43                                                     // leal         (%r8,%r10), %eax
 	WORD $0x634c; BYTE $0xf8                                             // movslq       %eax, %r15
 	LONG $0xffc18341                                                     // addl         $-1, %r9d
@@ -9367,7 +10577,7 @@ LBB30_10:
 	QUAD $0xcccccccccccdbe49; WORD $0xcccc                               // movabsq      $-3689348814741910323, %r14
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB30_12:
+LBB32_12:
 	WORD $0x8944; BYTE $0xc8       // movl         %r9d, %eax
 	LONG $0x34be0f49; BYTE $0x03   // movsbq       (%r11,%rax), %rsi
 	LONG $0xd0c68348               // addq         $-48, %rsi
@@ -9381,93 +10591,93 @@ LBB30_12:
 	WORD $0x8948; BYTE $0xf0       // movq         %rsi, %rax
 	WORD $0x2948; BYTE $0xd8       // subq         %rbx, %rax
 	LONG $0x087f394c               // cmpq         %r15, $8(%rdi)
-	LONG $0x000c860f; WORD $0x0000 // jbe          LBB30_18, $12(%rip)
+	LONG $0x000c860f; WORD $0x0000 // jbe          LBB32_18, $12(%rip)
 	WORD $0x3004                   // addb         $48, %al
 	LONG $0x3b048843               // movb         %al, (%r11,%r15)
-	LONG $0x000011e9; BYTE $0x00   // jmp          LBB30_20, $17(%rip)
+	LONG $0x000011e9; BYTE $0x00   // jmp          LBB32_20, $17(%rip)
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_18:
+LBB32_18:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x0007840f; WORD $0x0000             // je           LBB30_20, $7(%rip)
+	LONG $0x0007840f; WORD $0x0000             // je           LBB32_20, $7(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
 
-LBB30_20:
+LBB32_20:
 	LONG $0x02fa8349               // cmpq         $2, %r10
-	LONG $0x00148c0f; WORD $0x0000 // jl           LBB30_14, $20(%rip)
+	LONG $0x00148c0f; WORD $0x0000 // jl           LBB32_14, $20(%rip)
 	LONG $0xffc28349               // addq         $-1, %r10
 	WORD $0x8b4c; BYTE $0x1f       // movq         (%rdi), %r11
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0xffc78349               // addq         $-1, %r15
-	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB30_12, $-110(%rip)
+	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB32_12, $-110(%rip)
 
-LBB30_14:
+LBB32_14:
 	LONG $0x0afe8348               // cmpq         $10, %rsi
-	LONG $0x0071830f; WORD $0x0000 // jae          LBB30_15, $113(%rip)
+	LONG $0x0071830f; WORD $0x0000 // jae          LBB32_15, $113(%rip)
 
-LBB30_25:
+LBB32_25:
 	LONG $0x104f6348               // movslq       $16(%rdi), %rcx
 	WORD $0x6349; BYTE $0xc0       // movslq       %r8d, %rax
 	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0x084f8b48               // movq         $8(%rdi), %rcx
 	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
-	LONG $0x0005870f; WORD $0x0000 // ja           LBB30_27, $5(%rip)
+	LONG $0x0005870f; WORD $0x0000 // ja           LBB32_27, $5(%rip)
 	WORD $0x4f89; BYTE $0x10       // movl         %ecx, $16(%rdi)
 	WORD $0xc889                   // movl         %ecx, %eax
 
-LBB30_27:
+LBB32_27:
 	LONG $0x14470144               // addl         %r8d, $20(%rdi)
 	WORD $0xc085                   // testl        %eax, %eax
-	LONG $0x00328e0f; WORD $0x0000 // jle          LBB30_31, $50(%rip)
+	LONG $0x00328e0f; WORD $0x0000 // jle          LBB32_31, $50(%rip)
 	WORD $0x8b48; BYTE $0x0f       // movq         (%rdi), %rcx
 	WORD $0xc289                   // movl         %eax, %edx
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_29:
+LBB32_29:
 	WORD $0xc689                   // movl         %eax, %esi
 	LONG $0x30313c80               // cmpb         $48, (%rcx,%rsi)
-	LONG $0x0026850f; WORD $0x0000 // jne          LBB30_33, $38(%rip)
+	LONG $0x0026850f; WORD $0x0000 // jne          LBB32_33, $38(%rip)
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	LONG $0x01fa8348               // cmpq         $1, %rdx
-	LONG $0xffe08f0f; WORD $0xffff // jg           LBB30_29, $-32(%rip)
-	LONG $0x000006e9; BYTE $0x00   // jmp          LBB30_32, $6(%rip)
+	LONG $0xffe08f0f; WORD $0xffff // jg           LBB32_29, $-32(%rip)
+	LONG $0x000006e9; BYTE $0x00   // jmp          LBB32_32, $6(%rip)
 
-LBB30_31:
-	LONG $0x0007850f; WORD $0x0000 // jne          LBB30_33, $7(%rip)
+LBB32_31:
+	LONG $0x0007850f; WORD $0x0000 // jne          LBB32_33, $7(%rip)
 
-LBB30_32:
+LBB32_32:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 
-LBB30_33:
+LBB32_33:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	BYTE $0xc3   // retq
 
-LBB30_15:
+LBB32_15:
 	WORD $0x0145; BYTE $0xc1     // addl         %r8d, %r9d
 	WORD $0x6349; BYTE $0xf1     // movslq       %r9d, %rsi
 	LONG $0xffc68348             // addq         $-1, %rsi
-	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB30_16, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB32_16, $30(%rip)
 	QUAD $0x9090909090909090     // .p2align 4, 0x90
 
-LBB30_17:
+LBB32_17:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	WORD $0x0488; BYTE $0x33 // movb         %al, (%rbx,%rsi)
 
-LBB30_24:
+LBB32_24:
 	LONG $0xffc68348               // addq         $-1, %rsi
 	LONG $0x09f98348               // cmpq         $9, %rcx
-	LONG $0xff62860f; WORD $0xffff // jbe          LBB30_25, $-158(%rip)
+	LONG $0xff62860f; WORD $0xffff // jbe          LBB32_25, $-158(%rip)
 
-LBB30_16:
+LBB32_16:
 	WORD $0x8948; BYTE $0xd1                   // movq         %rdx, %rcx
 	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
 	WORD $0xf749; BYTE $0xe6                   // mulq         %r14
@@ -9477,15 +10687,15 @@ LBB30_16:
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
 	WORD $0x2948; BYTE $0xd8                   // subq         %rbx, %rax
 	LONG $0x08773948                           // cmpq         %rsi, $8(%rdi)
-	LONG $0xffc5870f; WORD $0xffff             // ja           LBB30_17, $-59(%rip)
+	LONG $0xffc5870f; WORD $0xffff             // ja           LBB32_17, $-59(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0xffc4840f; WORD $0xffff             // je           LBB30_24, $-60(%rip)
+	LONG $0xffc4840f; WORD $0xffff             // je           LBB32_24, $-60(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB30_24, $-72(%rip)
+	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB32_24, $-72(%rip)
 
-LBB30_5:
-	LONG $0xfe738c0f; WORD $0xffff // jl           LBB30_9, $-397(%rip)
-	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB30_10, $-398(%rip)
+LBB32_5:
+	LONG $0xfe738c0f; WORD $0xffff // jl           LBB32_9, $-397(%rip)
+	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB32_10, $-398(%rip)
 	LONG $0x90909090; BYTE $0x90   // .p2align 4, 0x90
 
 _right_shift:
@@ -9501,9 +10711,9 @@ _right_shift:
 	WORD $0xc031                   // xorl         %eax, %eax
 	LONG $0x90909090               // .p2align 4, 0x90
 
-LBB31_1:
+LBB33_1:
 	WORD $0x3949; BYTE $0xd3       // cmpq         %rdx, %r11
-	LONG $0x014f840f; WORD $0x0000 // je           LBB31_2, $335(%rip)
+	LONG $0x014f840f; WORD $0x0000 // je           LBB33_2, $335(%rip)
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	WORD $0x8b48; BYTE $0x37       // movq         (%rdi), %rsi
 	LONG $0x34be0f48; BYTE $0x16   // movsbq       (%rsi,%rdx), %rsi
@@ -9513,10 +10723,10 @@ LBB31_1:
 	WORD $0x8948; BYTE $0xc6       // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee       // shrq         %cl, %rsi
 	WORD $0x8548; BYTE $0xf6       // testq        %rsi, %rsi
-	LONG $0xffd0840f; WORD $0xffff // je           LBB31_1, $-48(%rip)
+	LONG $0xffd0840f; WORD $0xffff // je           LBB33_1, $-48(%rip)
 	WORD $0x8941; BYTE $0xd3       // movl         %edx, %r11d
 
-LBB31_7:
+LBB33_7:
 	WORD $0x578b; BYTE $0x14                                             // movl         $20(%rdi), %edx
 	WORD $0x2944; BYTE $0xda                                             // subl         %r11d, %edx
 	WORD $0xc283; BYTE $0x01                                             // addl         $1, %edx
@@ -9526,13 +10736,13 @@ LBB31_7:
 	WORD $0xf749; BYTE $0xd1                                             // notq         %r9
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	WORD $0x3945; BYTE $0xc3                                             // cmpl         %r8d, %r11d
-	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB31_10, $128(%rip)
+	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB33_10, $128(%rip)
 	WORD $0x634d; BYTE $0xc3                                             // movslq       %r11d, %r8
 	WORD $0x8b48; BYTE $0x37                                             // movq         (%rdi), %rsi
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_9:
+LBB33_9:
 	WORD $0x8948; BYTE $0xc2                               // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                               // shrq         %cl, %rdx
 	WORD $0x214c; BYTE $0xc8                               // andq         %r9, %rax
@@ -9548,95 +10758,353 @@ LBB31_9:
 	LONG $0xd0c08348                                       // addq         $-48, %rax
 	LONG $0x10576348                                       // movslq       $16(%rdi), %rdx
 	WORD $0x3948; BYTE $0xd3                               // cmpq         %rdx, %rbx
-	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB31_9, $-62(%rip)
-	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB31_10, $37(%rip)
+	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB33_9, $-62(%rip)
+	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB33_10, $37(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_12:
+LBB33_12:
 	LONG $0x30c68040         // addb         $48, %sil
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	LONG $0x13348840         // movb         %sil, (%rbx,%rdx)
 	WORD $0xc283; BYTE $0x01 // addl         $1, %edx
 	WORD $0x8941; BYTE $0xd2 // movl         %edx, %r10d
 
-LBB31_15:
+LBB33_15:
 	WORD $0x0148; BYTE $0xc0 // addq         %rax, %rax
 	LONG $0x80048d48         // leaq         (%rax,%rax,4), %rax
 
-LBB31_10:
+LBB33_10:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x002b840f; WORD $0x0000             // je           LBB31_16, $43(%rip)
+	LONG $0x002b840f; WORD $0x0000             // je           LBB33_16, $43(%rip)
 	WORD $0x8948; BYTE $0xc6                   // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee                   // shrq         %cl, %rsi
 	WORD $0x214c; BYTE $0xc8                   // andq         %r9, %rax
 	WORD $0x6349; BYTE $0xd2                   // movslq       %r10d, %rdx
 	LONG $0x08573948                           // cmpq         %rdx, $8(%rdi)
-	LONG $0xffc9870f; WORD $0xffff             // ja           LBB31_12, $-55(%rip)
+	LONG $0xffc9870f; WORD $0xffff             // ja           LBB33_12, $-55(%rip)
 	WORD $0x8548; BYTE $0xf6                   // testq        %rsi, %rsi
-	LONG $0xffd1840f; WORD $0xffff             // je           LBB31_15, $-47(%rip)
+	LONG $0xffd1840f; WORD $0xffff             // je           LBB33_15, $-47(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB31_15, $-59(%rip)
+	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB33_15, $-59(%rip)
 
-LBB31_16:
+LBB33_16:
 	LONG $0x10578944                     // movl         %r10d, $16(%rdi)
 	WORD $0x8545; BYTE $0xd2             // testl        %r10d, %r10d
-	LONG $0x00858e0f; WORD $0x0000       // jle          LBB31_20, $133(%rip)
+	LONG $0x00858e0f; WORD $0x0000       // jle          LBB33_20, $133(%rip)
 	WORD $0x8b48; BYTE $0x07             // movq         (%rdi), %rax
 	WORD $0x8944; BYTE $0xd1             // movl         %r10d, %ecx
 	LONG $0x01c18348                     // addq         $1, %rcx
 	LONG $0xffc28341                     // addl         $-1, %r10d
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_18:
+LBB33_18:
 	WORD $0x8944; BYTE $0xd2       // movl         %r10d, %edx
 	LONG $0x30103c80               // cmpb         $48, (%rax,%rdx)
-	LONG $0x0067850f; WORD $0x0000 // jne          LBB31_22, $103(%rip)
+	LONG $0x0067850f; WORD $0x0000 // jne          LBB33_22, $103(%rip)
 	LONG $0x10578944               // movl         %r10d, $16(%rdi)
 	LONG $0xffc18348               // addq         $-1, %rcx
 	LONG $0xffc28341               // addl         $-1, %r10d
 	LONG $0x01f98348               // cmpq         $1, %rcx
-	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB31_18, $-35(%rip)
-	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB31_21, $79(%rip)
+	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB33_18, $-35(%rip)
+	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB33_21, $79(%rip)
 
-LBB31_2:
+LBB33_2:
 	WORD $0x8548; BYTE $0xc0                                             // testq        %rax, %rax
-	LONG $0x0050840f; WORD $0x0000                                       // je           LBB31_23, $80(%rip)
+	LONG $0x0050840f; WORD $0x0000                                       // je           LBB33_23, $80(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 	WORD $0x8948; BYTE $0xc2                                             // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                                             // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2                                             // testq        %rdx, %rdx
-	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB31_7, $-332(%rip)
+	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB33_7, $-332(%rip)
 
-LBB31_4:
+LBB33_4:
 	WORD $0x0148; BYTE $0xc0       // addq         %rax, %rax
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	LONG $0x01c38341               // addl         $1, %r11d
 	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea       // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2       // testq        %rdx, %rdx
-	LONG $0xffe6840f; WORD $0xffff // je           LBB31_4, $-26(%rip)
-	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB31_7, $-363(%rip)
+	LONG $0xffe6840f; WORD $0xffff // je           LBB33_4, $-26(%rip)
+	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB33_7, $-363(%rip)
 
-LBB31_20:
-	LONG $0x0003840f; WORD $0x0000 // je           LBB31_21, $3(%rip)
+LBB33_20:
+	LONG $0x0003840f; WORD $0x0000 // je           LBB33_21, $3(%rip)
 
-LBB31_22:
+LBB33_22:
 	BYTE $0x5b // popq         %rbx
 	BYTE $0x5d // popq         %rbp
 	BYTE $0xc3 // retq
 
-LBB31_21:
+LBB33_21:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
 
-LBB31_23:
+LBB33_23:
 	LONG $0x001047c7; WORD $0x0000; BYTE $0x00 // movl         $0, $16(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
-	LONG $0x00000000; BYTE $0x00               // .p2align 4, 0x00
+	LONG $0x00000000; BYTE $0x00               // .p2align 5, 0x00
+
+LCPI34_0:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI34_1:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+	// .p2align 4, 0x90
+_advance_string_default:
+	BYTE $0x55                                               // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                                 // movq         %rsp, %rbp
+	WORD $0x5741                                             // pushq        %r15
+	WORD $0x5641                                             // pushq        %r14
+	WORD $0x5541                                             // pushq        %r13
+	WORD $0x5441                                             // pushq        %r12
+	BYTE $0x53                                               // pushq        %rbx
+	LONG $0x087f8b4c                                         // movq         $8(%rdi), %r15
+	WORD $0x2949; BYTE $0xf7                                 // subq         %rsi, %r15
+	LONG $0x02ec840f; WORD $0x0000                           // je           LBB34_17, $748(%rip)
+	WORD $0x8b4c; BYTE $0x0f                                 // movq         (%rdi), %r9
+	LONG $0xff02c748; WORD $0xffff; BYTE $0xff               // movq         $-1, (%rdx)
+	LONG $0x40ff8349                                         // cmpq         $64, %r15
+	LONG $0x0173820f; WORD $0x0000                           // jb           LBB34_18, $371(%rip)
+	WORD $0x8948; BYTE $0xf7                                 // movq         %rsi, %rdi
+	WORD $0xf748; BYTE $0xd7                                 // notq         %rdi
+	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff               // movq         $-1, %r8
+	WORD $0x3145; BYTE $0xf6                                 // xorl         %r14d, %r14d
+	QUAD $0xffffff7a056ffdc5                                 // vmovdqa      $-134(%rip), %ymm0  /* LCPI34_0(%rip) */
+	QUAD $0xffffff920d6ffdc5                                 // vmovdqa      $-110(%rip), %ymm1  /* LCPI34_1(%rip) */
+	QUAD $0xaaaaaaaaaaaaba49; WORD $0xaaaa                   // movabsq      $-6148914691236517206, %r10
+	QUAD $0x555555555555bb49; WORD $0x5555                   // movabsq      $6148914691236517205, %r11
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB34_3:
+	LONG $0x6f7ec1c4; WORD $0x3114             // vmovdqu      (%r9,%rsi), %ymm2
+	LONG $0x6f7ec1c4; WORD $0x315c; BYTE $0x20 // vmovdqu      $32(%r9,%rsi), %ymm3
+	LONG $0xe074edc5                           // vpcmpeqb     %ymm0, %ymm2, %ymm4
+	LONG $0xe4d77dc5                           // vpmovmskb    %ymm4, %r12d
+	LONG $0xe074e5c5                           // vpcmpeqb     %ymm0, %ymm3, %ymm4
+	LONG $0xccd7fdc5                           // vpmovmskb    %ymm4, %ecx
+	LONG $0xd174edc5                           // vpcmpeqb     %ymm1, %ymm2, %ymm2
+	LONG $0xc2d7fdc5                           // vpmovmskb    %ymm2, %eax
+	LONG $0xd174e5c5                           // vpcmpeqb     %ymm1, %ymm3, %ymm2
+	LONG $0xdad7fdc5                           // vpmovmskb    %ymm2, %ebx
+	LONG $0x20e1c148                           // shlq         $32, %rcx
+	WORD $0x0949; BYTE $0xcc                   // orq          %rcx, %r12
+	LONG $0x20e3c148                           // shlq         $32, %rbx
+	WORD $0x0948; BYTE $0xd8                   // orq          %rbx, %rax
+	LONG $0x0030850f; WORD $0x0000             // jne          LBB34_7, $48(%rip)
+	WORD $0x854d; BYTE $0xf6                   // testq        %r14, %r14
+	LONG $0x003b850f; WORD $0x0000             // jne          LBB34_9, $59(%rip)
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
+	LONG $0x006d850f; WORD $0x0000             // jne          LBB34_10, $109(%rip)
+
+LBB34_6:
+	LONG $0xc0c78349               // addq         $-64, %r15
+	LONG $0xc0c78348               // addq         $-64, %rdi
+	LONG $0x40c68348               // addq         $64, %rsi
+	LONG $0x3fff8349               // cmpq         $63, %r15
+	LONG $0xff94870f; WORD $0xffff // ja           LBB34_3, $-108(%rip)
+	LONG $0x000067e9; BYTE $0x00   // jmp          LBB34_12, $103(%rip)
+
+LBB34_7:
+	LONG $0xfff88349               // cmpq         $-1, %r8
+	LONG $0x000a850f; WORD $0x0000 // jne          LBB34_9, $10(%rip)
+	LONG $0xc0bc0f4c               // bsfq         %rax, %r8
+	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
+	WORD $0x894c; BYTE $0x02       // movq         %r8, (%rdx)
+
+LBB34_9:
+	WORD $0x894c; BYTE $0xf1       // movq         %r14, %rcx
+	WORD $0xf748; BYTE $0xd1       // notq         %rcx
+	WORD $0x2148; BYTE $0xc1       // andq         %rax, %rcx
+	LONG $0x092c8d4c               // leaq         (%rcx,%rcx), %r13
+	WORD $0x094d; BYTE $0xf5       // orq          %r14, %r13
+	WORD $0x894c; BYTE $0xeb       // movq         %r13, %rbx
+	WORD $0xf748; BYTE $0xd3       // notq         %rbx
+	WORD $0x2148; BYTE $0xc3       // andq         %rax, %rbx
+	WORD $0x214c; BYTE $0xd3       // andq         %r10, %rbx
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0x0148; BYTE $0xcb       // addq         %rcx, %rbx
+	LONG $0xc6920f41               // setb         %r14b
+	WORD $0x0148; BYTE $0xdb       // addq         %rbx, %rbx
+	WORD $0x314c; BYTE $0xdb       // xorq         %r11, %rbx
+	WORD $0x214c; BYTE $0xeb       // andq         %r13, %rbx
+	WORD $0xf748; BYTE $0xd3       // notq         %rbx
+	WORD $0x2149; BYTE $0xdc       // andq         %rbx, %r12
+	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
+	LONG $0xff93840f; WORD $0xffff // je           LBB34_6, $-109(%rip)
+
+LBB34_10:
+	LONG $0xc4bc0f49         // bsfq         %r12, %rax
+	WORD $0x2948; BYTE $0xf8 // subq         %rdi, %rax
+
+LBB34_11:
+	BYTE $0x5b               // popq         %rbx
+	WORD $0x5c41             // popq         %r12
+	WORD $0x5d41             // popq         %r13
+	WORD $0x5e41             // popq         %r14
+	WORD $0x5f41             // popq         %r15
+	BYTE $0x5d               // popq         %rbp
+	WORD $0xf8c5; BYTE $0x77 // vzeroupper
+	BYTE $0xc3               // retq
+
+LBB34_12:
+	WORD $0x014c; BYTE $0xce       // addq         %r9, %rsi
+	LONG $0x20ff8349               // cmpq         $32, %r15
+	LONG $0x00c3820f; WORD $0x0000 // jb           LBB34_23, $195(%rip)
+
+LBB34_13:
+	LONG $0x066ffec5               // vmovdqu      (%rsi), %ymm0
+	QUAD $0xfffffe5f0d74fdc5       // vpcmpeqb     $-417(%rip), %ymm0, %ymm1  /* LCPI34_0(%rip) */
+	LONG $0xf9d7fdc5               // vpmovmskb    %ymm1, %edi
+	QUAD $0xfffffe730574fdc5       // vpcmpeqb     $-397(%rip), %ymm0, %ymm0  /* LCPI34_1(%rip) */
+	LONG $0xc0d7fdc5               // vpmovmskb    %ymm0, %eax
+	WORD $0xc085                   // testl        %eax, %eax
+	LONG $0x0044850f; WORD $0x0000 // jne          LBB34_19, $68(%rip)
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x0055850f; WORD $0x0000 // jne          LBB34_21, $85(%rip)
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0x0082840f; WORD $0x0000 // je           LBB34_22, $130(%rip)
+
+LBB34_16:
+	LONG $0xc7bc0f48             // bsfq         %rdi, %rax
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xffff99e9; BYTE $0xff // jmp          LBB34_11, $-103(%rip)
+
+LBB34_18:
+	WORD $0x014c; BYTE $0xce                   // addq         %r9, %rsi
+	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	LONG $0x20ff8349                           // cmpq         $32, %r15
+	LONG $0xff9d830f; WORD $0xffff             // jae          LBB34_13, $-99(%rip)
+	LONG $0x00005be9; BYTE $0x00               // jmp          LBB34_23, $91(%rip)
+
+LBB34_19:
+	LONG $0xfff88349               // cmpq         $-1, %r8
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB34_21, $16(%rip)
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	WORD $0x294c; BYTE $0xc9       // subq         %r9, %rcx
+	LONG $0xc0bc0f4c               // bsfq         %rax, %r8
+	WORD $0x0149; BYTE $0xc8       // addq         %rcx, %r8
+	WORD $0x894c; BYTE $0x02       // movq         %r8, (%rdx)
+
+LBB34_21:
+	WORD $0x8944; BYTE $0xf1       // movl         %r14d, %ecx
+	WORD $0xd1f7                   // notl         %ecx
+	WORD $0xc121                   // andl         %eax, %ecx
+	WORD $0x1c8d; BYTE $0x09       // leal         (%rcx,%rcx), %ebx
+	LONG $0x4e148d45               // leal         (%r14,%rcx,2), %r10d
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xc321                   // andl         %eax, %ebx
+	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0xcb01                   // addl         %ecx, %ebx
+	LONG $0xc6920f41               // setb         %r14b
+	WORD $0xdb01                   // addl         %ebx, %ebx
+	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
+	WORD $0x2144; BYTE $0xd3       // andl         %r10d, %ebx
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xdf21                   // andl         %ebx, %edi
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0xff7e850f; WORD $0xffff // jne          LBB34_16, $-130(%rip)
+
+LBB34_22:
+	LONG $0x20c68348 // addq         $32, %rsi
+	LONG $0xe0c78349 // addq         $-32, %r15
+
+LBB34_23:
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x00b0850f; WORD $0x0000 // jne          LBB34_37, $176(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x009c840f; WORD $0x0000 // je           LBB34_36, $156(%rip)
+
+LBB34_25:
+	WORD $0x894d; BYTE $0xca // movq         %r9, %r10
+	WORD $0xf749; BYTE $0xd2 // notq         %r10
+	LONG $0x01c28349         // addq         $1, %r10
+
+LBB34_26:
+	WORD $0xc031 // xorl         %eax, %eax
+
+LBB34_27:
+	WORD $0x8948; BYTE $0xc7       // movq         %rax, %rdi
+	LONG $0x061cb60f               // movzbl       (%rsi,%rax), %ebx
+	WORD $0xfb80; BYTE $0x22       // cmpb         $34, %bl
+	LONG $0x0079840f; WORD $0x0000 // je           LBB34_35, $121(%rip)
+	WORD $0xfb80; BYTE $0x5c       // cmpb         $92, %bl
+	LONG $0x0012840f; WORD $0x0000 // je           LBB34_30, $18(%rip)
+	LONG $0x01478d48               // leaq         $1(%rdi), %rax
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	LONG $0xffda850f; WORD $0xffff // jne          LBB34_27, $-38(%rip)
+	LONG $0x00004ee9; BYTE $0x00   // jmp          LBB34_34, $78(%rip)
+
+LBB34_30:
+	LONG $0xff4f8d49                           // leaq         $-1(%r15), %rcx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x3948; BYTE $0xf9                   // cmpq         %rdi, %rcx
+	LONG $0xfec5840f; WORD $0xffff             // je           LBB34_11, $-315(%rip)
+	LONG $0xfff88349                           // cmpq         $-1, %r8
+	LONG $0x000a850f; WORD $0x0000             // jne          LBB34_33, $10(%rip)
+	LONG $0x32048d4d                           // leaq         (%r10,%rsi), %r8
+	WORD $0x0149; BYTE $0xf8                   // addq         %rdi, %r8
+	WORD $0x894c; BYTE $0x02                   // movq         %r8, (%rdx)
+
+LBB34_33:
+	WORD $0x0148; BYTE $0xfe       // addq         %rdi, %rsi
+	LONG $0x02c68348               // addq         $2, %rsi
+	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
+	WORD $0x2948; BYTE $0xf9       // subq         %rdi, %rcx
+	LONG $0xfec18348               // addq         $-2, %rcx
+	LONG $0xfec78349               // addq         $-2, %r15
+	WORD $0x3949; BYTE $0xff       // cmpq         %rdi, %r15
+	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
+	LONG $0xff8a850f; WORD $0xffff // jne          LBB34_26, $-118(%rip)
+	LONG $0xfffe8be9; BYTE $0xff   // jmp          LBB34_11, $-373(%rip)
+
+LBB34_34:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0xfb80; BYTE $0x22                   // cmpb         $34, %bl
+	LONG $0xfe7b850f; WORD $0xffff             // jne          LBB34_11, $-389(%rip)
+
+LBB34_35:
+	WORD $0x0148; BYTE $0xfe // addq         %rdi, %rsi
+	LONG $0x01c68348         // addq         $1, %rsi
+
+LBB34_36:
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
+	LONG $0xfffe69e9; BYTE $0xff // jmp          LBB34_11, $-407(%rip)
+
+LBB34_37:
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x002c840f; WORD $0x0000 // je           LBB34_17, $44(%rip)
+	LONG $0xfff88349               // cmpq         $-1, %r8
+	LONG $0x000c850f; WORD $0x0000 // jne          LBB34_40, $12(%rip)
+	WORD $0x894d; BYTE $0xc8       // movq         %r9, %r8
+	WORD $0xf749; BYTE $0xd0       // notq         %r8
+	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
+	WORD $0x894c; BYTE $0x02       // movq         %r8, (%rdx)
+
+LBB34_40:
+	LONG $0x01c68348               // addq         $1, %rsi
+	LONG $0xffc78349               // addq         $-1, %r15
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0xff29850f; WORD $0xffff // jne          LBB34_25, $-215(%rip)
+	LONG $0xffffc0e9; BYTE $0xff   // jmp          LBB34_36, $-64(%rip)
+
+LBB34_17:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff               // movq         $-1, %rax
+	LONG $0xfffe28e9; BYTE $0xff                             // jmp          LBB34_11, $-472(%rip)
+	QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 4, 0x00
 
 _POW10_M128_TAB:
 	QUAD $0x1732c869cd60e453                           // .quad 1671618768450675795
@@ -11065,7 +12533,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_9ad33a8d: // _pow10_ceil_sig.g
+_LB_4f34bdea: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -13720,7 +15188,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_792baa9e: // _pow10_ceil_sig_f32.g
+_LB_5b82bce7: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -13811,7 +15279,7 @@ _entry:
 _f32toa:
 	MOVQ  out+0(FP), DI
 	MOVSD val+8(FP), X0
-	CALL  ·__native_entry__+28464(SB) // _f32toa
+	CALL  ·__native_entry__+32816(SB) // _f32toa
 	MOVQ  AX, ret+16(FP)
 	RET
 
@@ -13833,6 +15301,27 @@ _f64toa:
 	MOVSD val+8(FP), X0
 	CALL  ·__native_entry__+752(SB) // _f64toa
 	MOVQ  AX, ret+16(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__get_by_path(SB), NOSPLIT | NOFRAME, $0 - 32
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -304(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_get_by_path:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	MOVQ path+16(FP), DX
+	CALL ·__native_entry__+30896(SB) // _get_by_path
+	MOVQ AX, ret+24(FP)
 	RET
 
 _stack_grow:
@@ -13939,7 +15428,7 @@ _skip_array:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+26112(SB) // _skip_array
+	CALL ·__native_entry__+23472(SB) // _skip_array
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -13959,7 +15448,7 @@ _entry:
 _skip_number:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
-	CALL ·__native_entry__+28208(SB) // _skip_number
+	CALL ·__native_entry__+27440(SB) // _skip_number
 	MOVQ AX, ret+16(FP)
 	RET
 
@@ -13981,7 +15470,7 @@ _skip_object:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+26160(SB) // _skip_object
+	CALL ·__native_entry__+25392(SB) // _skip_object
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -14003,8 +15492,28 @@ _skip_one:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+24208(SB) // _skip_one
+	CALL ·__native_entry__+27584(SB) // _skip_one
 	MOVQ AX, ret+32(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__skip_one_fast(SB), NOSPLIT | NOFRAME, $0 - 24
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -216(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_skip_one_fast:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	CALL ·__native_entry__+27984(SB) // _skip_one_fast
+	MOVQ AX, ret+16(FP)
 	RET
 
 _stack_grow:
@@ -14067,7 +15576,7 @@ _validate_one:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+28352(SB) // _validate_one
+	CALL ·__native_entry__+27616(SB) // _validate_one
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -14111,7 +15620,7 @@ _vnumber:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+21952(SB), AX // _vnumber
+	LEAQ ·__native_entry__+21216(SB), AX // _vnumber
 	JMP  AX
 
 _stack_grow:
@@ -14131,7 +15640,7 @@ _vsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+23504(SB), AX // _vsigned
+	LEAQ ·__native_entry__+22768(SB), AX // _vsigned
 	JMP  AX
 
 _stack_grow:
@@ -14143,7 +15652,7 @@ TEXT ·__vstring(SB), NOSPLIT | NOFRAME, $0 - 32
 
 _entry:
 	MOVQ (TLS), R14
-	LEAQ -128(SP), R12
+	LEAQ -136(SP), R12
 	CMPQ R12, 16(R14)
 	JBE  _stack_grow
 
@@ -14172,7 +15681,7 @@ _vunsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+23856(SB), AX // _vunsigned
+	LEAQ ·__native_entry__+23120(SB), AX // _vunsigned
 	JMP  AX
 
 _stack_grow:

--- a/internal/native/avx2/native_amd64_test.go
+++ b/internal/native/avx2/native_amd64_test.go
@@ -591,3 +591,59 @@ func TestNative_SkipNumber(t *testing.T) {
     assert.Equal(t, 9, p)
     assert.Equal(t, 0, q)
 }
+
+func TestNative_SkipOneFast(t *testing.T) {
+    p := 0
+    s := ` {"asdf": [null, true, false, 1, 2.0, -3]}, 1234.5`
+    q := __skip_one_fast(&s, &p)
+    assert.Equal(t, 42, p)
+    assert.Equal(t, 1, q)
+    p = 0
+    s = `1, 2.5, -3, "asdf\nqwer", true, false, null, {}, [],`
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 1, p)
+    assert.Equal(t, 0, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 6, p)
+    assert.Equal(t, 3, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 10, p)
+    assert.Equal(t, 8, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 24, p)
+    assert.Equal(t, 12, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 30, p)
+    assert.Equal(t, 26, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 37, p)
+    assert.Equal(t, 32, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 43, p)
+    assert.Equal(t, 39, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 47, p)
+    assert.Equal(t, 45, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 51, p)
+    assert.Equal(t, 49, q)
+}
+
+func TestNative_SkipOneFast_Error(t *testing.T) {
+    for _, s := range([]string{
+        "{{", "[{",  "{{}",
+        `"asdf`, `"\\\"`,
+    }) {
+        p := 0
+        q := __skip_one_fast(&s, &p)
+        assert.True(t, q < 0)
+    }
+}

--- a/internal/native/avx2/native_export_amd64.go
+++ b/internal/native/avx2/native_export_amd64.go
@@ -41,7 +41,9 @@ var (
 
 var (
     S_skip_one    = _subr__skip_one
+    S_skip_one_fast = _subr__skip_one_fast
     S_skip_array  = _subr__skip_array
     S_skip_object = _subr__skip_object
     S_skip_number = _subr__skip_number
+    S_get_by_path = _subr__get_by_path
 )

--- a/internal/native/avx2/native_subr_amd64.go
+++ b/internal/native/avx2/native_subr_amd64.go
@@ -9,29 +9,32 @@ package avx2
 func __native_entry__() uintptr
 
 var (
-    _subr__f32toa       = __native_entry__() + 28464
-    _subr__f64toa       = __native_entry__() + 752
-    _subr__html_escape  = __native_entry__() + 12320
-    _subr__i64toa       = __native_entry__() + 4432
-    _subr__lspace       = __native_entry__() + 224
-    _subr__quote        = __native_entry__() + 5904
-    _subr__skip_array   = __native_entry__() + 26112
-    _subr__skip_number  = __native_entry__() + 28208
-    _subr__skip_object  = __native_entry__() + 26160
-    _subr__skip_one     = __native_entry__() + 24208
-    _subr__u64toa       = __native_entry__() + 4544
-    _subr__unquote      = __native_entry__() + 8848
-    _subr__validate_one = __native_entry__() + 28352
-    _subr__value        = __native_entry__() + 16896
-    _subr__vnumber      = __native_entry__() + 21952
-    _subr__vsigned      = __native_entry__() + 23504
-    _subr__vstring      = __native_entry__() + 19280
-    _subr__vunsigned    = __native_entry__() + 23856
+    _subr__f32toa        = __native_entry__() + 32816
+    _subr__f64toa        = __native_entry__() + 752
+    _subr__get_by_path   = __native_entry__() + 30896
+    _subr__html_escape   = __native_entry__() + 12320
+    _subr__i64toa        = __native_entry__() + 4432
+    _subr__lspace        = __native_entry__() + 224
+    _subr__quote         = __native_entry__() + 5904
+    _subr__skip_array    = __native_entry__() + 23472
+    _subr__skip_number   = __native_entry__() + 27440
+    _subr__skip_object   = __native_entry__() + 25392
+    _subr__skip_one      = __native_entry__() + 27584
+    _subr__skip_one_fast = __native_entry__() + 27984
+    _subr__u64toa        = __native_entry__() + 4544
+    _subr__unquote       = __native_entry__() + 8848
+    _subr__validate_one  = __native_entry__() + 27616
+    _subr__value         = __native_entry__() + 16896
+    _subr__vnumber       = __native_entry__() + 21216
+    _subr__vsigned       = __native_entry__() + 22768
+    _subr__vstring       = __native_entry__() + 19280
+    _subr__vunsigned     = __native_entry__() + 23120
 )
 
 const (
     _stack__f32toa = 64
     _stack__f64toa = 80
+    _stack__get_by_path = 304
     _stack__html_escape = 72
     _stack__i64toa = 16
     _stack__lspace = 8
@@ -40,19 +43,21 @@ const (
     _stack__skip_number = 80
     _stack__skip_object = 136
     _stack__skip_one = 136
+    _stack__skip_one_fast = 216
     _stack__u64toa = 8
     _stack__unquote = 72
     _stack__validate_one = 136
     _stack__value = 336
     _stack__vnumber = 248
     _stack__vsigned = 16
-    _stack__vstring = 128
+    _stack__vstring = 136
     _stack__vunsigned = 24
 )
 
 var (
     _ = _subr__f32toa
     _ = _subr__f64toa
+    _ = _subr__get_by_path
     _ = _subr__html_escape
     _ = _subr__i64toa
     _ = _subr__lspace
@@ -61,6 +66,7 @@ var (
     _ = _subr__skip_number
     _ = _subr__skip_object
     _ = _subr__skip_one
+    _ = _subr__skip_one_fast
     _ = _subr__u64toa
     _ = _subr__unquote
     _ = _subr__validate_one
@@ -74,6 +80,7 @@ var (
 const (
     _ = _stack__f32toa
     _ = _stack__f64toa
+    _ = _stack__get_by_path
     _ = _stack__html_escape
     _ = _stack__i64toa
     _ = _stack__lspace
@@ -82,6 +89,7 @@ const (
     _ = _stack__skip_number
     _ = _stack__skip_object
     _ = _stack__skip_one
+    _ = _stack__skip_one_fast
     _ = _stack__u64toa
     _ = _stack__unquote
     _ = _stack__validate_one

--- a/internal/native/dispatch_amd64.go
+++ b/internal/native/dispatch_amd64.go
@@ -51,6 +51,8 @@ var (
 
 var (
     S_skip_one    uintptr
+    S_skip_one_fast    uintptr
+    S_get_by_path    uintptr
     S_skip_array  uintptr
     S_skip_object uintptr
     S_skip_number uintptr
@@ -80,6 +82,16 @@ func Value(s unsafe.Pointer, n int, p int, v *types.JsonState, flags uint64) int
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func SkipOne(s *string, p *int, m *types.StateMachine, flags uint64) int
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func SkipOneFast(s *string, p *int) int
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func GetByPath(s *string, p *int, path *[]interface{}) int
 
 //go:nosplit
 //go:noescape
@@ -115,9 +127,11 @@ func useAVX() {
     S_vsigned     = avx.S_vsigned
     S_vunsigned   = avx.S_vunsigned
     S_skip_one    = avx.S_skip_one
+    S_skip_one_fast = avx.S_skip_one_fast
     S_skip_array  = avx.S_skip_array
     S_skip_object = avx.S_skip_object
     S_skip_number = avx.S_skip_number
+    S_get_by_path = avx.S_get_by_path
 }
 
 func useAVX2() {
@@ -134,9 +148,11 @@ func useAVX2() {
     S_vsigned     = avx2.S_vsigned
     S_vunsigned   = avx2.S_vunsigned
     S_skip_one    = avx2.S_skip_one
+    S_skip_one_fast = avx2.S_skip_one_fast
     S_skip_array  = avx2.S_skip_array
     S_skip_object = avx2.S_skip_object
     S_skip_number = avx2.S_skip_number
+    S_get_by_path = avx2.S_get_by_path
 }
 
 func useSSE() {
@@ -153,9 +169,11 @@ func useSSE() {
     S_vsigned = sse.S_vsigned
     S_vunsigned = sse.S_vunsigned
     S_skip_one = sse.S_skip_one
+    S_skip_one_fast = sse.S_skip_one_fast
     S_skip_array = sse.S_skip_array
     S_skip_object = sse.S_skip_object
     S_skip_number = sse.S_skip_number
+    S_get_by_path = sse.S_get_by_path
 }
 
 func init() {

--- a/internal/native/dispatch_amd64.s
+++ b/internal/native/dispatch_amd64.s
@@ -64,6 +64,23 @@ TEXT ·SkipOne(SB), NOSPLIT, $0 - 40
     JMP  github·com∕bytedance∕sonic∕internal∕native∕avx·__skip_one(SB)
     JMP  github·com∕bytedance∕sonic∕internal∕native∕sse·__skip_one(SB)
 
+TEXT ·SkipOneFast(SB), NOSPLIT, $0 - 24
+    CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX2(SB), $0
+    JE   2(PC)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx2·__skip_one_fast(SB)
+    CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX(SB), $0
+    JE   2(PC)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx·__skip_one_fast(SB)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕sse·__skip_one_fast(SB)
+
+TEXT ·GetByPath(SB), NOSPLIT, $0 - 32
+    CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX2(SB), $0
+    JE   2(PC)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx2·__get_by_path(SB)
+    CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX(SB), $0
+    JE   2(PC)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕avx·__get_by_path(SB)
+    JMP  github·com∕bytedance∕sonic∕internal∕native∕sse·__get_by_path(SB)
 TEXT ·ValidateOne(SB), NOSPLIT, $0 - 32
     CMPB github·com∕bytedance∕sonic∕internal∕cpu·HasAVX2(SB), $0
     JE   2(PC)

--- a/internal/native/native_amd64.tmpl
+++ b/internal/native/native_amd64.tmpl
@@ -95,6 +95,11 @@ func __skip_one(s *string, p *int, m *types.StateMachine, flags uint64) (ret int
 //go:nosplit
 //go:noescape
 //goland:noinspection GoUnusedParameter
+func __skip_one_fast(s *string, p *int) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
 func __skip_array(s *string, p *int, m *types.StateMachine, flags uint64) (ret int)
 
 //go:nosplit
@@ -111,3 +116,8 @@ func __skip_number(s *string, p *int) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __get_by_path(s *string, p *int, path *[]interface{}) (ret int)

--- a/internal/native/native_amd64_test.tmpl
+++ b/internal/native/native_amd64_test.tmpl
@@ -589,3 +589,59 @@ func TestNative_SkipNumber(t *testing.T) {
     assert.Equal(t, 9, p)
     assert.Equal(t, 0, q)
 }
+
+func TestNative_SkipOneFast(t *testing.T) {
+    p := 0
+    s := ` {"asdf": [null, true, false, 1, 2.0, -3]}, 1234.5`
+    q := __skip_one_fast(&s, &p)
+    assert.Equal(t, 42, p)
+    assert.Equal(t, 1, q)
+    p = 0
+    s = `1, 2.5, -3, "asdf\nqwer", true, false, null, {}, [],`
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 1, p)
+    assert.Equal(t, 0, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 6, p)
+    assert.Equal(t, 3, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 10, p)
+    assert.Equal(t, 8, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 24, p)
+    assert.Equal(t, 12, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 30, p)
+    assert.Equal(t, 26, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 37, p)
+    assert.Equal(t, 32, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 43, p)
+    assert.Equal(t, 39, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 47, p)
+    assert.Equal(t, 45, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 51, p)
+    assert.Equal(t, 49, q)
+}
+
+func TestNative_SkipOneFast_Error(t *testing.T) {
+    for _, s := range([]string{
+        "{{", "[{",  "{{}",
+        `"asdf`, `"\\\"`,
+    }) {
+        p := 0
+        q := __skip_one_fast(&s, &p)
+        assert.True(t, q < 0)
+    }
+}

--- a/internal/native/native_export_amd64.tmpl
+++ b/internal/native/native_export_amd64.tmpl
@@ -39,7 +39,9 @@ var (
 
 var (
     S_skip_one    = _subr__skip_one
+    S_skip_one_fast = _subr__skip_one_fast
     S_skip_array  = _subr__skip_array
     S_skip_object = _subr__skip_object
     S_skip_number = _subr__skip_number
+    S_get_by_path = _subr__get_by_path
 )

--- a/internal/native/sse/native_amd64.go
+++ b/internal/native/sse/native_amd64.go
@@ -97,6 +97,11 @@ func __skip_one(s *string, p *int, m *types.StateMachine, flags uint64) (ret int
 //go:nosplit
 //go:noescape
 //goland:noinspection GoUnusedParameter
+func __skip_one_fast(s *string, p *int) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
 func __skip_array(s *string, p *int, m *types.StateMachine, flags uint64) (ret int)
 
 //go:nosplit
@@ -113,3 +118,8 @@ func __skip_number(s *string, p *int) (ret int)
 //go:noescape
 //goland:noinspection GoUnusedParameter
 func __validate_one(s *string, p *int, m *types.StateMachine) (ret int)
+
+//go:nosplit
+//go:noescape
+//goland:noinspection GoUnusedParameter
+func __get_by_path(s *string, p *int, path *[]interface{}) (ret int)

--- a/internal/native/sse/native_amd64.s
+++ b/internal/native/sse/native_amd64.s
@@ -208,7 +208,7 @@ LBB1_8:
 	LONG $0x04e6c148                           // shlq         $4, %rsi
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xd348; BYTE $0xe3                   // shlq         %cl, %rbx
-	LONG $0x121d8d4c; WORD $0x009e; BYTE $0x00 // leaq         $40466(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
+	LONG $0x821d8d4c; WORD $0x00b3; BYTE $0x00 // leaq         $45954(%rip), %r11  /* _pow10_ceil_sig.g(%rip) */
 	LONG $0x1e648b4e; BYTE $0x08               // movq         $8(%rsi,%r11), %r12
 	WORD $0x8948; BYTE $0xd8                   // movq         %rbx, %rax
 	WORD $0xf749; BYTE $0xe4                   // mulq         %r12
@@ -381,7 +381,7 @@ LBB1_31:
 	LONG $0x0099820f; WORD $0x0000 // jb           LBB1_39, $153(%rip)
 	LONG $0x01678d4d               // leaq         $1(%r15), %r12
 	WORD $0x894c; BYTE $0xe6       // movq         %r12, %rsi
-	LONG $0x0068ede8; BYTE $0x00   // callq        _format_significand, $26861(%rip)
+	LONG $0x007a8de8; BYTE $0x00   // callq        _format_significand, $31373(%rip)
 	WORD $0x8948; BYTE $0xc3       // movq         %rax, %rbx
 	LONG $0xd07d8b48               // movq         $-48(%rbp), %rdi
 	WORD $0x2948; BYTE $0xf8       // subq         %rdi, %rax
@@ -418,7 +418,7 @@ LBB1_38:
 	WORD $0x0c8d; BYTE $0x12                   // leal         (%rdx,%rdx), %ecx
 	WORD $0x0c8d; BYTE $0x89                   // leal         (%rcx,%rcx,4), %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
-	LONG $0x160d8d48; WORD $0x009a; BYTE $0x00 // leaq         $39446(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x860d8d48; WORD $0x00af; BYTE $0x00 // leaq         $44934(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x510cb70f                           // movzwl       (%rcx,%rdx,2), %ecx
 	LONG $0x024b8966                           // movw         %cx, $2(%rbx)
 	WORD $0x300c                               // orb          $48, %al
@@ -504,7 +504,7 @@ LBB1_52:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
 	LONG $0x007f8c0f; WORD $0x0000             // jl           LBB1_60, $127(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xc30d8d48; WORD $0x0098; BYTE $0x00 // leaq         $39107(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x330d8d48; WORD $0x00ae; BYTE $0x00 // leaq         $44595(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x02438966                           // movw         %ax, $2(%rbx)
 	LONG $0x04c38348                           // addq         $4, %rbx
@@ -744,7 +744,7 @@ LBB1_96:
 
 LBB1_97:
 	WORD $0x894c; BYTE $0xfe     // movq         %r15, %rsi
-	LONG $0x006367e8; BYTE $0x00 // callq        _format_significand, $25447(%rip)
+	LONG $0x007507e8; BYTE $0x00 // callq        _format_significand, $29959(%rip)
 	WORD $0xc289                 // movl         %eax, %edx
 	WORD $0x2844; BYTE $0xfa     // subb         %r15b, %dl
 	WORD $0x2844; BYTE $0xf2     // subb         %r14b, %dl
@@ -1029,7 +1029,7 @@ LBB2_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0x400d8d48; WORD $0x0091; BYTE $0x00 // leaq         $37184(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb00d8d48; WORD $0x00a6; BYTE $0x00 // leaq         $42672(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -1045,7 +1045,7 @@ LBB2_2:
 
 LBB2_5:
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
-	LONG $0xf9158d4c; WORD $0x0090; BYTE $0x00 // leaq         $37113(%rip), %r10  /* _Digits(%rip) */
+	LONG $0x69158d4c; WORD $0x00a6; BYTE $0x00 // leaq         $42601(%rip), %r10  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
 LBB2_6:
@@ -1077,7 +1077,7 @@ LBB2_7:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xca                   // movzwl       %dx, %ecx
-	LONG $0x81158d48; WORD $0x0090; BYTE $0x00 // leaq         $36993(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xf1158d48; WORD $0x00a5; BYTE $0x00 // leaq         $42481(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4b894166; BYTE $0xfe               // movw         %cx, $-2(%r11)
 	LONG $0xfec38349                           // addq         $-2, %r11
@@ -1087,7 +1087,7 @@ LBB2_9:
 	WORD $0xfa83; BYTE $0x0a                   // cmpl         $10, %edx
 	LONG $0x0018820f; WORD $0x0000             // jb           LBB2_11, $24(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x600d8d48; WORD $0x0090; BYTE $0x00 // leaq         $36960(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xd00d8d48; WORD $0x00a5; BYTE $0x00 // leaq         $42448(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x43894166; BYTE $0xfe               // movw         %ax, $-2(%r11)
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
@@ -1176,7 +1176,7 @@ _u64toa:
 	WORD $0x0148; BYTE $0xc0                   // addq         %rax, %rax
 	LONG $0x03e8fe81; WORD $0x0000             // cmpl         $1000, %esi
 	LONG $0x0016820f; WORD $0x0000             // jb           LBB4_3, $22(%rip)
-	LONG $0x7c0d8d48; WORD $0x008f; BYTE $0x00 // leaq         $36732(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xec0d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42220(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x0c8a; BYTE $0x0a                   // movb         (%rdx,%rcx), %cl
 	WORD $0x0f88                               // movb         %cl, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1190,14 +1190,14 @@ LBB4_3:
 LBB4_4:
 	WORD $0xb70f; BYTE $0xd2                   // movzwl       %dx, %edx
 	LONG $0x01ca8348                           // orq          $1, %rdx
-	LONG $0x54358d48; WORD $0x008f; BYTE $0x00 // leaq         $36692(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xc4358d48; WORD $0x00a4; BYTE $0x00 // leaq         $42180(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x32                   // movb         (%rdx,%rsi), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x1488; BYTE $0x37                   // movb         %dl, (%rdi,%rsi)
 
 LBB4_6:
-	LONG $0x42158d48; WORD $0x008f; BYTE $0x00 // leaq         $36674(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xb2158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42162(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x10                   // movb         (%rax,%rdx), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1206,7 +1206,7 @@ LBB4_6:
 LBB4_7:
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x29158d48; WORD $0x008f; BYTE $0x00 // leaq         $36649(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x99158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42137(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x10                   // movb         (%rax,%rdx), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1253,7 +1253,7 @@ LBB4_8:
 	WORD $0x014d; BYTE $0xdb                   // addq         %r11, %r11
 	LONG $0x9680fe81; WORD $0x0098             // cmpl         $10000000, %esi
 	LONG $0x0017820f; WORD $0x0000             // jb           LBB4_11, $23(%rip)
-	LONG $0x86058d48; WORD $0x008e; BYTE $0x00 // leaq         $36486(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xf6058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41974(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x02048a41                           // movb         (%r10,%rax), %al
 	WORD $0x0788                               // movb         %al, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1267,14 +1267,14 @@ LBB4_11:
 LBB4_12:
 	WORD $0x8944; BYTE $0xd0                   // movl         %r10d, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x5a358d48; WORD $0x008e; BYTE $0x00 // leaq         $36442(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xca358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41930(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
 	WORD $0x0488; BYTE $0x37                   // movb         %al, (%rdi,%rsi)
 
 LBB4_14:
-	LONG $0x48058d48; WORD $0x008e; BYTE $0x00 // leaq         $36424(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xb8058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41912(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x01048a41                           // movb         (%r9,%rax), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc183; BYTE $0x01                   // addl         $1, %ecx
@@ -1283,7 +1283,7 @@ LBB4_14:
 LBB4_15:
 	LONG $0xc1b70f41                           // movzwl       %r9w, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x2d358d48; WORD $0x008e; BYTE $0x00 // leaq         $36397(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x9d358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41885(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0x0488; BYTE $0x17                   // movb         %al, (%rdi,%rdx)
@@ -1369,7 +1369,7 @@ LBB4_16:
 	LONG $0x000010b9; BYTE $0x00               // movl         $16, %ecx
 	WORD $0xc129                               // subl         %eax, %ecx
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0x26158d48; WORD $0x00b4; BYTE $0x00 // leaq         $46118(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x96158d48; WORD $0x00c9; BYTE $0x00 // leaq         $51606(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x00380f66; WORD $0x100c             // pshufb       (%rax,%rdx), %xmm1
 	LONG $0x0f7f0ff3                           // movdqu       %xmm1, (%rdi)
 	WORD $0xc889                               // movl         %ecx, %eax
@@ -1395,7 +1395,7 @@ LBB4_20:
 	WORD $0xfa83; BYTE $0x63                   // cmpl         $99, %edx
 	LONG $0x001a870f; WORD $0x0000             // ja           LBB4_22, $26(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x690d8d48; WORD $0x008c; BYTE $0x00 // leaq         $35945(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xd90d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41433(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	LONG $0x000002b9; BYTE $0x00               // movl         $2, %ecx
@@ -1418,7 +1418,7 @@ LBB4_22:
 	WORD $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0x190d8d48; WORD $0x008c; BYTE $0x00 // leaq         $35865(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x890d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41353(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x01478966                           // movw         %ax, $1(%rdi)
 	LONG $0x000003b9; BYTE $0x00               // movl         $3, %ecx
@@ -1428,7 +1428,7 @@ LBB4_24:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xf80d8d48; WORD $0x008b; BYTE $0x00 // leaq         $35832(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x680d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41320(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x8966; BYTE $0x07                   // movw         %ax, (%rdi)
 	WORD $0xb70f; BYTE $0xc2                   // movzwl       %dx, %eax
@@ -1518,8 +1518,8 @@ _quote:
 	WORD $0x8b4c; BYTE $0x11                   // movq         (%rcx), %r10
 	LONG $0x01c0f641                           // testb        $1, %r8b
 	WORD $0x8948; BYTE $0xf0                   // movq         %rsi, %rax
-	LONG $0x880d8d48; WORD $0x00b2; BYTE $0x00 // leaq         $45704(%rip), %rcx  /* __SingleQuoteTab(%rip) */
-	LONG $0x81258d4c; WORD $0x00c2; BYTE $0x00 // leaq         $49793(%rip), %r12  /* __DoubleQuoteTab(%rip) */
+	LONG $0xf80d8d48; WORD $0x00c7; BYTE $0x00 // leaq         $51192(%rip), %rcx  /* __SingleQuoteTab(%rip) */
+	LONG $0xf1258d4c; WORD $0x00d7; BYTE $0x00 // leaq         $55281(%rip), %r12  /* __DoubleQuoteTab(%rip) */
 	LONG $0xe1440f4c                           // cmoveq       %rcx, %r12
 	QUAD $0x00000000f50c8d48                   // leaq         (,%rsi,8), %rcx
 	WORD $0x3949; BYTE $0xca                   // cmpq         %rcx, %r10
@@ -1629,7 +1629,7 @@ LBB5_17:
 	LONG $0x4cb60f43; WORD $0x000d             // movzbl       (%r13,%r9), %ecx
 	WORD $0x8948; BYTE $0xcb                   // movq         %rcx, %rbx
 	LONG $0x04e3c148                           // shlq         $4, %rbx
-	LONG $0xdc358d48; WORD $0x00b0; BYTE $0x00 // leaq         $45276(%rip), %rsi  /* __SingleQuoteTab(%rip) */
+	LONG $0x4c358d48; WORD $0x00c6; BYTE $0x00 // leaq         $50764(%rip), %rsi  /* __SingleQuoteTab(%rip) */
 	LONG $0x333c8348; BYTE $0x00               // cmpq         $0, (%rbx,%rsi)
 	LONG $0x008c850f; WORD $0x0000             // jne          LBB5_27, $140(%rip)
 	LONG $0x13048d4d                           // leaq         (%r11,%rdx), %r8
@@ -1843,7 +1843,7 @@ LBB5_80:
 	LONG $0x000255e9; BYTE $0x00 // jmp          LBB5_82, $597(%rip)
 
 LBB5_56:
-	LONG $0x590d8d4c; WORD $0x00ce; BYTE $0x00 // leaq         $52825(%rip), %r9  /* __EscTab(%rip) */
+	LONG $0xc90d8d4c; WORD $0x00e3; BYTE $0x00 // leaq         $58313(%rip), %r9  /* __EscTab(%rip) */
 	QUAD $0xfffffb71056f0f66                   // movdqa       $-1167(%rip), %xmm0  /* LCPI5_0(%rip) */
 	QUAD $0xfffffb790d6f0f66                   // movdqa       $-1159(%rip), %xmm1  /* LCPI5_1(%rip) */
 	QUAD $0xfffffb81156f0f66                   // movdqa       $-1151(%rip), %xmm2  /* LCPI5_2(%rip) */
@@ -2145,7 +2145,7 @@ LBB6_15:
 LBB6_17:
 	WORD $0x014c; BYTE $0xf0                   // addq         %r14, %rax
 	LONG $0x5bb60f41; BYTE $0xff               // movzbl       $-1(%r11), %ebx
-	LONG $0x84158d4c; WORD $0x00cb; BYTE $0x00 // leaq         $52100(%rip), %r10  /* __UnquoteTab(%rip) */
+	LONG $0xf4158d4c; WORD $0x00e0; BYTE $0x00 // leaq         $57588(%rip), %r10  /* __UnquoteTab(%rip) */
 	LONG $0x131c8a42                           // movb         (%rbx,%r10), %bl
 	WORD $0xfb80; BYTE $0xff                   // cmpb         $-1, %bl
 	LONG $0x0017840f; WORD $0x0000             // je           LBB6_20, $23(%rip)
@@ -2929,7 +2929,7 @@ _html_escape:
 	QUAD $0xffffff910d6f0f66                   // movdqa       $-111(%rip), %xmm1  /* LCPI7_1(%rip) */
 	QUAD $0xffffff99156f0f66                   // movdqa       $-103(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD $0xffffffa11d6f0f66                   // movdqa       $-95(%rip), %xmm3  /* LCPI7_3(%rip) */
-	LONG $0xfa1d8d4c; WORD $0x00c0; BYTE $0x00 // leaq         $49402(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x6a1d8d4c; WORD $0x00d6; BYTE $0x00 // leaq         $54890(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x8949; BYTE $0xfc                   // movq         %rdi, %r12
 	LONG $0xd0758b4c                           // movq         $-48(%rbp), %r14
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
@@ -3043,7 +3043,7 @@ LBB7_17:
 LBB7_20:
 	WORD $0x2949; BYTE $0xdf                   // subq         %rbx, %r15
 	WORD $0x0148; BYTE $0xd9                   // addq         %rbx, %rcx
-	LONG $0x4c1d8d4c; WORD $0x00bf; BYTE $0x00 // leaq         $48972(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0xbc1d8d4c; WORD $0x00d4; BYTE $0x00 // leaq         $54460(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
 LBB7_21:
@@ -3078,7 +3078,7 @@ LBB7_24:
 LBB7_45:
 	WORD $0x294d; BYTE $0xe7                   // subq         %r12, %r15
 	WORD $0x2949; BYTE $0xc7                   // subq         %rax, %r15
-	LONG $0xd21d8d4c; WORD $0x00be; BYTE $0x00 // leaq         $48850(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0x421d8d4c; WORD $0x00d4; BYTE $0x00 // leaq         $54338(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x854d; BYTE $0xff                   // testq        %r15, %r15
 	LONG $0x0109890f; WORD $0x0000             // jns          LBB7_49, $265(%rip)
 	LONG $0x000229e9; BYTE $0x00               // jmp          LBB7_48, $553(%rip)
@@ -3328,7 +3328,7 @@ LBB8_5:
 	WORD $0xd348; BYTE $0xe7                   // shlq         %cl, %rdi
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0x04e1c148                           // shlq         $4, %rcx
-	LONG $0x413d8d4c; WORD $0x0046; BYTE $0x00 // leaq         $17985(%rip), %r15  /* _POW10_M128_TAB(%rip) */
+	LONG $0xb13d8d4c; WORD $0x005b; BYTE $0x00 // leaq         $23473(%rip), %r15  /* _POW10_M128_TAB(%rip) */
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	LONG $0x3964f74a; BYTE $0x08               // mulq         $8(%rcx,%r15)
 	WORD $0x8949; BYTE $0xc3                   // movq         %rax, %r11
@@ -3447,7 +3447,7 @@ LBB9_5:
 	LONG $0xd05d8948                           // movq         %rbx, $-48(%rbp)
 	LONG $0x005a8e0f; WORD $0x0000             // jle          LBB9_12, $90(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0x38358d4c; WORD $0x0070; BYTE $0x00 // leaq         $28728(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0xa8358d4c; WORD $0x0085; BYTE $0x00 // leaq         $34216(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_8, $45(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
@@ -3460,7 +3460,7 @@ LBB9_10:
 LBB9_11:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x0042a5e8; BYTE $0x00 // callq        _right_shift, $17061(%rip)
+	LONG $0x005445e8; BYTE $0x00 // callq        _right_shift, $21573(%rip)
 
 LBB9_7:
 	WORD $0x0141; BYTE $0xdc       // addl         %ebx, %r12d
@@ -3477,7 +3477,7 @@ LBB9_8:
 	LONG $0xffffd3e9; BYTE $0xff   // jmp          LBB9_7, $-45(%rip)
 
 LBB9_12:
-	LONG $0xe1358d4c; WORD $0x006f; BYTE $0x00 // leaq         $28641(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x51358d4c; WORD $0x0085; BYTE $0x00 // leaq         $34129(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_14, $45(%rip)
 
 LBB9_18:
@@ -3489,7 +3489,7 @@ LBB9_18:
 LBB9_20:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x004026e8; BYTE $0x00 // callq        _left_shift, $16422(%rip)
+	LONG $0x0051c6e8; BYTE $0x00 // callq        _left_shift, $20934(%rip)
 	LONG $0x14478b41             // movl         $20(%r15), %eax
 
 LBB9_13:
@@ -3531,7 +3531,7 @@ LBB9_21:
 LBB9_25:
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x00003cbe; BYTE $0x00   // movl         $60, %esi
-	LONG $0x0041b3e8; BYTE $0x00   // callq        _right_shift, $16819(%rip)
+	LONG $0x005353e8; BYTE $0x00   // callq        _right_shift, $21331(%rip)
 	LONG $0x3cc48341               // addl         $60, %r12d
 	LONG $0x88fc8341               // cmpl         $-120, %r12d
 	LONG $0xffe58c0f; WORD $0xffff // jl           LBB9_25, $-27(%rip)
@@ -3557,7 +3557,7 @@ LBB9_31:
 	WORD $0xf741; BYTE $0xdc       // negl         %r12d
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	WORD $0x8944; BYTE $0xe6       // movl         %r12d, %esi
-	LONG $0x00415fe8; BYTE $0x00   // callq        _right_shift, $16735(%rip)
+	LONG $0x0052ffe8; BYTE $0x00   // callq        _right_shift, $21247(%rip)
 	LONG $0xfc02be41; WORD $0xffff // movl         $-1022, %r14d
 
 LBB9_32:
@@ -3565,7 +3565,7 @@ LBB9_32:
 	LONG $0x000d840f; WORD $0x0000 // je           LBB9_34, $13(%rip)
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x000035be; BYTE $0x00   // movl         $53, %esi
-	LONG $0x003f21e8; BYTE $0x00   // callq        _left_shift, $16161(%rip)
+	LONG $0x0050c1e8; BYTE $0x00   // callq        _left_shift, $20673(%rip)
 
 LBB9_34:
 	LONG $0x14478b41                           // movl         $20(%r15), %eax
@@ -3940,7 +3940,7 @@ LBB11_2:
 	LONG $0xb07d8d48               // leaq         $-80(%rbp), %rdi
 	LONG $0xd0758d48               // leaq         $-48(%rbp), %rsi
 	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
-	LONG $0x001387e8; BYTE $0x00   // callq        _vnumber, $4999(%rip)
+	LONG $0x000ff7e8; BYTE $0x00   // callq        _vnumber, $4087(%rip)
 	LONG $0xd0658b4c               // movq         $-48(%rbp), %r12
 	LONG $0x0002f3e9; BYTE $0x00   // jmp          LBB11_49, $755(%rip)
 
@@ -3962,7 +3962,7 @@ LBB11_4:
 LBB11_7:
 	WORD $0x894c; BYTE $0xe7                   // movq         %r12, %rdi
 	WORD $0x8948; BYTE $0xde                   // movq         %rbx, %rsi
-	LONG $0x0024e2e8; BYTE $0x00               // callq        _do_skip_number, $9442(%rip)
+	LONG $0x002132e8; BYTE $0x00               // callq        _do_skip_number, $8498(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
 	LONG $0x0293880f; WORD $0x0000             // js           LBB11_45, $659(%rip)
 	WORD $0x0149; BYTE $0xc4                   // addq         %rax, %r12
@@ -4582,6 +4582,11 @@ LCPI14_2:
 
 	// .p2align 4, 0x90
 _advance_string:
+	WORD $0xc1f6; BYTE $0x20       // testb        $32, %cl
+	LONG $0x0005850f; WORD $0x0000 // jne          LBB14_2, $5(%rip)
+	LONG $0x0047c2e9; BYTE $0x00   // jmp          _advance_string_default, $18370(%rip)
+
+LBB14_2:
 	BYTE $0x55                                 // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
 	WORD $0x5741                               // pushq        %r15
@@ -4590,142 +4595,34 @@ _advance_string:
 	WORD $0x5441                               // pushq        %r12
 	BYTE $0x53                                 // pushq        %rbx
 	LONG $0x28ec8348                           // subq         $40, %rsp
-	LONG $0xd0558948                           // movq         %rdx, $-48(%rbp)
-	WORD $0xc1f6; BYTE $0x20                   // testb        $32, %cl
-	LONG $0x0192850f; WORD $0x0000             // jne          LBB14_12, $402(%rip)
-	LONG $0x087f8b4c                           // movq         $8(%rdi), %r15
-	WORD $0x2949; BYTE $0xf7                   // subq         %rsi, %r15
-	LONG $0x0ac5840f; WORD $0x0000             // je           LBB14_111, $2757(%rip)
-	WORD $0x8b4c; BYTE $0x37                   // movq         (%rdi), %r14
-	LONG $0xd0458b48                           // movq         $-48(%rbp), %rax
-	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
-	LONG $0x40ff8349                           // cmpq         $64, %r15
-	LONG $0x08e6820f; WORD $0x0000             // jb           LBB14_112, $2278(%rip)
-	WORD $0x8948; BYTE $0xf3                   // movq         %rsi, %rbx
-	WORD $0xf748; BYTE $0xd3                   // notq         %rbx
-	QUAD $0xffffffffc045c748                   // movq         $-1, $-64(%rbp)
-	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	QUAD $0xffffff74056f0f66                   // movdqa       $-140(%rip), %xmm0  /* LCPI14_0(%rip) */
-	QUAD $0xffffff7c0d6f0f66                   // movdqa       $-132(%rip), %xmm1  /* LCPI14_1(%rip) */
-	QUAD $0x555555555555ba49; WORD $0x5555     // movabsq      $6148914691236517205, %r10
-	WORD $0x9090                               // .p2align 4, 0x90
-
-LBB14_4:
-	LONG $0x6f0f41f3; WORD $0x3614             // movdqu       (%r14,%rsi), %xmm2
-	LONG $0x6f0f41f3; WORD $0x365c; BYTE $0x10 // movdqu       $16(%r14,%rsi), %xmm3
-	LONG $0x6f0f41f3; WORD $0x3664; BYTE $0x20 // movdqu       $32(%r14,%rsi), %xmm4
-	LONG $0x6f0f41f3; WORD $0x366c; BYTE $0x30 // movdqu       $48(%r14,%rsi), %xmm5
-	LONG $0xf26f0f66                           // movdqa       %xmm2, %xmm6
-	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
-	LONG $0xd70f4466; BYTE $0xe6               // pmovmskb     %xmm6, %r12d
-	LONG $0xf36f0f66                           // movdqa       %xmm3, %xmm6
-	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
-	LONG $0xced70f66                           // pmovmskb     %xmm6, %ecx
-	LONG $0xf46f0f66                           // movdqa       %xmm4, %xmm6
-	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
-	LONG $0xc6d70f66                           // pmovmskb     %xmm6, %eax
-	LONG $0xf56f0f66                           // movdqa       %xmm5, %xmm6
-	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
-	LONG $0xfed70f66                           // pmovmskb     %xmm6, %edi
-	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
-	LONG $0xd70f4466; BYTE $0xea               // pmovmskb     %xmm2, %r13d
-	LONG $0xd9740f66                           // pcmpeqb      %xmm1, %xmm3
-	LONG $0xd3d70f66                           // pmovmskb     %xmm3, %edx
-	LONG $0xe1740f66                           // pcmpeqb      %xmm1, %xmm4
-	LONG $0xd70f4466; BYTE $0xc4               // pmovmskb     %xmm4, %r8d
-	LONG $0xe9740f66                           // pcmpeqb      %xmm1, %xmm5
-	LONG $0xd70f4466; BYTE $0xcd               // pmovmskb     %xmm5, %r9d
-	LONG $0x30e7c148                           // shlq         $48, %rdi
-	LONG $0x20e0c148                           // shlq         $32, %rax
-	WORD $0x0948; BYTE $0xf8                   // orq          %rdi, %rax
-	LONG $0x10e1c148                           // shlq         $16, %rcx
-	WORD $0x0948; BYTE $0xc1                   // orq          %rax, %rcx
-	WORD $0x0949; BYTE $0xcc                   // orq          %rcx, %r12
-	LONG $0x30e1c149                           // shlq         $48, %r9
-	LONG $0x20e0c149                           // shlq         $32, %r8
-	WORD $0x094d; BYTE $0xc8                   // orq          %r9, %r8
-	LONG $0x10e2c148                           // shlq         $16, %rdx
-	WORD $0x094c; BYTE $0xc2                   // orq          %r8, %rdx
-	WORD $0x0949; BYTE $0xd5                   // orq          %rdx, %r13
-	LONG $0x0030850f; WORD $0x0000             // jne          LBB14_8, $48(%rip)
-	WORD $0x854d; BYTE $0xdb                   // testq        %r11, %r11
-	LONG $0x0044850f; WORD $0x0000             // jne          LBB14_10, $68(%rip)
-	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
-	LONG $0x0080850f; WORD $0x0000             // jne          LBB14_11, $128(%rip)
-
-LBB14_7:
-	LONG $0xc0c78349               // addq         $-64, %r15
-	LONG $0xc0c38348               // addq         $-64, %rbx
-	LONG $0x40c68348               // addq         $64, %rsi
-	LONG $0x3fff8349               // cmpq         $63, %r15
-	LONG $0xff36870f; WORD $0xffff // ja           LBB14_4, $-202(%rip)
-	LONG $0x0005b6e9; BYTE $0x00   // jmp          LBB14_70, $1462(%rip)
-
-LBB14_8:
-	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_10, $18(%rip)
-	LONG $0xcdbc0f49               // bsfq         %r13, %rcx
-	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
-	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
-
-LBB14_10:
-	WORD $0x894c; BYTE $0xd8               // movq         %r11, %rax
-	WORD $0xf748; BYTE $0xd0               // notq         %rax
-	WORD $0x214c; BYTE $0xe8               // andq         %r13, %rax
-	LONG $0x000c8d48                       // leaq         (%rax,%rax), %rcx
-	WORD $0x094c; BYTE $0xd9               // orq          %r11, %rcx
-	WORD $0x8948; BYTE $0xca               // movq         %rcx, %rdx
-	WORD $0xf748; BYTE $0xd2               // notq         %rdx
-	WORD $0x214c; BYTE $0xea               // andq         %r13, %rdx
-	QUAD $0xaaaaaaaaaaaabf48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rdi
-	WORD $0x2148; BYTE $0xfa               // andq         %rdi, %rdx
-	WORD $0x3145; BYTE $0xdb               // xorl         %r11d, %r11d
-	WORD $0x0148; BYTE $0xc2               // addq         %rax, %rdx
-	LONG $0xc3920f41                       // setb         %r11b
-	WORD $0x0148; BYTE $0xd2               // addq         %rdx, %rdx
-	WORD $0x314c; BYTE $0xd2               // xorq         %r10, %rdx
-	WORD $0x2148; BYTE $0xca               // andq         %rcx, %rdx
-	WORD $0xf748; BYTE $0xd2               // notq         %rdx
-	WORD $0x2149; BYTE $0xd4               // andq         %rdx, %r12
-	WORD $0x854d; BYTE $0xe4               // testq        %r12, %r12
-	LONG $0xff80840f; WORD $0xffff         // je           LBB14_7, $-128(%rip)
-
-LBB14_11:
-	LONG $0xc4bc0f49             // bsfq         %r12, %rax
-	WORD $0x2948; BYTE $0xd8     // subq         %rbx, %rax
-	LONG $0x00075de9; BYTE $0x00 // jmp          LBB14_108, $1885(%rip)
-
-LBB14_12:
+	LONG $0xc8558948                           // movq         %rdx, $-56(%rbp)
 	LONG $0x086f8b4c                           // movq         $8(%rdi), %r13
 	WORD $0x2949; BYTE $0xf5                   // subq         %rsi, %r13
-	LONG $0x0933840f; WORD $0x0000             // je           LBB14_111, $2355(%rip)
+	LONG $0x0729840f; WORD $0x0000             // je           LBB14_95, $1833(%rip)
 	WORD $0x8b48; BYTE $0x0f                   // movq         (%rdi), %rcx
 	WORD $0x0148; BYTE $0xce                   // addq         %rcx, %rsi
-	LONG $0xd0458b48                           // movq         $-48(%rbp), %rax
+	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
 	LONG $0xff00c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rax)
-	LONG $0xc84d8948                           // movq         %rcx, $-56(%rbp)
+	LONG $0xd04d8948                           // movq         %rcx, $-48(%rbp)
 	WORD $0xf748; BYTE $0xd9                   // negq         %rcx
-	LONG $0xc04d8948                           // movq         %rcx, $-64(%rbp)
-	QUAD $0xffffffffb845c748                   // movq         $-1, $-72(%rbp)
-	QUAD $0xfffde6056f0f4466; BYTE $0xff       // movdqa       $-538(%rip), %xmm8  /* LCPI14_0(%rip) */
-	QUAD $0xfffffdee0d6f0f66                   // movdqa       $-530(%rip), %xmm1  /* LCPI14_1(%rip) */
-	QUAD $0xfffffdf6156f0f66                   // movdqa       $-522(%rip), %xmm2  /* LCPI14_2(%rip) */
+	LONG $0xb04d8948                           // movq         %rcx, $-80(%rbp)
+	QUAD $0xffffffffc045c748                   // movq         $-1, $-64(%rbp)
+	QUAD $0xffff73056f0f4466; BYTE $0xff       // movdqa       $-141(%rip), %xmm8  /* LCPI14_0(%rip) */
+	QUAD $0xffffff7b0d6f0f66                   // movdqa       $-133(%rip), %xmm1  /* LCPI14_1(%rip) */
+	QUAD $0xffffff83156f0f66                   // movdqa       $-125(%rip), %xmm2  /* LCPI14_2(%rip) */
 	LONG $0xdb760f66                           // pcmpeqd      %xmm3, %xmm3
 
-LBB14_14:
-	LONG $0x40fd8349                           // cmpq         $64, %r13
-	LONG $0x0442820f; WORD $0x0000             // jb           LBB14_63, $1090(%rip)
-	LONG $0xc0458b48                           // movq         $-64(%rbp), %rax
-	WORD $0x0148; BYTE $0xf0                   // addq         %rsi, %rax
-	LONG $0xb0458948                           // movq         %rax, $-80(%rbp)
-	WORD $0x3145; BYTE $0xff                   // xorl         %r15d, %r15d
-	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+LBB14_4:
+	LONG $0x40fd8349               // cmpq         $64, %r13
+	LONG $0x043f820f; WORD $0x0000 // jb           LBB14_53, $1087(%rip)
+	LONG $0xb0458b48               // movq         $-80(%rbp), %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xb8458948               // movq         %rax, $-72(%rbp)
+	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
+	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
+	LONG $0x90909090               // .p2align 4, 0x90
 
-LBB14_16:
+LBB14_6:
 	LONG $0x6f0f42f3; WORD $0x3e04             // movdqu       (%rsi,%r15), %xmm0
 	LONG $0x6f0f42f3; WORD $0x3e6c; BYTE $0x10 // movdqu       $16(%rsi,%r15), %xmm5
 	LONG $0x6f0f42f3; WORD $0x3e7c; BYTE $0x20 // movdqu       $32(%rsi,%r15), %xmm7
@@ -4763,11 +4660,11 @@ LBB14_16:
 	LONG $0xe7640f66                           // pcmpgtb      %xmm7, %xmm4
 	LONG $0x10e1c148                           // shlq         $16, %rcx
 	WORD $0x094c; BYTE $0xc1                   // orq          %r8, %rcx
-	LONG $0xd7d70f66                           // pmovmskb     %xmm7, %edx
+	LONG $0xc7d70f66                           // pmovmskb     %xmm7, %eax
 	LONG $0xfb640f66                           // pcmpgtb      %xmm3, %xmm7
 	LONG $0xfcdb0f66                           // pand         %xmm4, %xmm7
 	WORD $0x0949; BYTE $0xce                   // orq          %rcx, %r14
-	LONG $0xc7d70f66                           // pmovmskb     %xmm7, %eax
+	LONG $0xd7d70f66                           // pmovmskb     %xmm7, %edx
 	LONG $0xe26f0f66                           // movdqa       %xmm2, %xmm4
 	LONG $0xe6640f66                           // pcmpgtb      %xmm6, %xmm4
 	LONG $0x30e3c149                           // shlq         $48, %r11
@@ -4780,26 +4677,26 @@ LBB14_16:
 	WORD $0x094d; BYTE $0xd1                   // orq          %r10, %r9
 	LONG $0xced70f66                           // pmovmskb     %xmm6, %ecx
 	LONG $0x30e1c148                           // shlq         $48, %rcx
-	LONG $0x20e0c148                           // shlq         $32, %rax
-	WORD $0x0948; BYTE $0xc8                   // orq          %rcx, %rax
+	LONG $0x20e2c148                           // shlq         $32, %rdx
+	WORD $0x0948; BYTE $0xca                   // orq          %rcx, %rdx
 	LONG $0xcdd70f66                           // pmovmskb     %xmm5, %ecx
 	LONG $0x10e1c148                           // shlq         $16, %rcx
-	WORD $0x0948; BYTE $0xc1                   // orq          %rax, %rcx
+	WORD $0x0948; BYTE $0xd1                   // orq          %rdx, %rcx
 	LONG $0x30e3c148                           // shlq         $48, %rbx
-	LONG $0x20e2c148                           // shlq         $32, %rdx
-	WORD $0x0948; BYTE $0xda                   // orq          %rbx, %rdx
+	LONG $0x20e0c148                           // shlq         $32, %rax
+	WORD $0x0948; BYTE $0xd8                   // orq          %rbx, %rax
 	LONG $0xe06f0f66                           // movdqa       %xmm0, %xmm4
 	LONG $0xe1740f66                           // pcmpeqb      %xmm1, %xmm4
 	LONG $0x10e7c148                           // shlq         $16, %rdi
-	WORD $0x0948; BYTE $0xd7                   // orq          %rdx, %rdi
-	LONG $0xd4d70f66                           // pmovmskb     %xmm4, %edx
-	WORD $0x094c; BYTE $0xca                   // orq          %r9, %rdx
-	LONG $0x005c850f; WORD $0x0000             // jne          LBB14_23, $92(%rip)
+	WORD $0x0948; BYTE $0xc7                   // orq          %rax, %rdi
+	LONG $0xc4d70f66                           // pmovmskb     %xmm4, %eax
+	WORD $0x094c; BYTE $0xc8                   // orq          %r9, %rax
+	LONG $0x005c850f; WORD $0x0000             // jne          LBB14_13, $92(%rip)
 	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
-	LONG $0x0074850f; WORD $0x0000             // jne          LBB14_25, $116(%rip)
+	LONG $0x0074850f; WORD $0x0000             // jne          LBB14_15, $116(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
 
-LBB14_19:
+LBB14_9:
 	LONG $0xe26f0f66               // movdqa       %xmm2, %xmm4
 	LONG $0xe0640f66               // pcmpgtb      %xmm0, %xmm4
 	LONG $0xc0d70f66               // pmovmskb     %xmm0, %eax
@@ -4809,40 +4706,40 @@ LBB14_19:
 	WORD $0x0948; BYTE $0xd1       // orq          %rdx, %rcx
 	WORD $0x0948; BYTE $0xc7       // orq          %rax, %rdi
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
-	LONG $0x009d850f; WORD $0x0000 // jne          LBB14_26, $157(%rip)
+	LONG $0x009d850f; WORD $0x0000 // jne          LBB14_16, $157(%rip)
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x034d850f; WORD $0x0000 // jne          LBB14_68, $845(%rip)
+	LONG $0x034d850f; WORD $0x0000 // jne          LBB14_58, $845(%rip)
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x01a3850f; WORD $0x0000 // jne          LBB14_46, $419(%rip)
+	LONG $0x01a3850f; WORD $0x0000 // jne          LBB14_36, $419(%rip)
 	LONG $0xc0c58349               // addq         $-64, %r13
 	LONG $0x40c78349               // addq         $64, %r15
 	LONG $0x3ffd8349               // cmpq         $63, %r13
-	LONG $0xfe89870f; WORD $0xffff // ja           LBB14_16, $-375(%rip)
-	LONG $0x000195e9; BYTE $0x00   // jmp          LBB14_47, $405(%rip)
+	LONG $0xfe89870f; WORD $0xffff // ja           LBB14_6, $-375(%rip)
+	LONG $0x000195e9; BYTE $0x00   // jmp          LBB14_37, $405(%rip)
 
-LBB14_23:
-	LONG $0xb87d8348; BYTE $0xff   // cmpq         $-1, $-72(%rbp)
-	LONG $0x0016850f; WORD $0x0000 // jne          LBB14_25, $22(%rip)
-	LONG $0xdabc0f48               // bsfq         %rdx, %rbx
-	LONG $0xb05d0348               // addq         $-80(%rbp), %rbx
+LBB14_13:
+	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
+	LONG $0x0016850f; WORD $0x0000 // jne          LBB14_15, $22(%rip)
+	LONG $0xd8bc0f48               // bsfq         %rax, %rbx
+	LONG $0xb85d0348               // addq         $-72(%rbp), %rbx
 	WORD $0x014c; BYTE $0xfb       // addq         %r15, %rbx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
-	LONG $0xb85d8948               // movq         %rbx, $-72(%rbp)
-	WORD $0x8948; BYTE $0x18       // movq         %rbx, (%rax)
+	LONG $0xc8558b48               // movq         $-56(%rbp), %rdx
+	LONG $0xc05d8948               // movq         %rbx, $-64(%rbp)
+	WORD $0x8948; BYTE $0x1a       // movq         %rbx, (%rdx)
 
-LBB14_25:
-	WORD $0x894c; BYTE $0xe0               // movq         %r12, %rax
-	WORD $0xf748; BYTE $0xd0               // notq         %rax
-	WORD $0x2148; BYTE $0xd0               // andq         %rdx, %rax
-	LONG $0x00048d4c                       // leaq         (%rax,%rax), %r8
+LBB14_15:
+	WORD $0x894c; BYTE $0xe2               // movq         %r12, %rdx
+	WORD $0xf748; BYTE $0xd2               // notq         %rdx
+	WORD $0x2148; BYTE $0xc2               // andq         %rax, %rdx
+	LONG $0x12048d4c                       // leaq         (%rdx,%rdx), %r8
 	WORD $0x094d; BYTE $0xe0               // orq          %r12, %r8
 	WORD $0x894c; BYTE $0xc3               // movq         %r8, %rbx
 	WORD $0xf748; BYTE $0xd3               // notq         %rbx
-	WORD $0x2148; BYTE $0xd3               // andq         %rdx, %rbx
-	QUAD $0xaaaaaaaaaaaaba48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rdx
-	WORD $0x2148; BYTE $0xd3               // andq         %rdx, %rbx
+	WORD $0x2148; BYTE $0xc3               // andq         %rax, %rbx
+	QUAD $0xaaaaaaaaaaaab848; WORD $0xaaaa // movabsq      $-6148914691236517206, %rax
+	WORD $0x2148; BYTE $0xc3               // andq         %rax, %rbx
 	WORD $0x3145; BYTE $0xe4               // xorl         %r12d, %r12d
-	WORD $0x0148; BYTE $0xc3               // addq         %rax, %rbx
+	WORD $0x0148; BYTE $0xd3               // addq         %rdx, %rbx
 	LONG $0xc4920f41                       // setb         %r12b
 	WORD $0x0148; BYTE $0xdb               // addq         %rbx, %rbx
 	QUAD $0x555555555555b848; WORD $0x5555 // movabsq      $6148914691236517205, %rax
@@ -4850,95 +4747,95 @@ LBB14_25:
 	WORD $0x214c; BYTE $0xc3               // andq         %r8, %rbx
 	WORD $0xf748; BYTE $0xd3               // notq         %rbx
 	WORD $0x2149; BYTE $0xde               // andq         %rbx, %r14
-	LONG $0xffff41e9; BYTE $0xff           // jmp          LBB14_19, $-191(%rip)
+	LONG $0xffff41e9; BYTE $0xff           // jmp          LBB14_9, $-191(%rip)
 	LONG $0x90909090; BYTE $0x90           // .p2align 4, 0x90
 
-LBB14_26:
-	LONG $0x000040bb; BYTE $0x00   // movl         $64, %ebx
+LBB14_16:
 	LONG $0x000040ba; BYTE $0x00   // movl         $64, %edx
+	LONG $0x000040b8; BYTE $0x00   // movl         $64, %eax
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_28, $4(%rip)
-	LONG $0xd1bc0f48               // bsfq         %rcx, %rdx
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_18, $4(%rip)
+	LONG $0xc1bc0f48               // bsfq         %rcx, %rax
 
-LBB14_28:
-	LONG $0xc6bc0f49               // bsfq         %r14, %rax
+LBB14_18:
+	LONG $0xcebc0f49               // bsfq         %r14, %rcx
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_30, $4(%rip)
-	LONG $0xdfbc0f48               // bsfq         %rdi, %rbx
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_20, $4(%rip)
+	LONG $0xd7bc0f48               // bsfq         %rdi, %rdx
 
-LBB14_30:
-	WORD $0x3948; BYTE $0xc2       // cmpq         %rax, %rdx
-	LONG $0x033a820f; WORD $0x0000 // jb           LBB14_75, $826(%rip)
-	WORD $0x3948; BYTE $0xc3       // cmpq         %rax, %rbx
-	LONG $0x026b830f; WORD $0x0000 // jae          LBB14_67, $619(%rip)
+LBB14_20:
+	WORD $0x3948; BYTE $0xc8       // cmpq         %rcx, %rax
+	LONG $0x02b4820f; WORD $0x0000 // jb           LBB14_60, $692(%rip)
+	WORD $0x3948; BYTE $0xca       // cmpq         %rcx, %rdx
+	LONG $0x026b830f; WORD $0x0000 // jae          LBB14_57, $619(%rip)
 
-LBB14_32:
+LBB14_22:
 	WORD $0x014c; BYTE $0xfe // addq         %r15, %rsi
 
-LBB14_33:
-	WORD $0x0148; BYTE $0xde                               // addq         %rbx, %rsi
-	WORD $0x2949; BYTE $0xdd                               // subq         %rbx, %r13
+LBB14_23:
+	WORD $0x0148; BYTE $0xd6                               // addq         %rdx, %rsi
+	WORD $0x2949; BYTE $0xd5                               // subq         %rdx, %r13
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_34:
+LBB14_24:
 	LONG $0x04fd8349                                                     // cmpq         $4, %r13
-	LONG $0x0341820f; WORD $0x0000                                       // jb           LBB14_79, $833(%rip)
+	LONG $0x02bc820f; WORD $0x0000                                       // jb           LBB14_64, $700(%rip)
 	WORD $0x068b                                                         // movl         (%rsi), %eax
 	WORD $0xc189                                                         // movl         %eax, %ecx
 	LONG $0xc0f0e181; WORD $0x00c0                                       // andl         $12632304, %ecx
 	LONG $0x80e0f981; WORD $0x0080                                       // cmpl         $8421600, %ecx
-	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_38, $48(%rip)
-	WORD $0xc289                                                         // movl         %eax, %edx
-	LONG $0x200fe281; WORD $0x0000                                       // andl         $8207, %edx
-	LONG $0x200dfa81; WORD $0x0000                                       // cmpl         $8205, %edx
-	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_38, $28(%rip)
+	LONG $0x0030850f; WORD $0x0000                                       // jne          LBB14_28, $48(%rip)
+	WORD $0xc789                                                         // movl         %eax, %edi
+	LONG $0x200fe781; WORD $0x0000                                       // andl         $8207, %edi
+	LONG $0x200dff81; WORD $0x0000                                       // cmpl         $8205, %edi
+	LONG $0x001c840f; WORD $0x0000                                       // je           LBB14_28, $28(%rip)
 	LONG $0x000003b9; BYTE $0x00                                         // movl         $3, %ecx
-	WORD $0xd285                                                         // testl        %edx, %edx
-	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_44, $109(%rip)
+	WORD $0xff85                                                         // testl        %edi, %edi
+	LONG $0x006d850f; WORD $0x0000                                       // jne          LBB14_34, $109(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB14_38:
+LBB14_28:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0e0e181; WORD $0x0000 // andl         $49376, %ecx
 	LONG $0x80c0f981; WORD $0x0000 // cmpl         $32960, %ecx
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_40, $16(%rip)
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_30, $16(%rip)
 	WORD $0xc289                   // movl         %eax, %edx
 	LONG $0x000002b9; BYTE $0x00   // movl         $2, %ecx
 	WORD $0xe283; BYTE $0x1e       // andl         $30, %edx
-	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_44, $58(%rip)
+	LONG $0x003a850f; WORD $0x0000 // jne          LBB14_34, $58(%rip)
 
-LBB14_40:
+LBB14_30:
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0xc0f8e181; WORD $0xc0c0 // andl         $-1061109512, %ecx
 	LONG $0x80f0f981; WORD $0x8080 // cmpl         $-2139062032, %ecx
-	LONG $0x0413850f; WORD $0x0000 // jne          LBB14_106, $1043(%rip)
+	LONG $0x038e850f; WORD $0x0000 // jne          LBB14_91, $910(%rip)
 	WORD $0xc189                   // movl         %eax, %ecx
 	LONG $0x3007e181; WORD $0x0000 // andl         $12295, %ecx
-	LONG $0x0405840f; WORD $0x0000 // je           LBB14_106, $1029(%rip)
+	LONG $0x0380840f; WORD $0x0000 // je           LBB14_91, $896(%rip)
 	LONG $0x000004b9; BYTE $0x00   // movl         $4, %ecx
 	WORD $0x04a8                   // testb        $4, %al
-	LONG $0x000b840f; WORD $0x0000 // je           LBB14_44, $11(%rip)
+	LONG $0x000b840f; WORD $0x0000 // je           LBB14_34, $11(%rip)
 	LONG $0x00300325; BYTE $0x00   // andl         $12291, %eax
-	LONG $0x03ed850f; WORD $0x0000 // jne          LBB14_106, $1005(%rip)
+	LONG $0x0368850f; WORD $0x0000 // jne          LBB14_91, $872(%rip)
 
-LBB14_44:
+LBB14_34:
 	WORD $0x0148; BYTE $0xce       // addq         %rcx, %rsi
 	WORD $0x2949; BYTE $0xcd       // subq         %rcx, %r13
-	LONG $0xfce4840f; WORD $0xffff // je           LBB14_14, $-796(%rip)
+	LONG $0xfce7840f; WORD $0xffff // je           LBB14_4, $-793(%rip)
 	WORD $0x3e80; BYTE $0x00       // cmpb         $0, (%rsi)
-	LONG $0xff3d880f; WORD $0xffff // js           LBB14_34, $-195(%rip)
-	LONG $0xfffcd6e9; BYTE $0xff   // jmp          LBB14_14, $-810(%rip)
+	LONG $0xff3d880f; WORD $0xffff // js           LBB14_24, $-195(%rip)
+	LONG $0xfffcd9e9; BYTE $0xff   // jmp          LBB14_4, $-807(%rip)
 
-LBB14_46:
-	LONG $0xdfbc0f48             // bsfq         %rdi, %rbx
-	LONG $0xffff19e9; BYTE $0xff // jmp          LBB14_32, $-231(%rip)
+LBB14_36:
+	LONG $0xd7bc0f48             // bsfq         %rdi, %rdx
+	LONG $0xffff19e9; BYTE $0xff // jmp          LBB14_22, $-231(%rip)
 
-LBB14_47:
+LBB14_37:
 	WORD $0x014c; BYTE $0xfe       // addq         %r15, %rsi
 	LONG $0x20fd8349               // cmpq         $32, %r13
-	LONG $0x0264820f; WORD $0x0000 // jb           LBB14_78, $612(%rip)
+	LONG $0x01df820f; WORD $0x0000 // jb           LBB14_63, $479(%rip)
 
-LBB14_48:
+LBB14_38:
 	LONG $0x266f0ff3               // movdqu       (%rsi), %xmm4
 	LONG $0x6e6f0ff3; BYTE $0x10   // movdqu       $16(%rsi), %xmm5
 	LONG $0xc46f0f66               // movdqa       %xmm4, %xmm0
@@ -4959,12 +4856,12 @@ LBB14_48:
 	LONG $0x10e2c148               // shlq         $16, %rdx
 	LONG $0x10e7c148               // shlq         $16, %rdi
 	WORD $0x0948; BYTE $0xd1       // orq          %rdx, %rcx
-	LONG $0x00c6850f; WORD $0x0000 // jne          LBB14_64, $198(%rip)
+	LONG $0x00c6850f; WORD $0x0000 // jne          LBB14_54, $198(%rip)
 	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
-	LONG $0x00e1850f; WORD $0x0000 // jne          LBB14_66, $225(%rip)
+	LONG $0x00e1850f; WORD $0x0000 // jne          LBB14_56, $225(%rip)
 	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
 
-LBB14_51:
+LBB14_41:
 	LONG $0xc26f0f66               // movdqa       %xmm2, %xmm0
 	LONG $0xc5640f66               // pcmpgtb      %xmm5, %xmm0
 	LONG $0xeb640f66               // pcmpgtb      %xmm3, %xmm5
@@ -4973,66 +4870,66 @@ LBB14_51:
 	LONG $0x10e1c148               // shlq         $16, %rcx
 	LONG $0xc4d70f66               // pmovmskb     %xmm4, %eax
 	WORD $0x0948; BYTE $0xc7       // orq          %rax, %rdi
+	LONG $0x000040ba; BYTE $0x00   // movl         $64, %edx
 	LONG $0x000040bb; BYTE $0x00   // movl         $64, %ebx
-	LONG $0x000040b8; BYTE $0x00   // movl         $64, %eax
 	WORD $0x854d; BYTE $0xc0       // testq        %r8, %r8
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_53, $4(%rip)
-	LONG $0xc0bc0f49               // bsfq         %r8, %rax
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_43, $4(%rip)
+	LONG $0xd8bc0f49               // bsfq         %r8, %rbx
 
-LBB14_53:
+LBB14_43:
 	LONG $0xc26f0f66               // movdqa       %xmm2, %xmm0
 	LONG $0xc4640f66               // pcmpgtb      %xmm4, %xmm0
 	LONG $0xe3640f66               // pcmpgtb      %xmm3, %xmm4
 	LONG $0xe0db0f66               // pand         %xmm0, %xmm4
-	LONG $0xd4d70f66               // pmovmskb     %xmm4, %edx
-	WORD $0x0948; BYTE $0xd1       // orq          %rdx, %rcx
+	LONG $0xc4d70f66               // pmovmskb     %xmm4, %eax
+	WORD $0x0948; BYTE $0xc1       // orq          %rax, %rcx
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0x0004840f; WORD $0x0000 // je           LBB14_55, $4(%rip)
-	LONG $0xdfbc0f48               // bsfq         %rdi, %rbx
+	LONG $0x0004840f; WORD $0x0000 // je           LBB14_45, $4(%rip)
+	LONG $0xd7bc0f48               // bsfq         %rdi, %rdx
 
-LBB14_55:
+LBB14_45:
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x0009840f; WORD $0x0000 // je           LBB14_57, $9(%rip)
-	LONG $0xd1bc0f48               // bsfq         %rcx, %rdx
-	LONG $0x000005e9; BYTE $0x00   // jmp          LBB14_58, $5(%rip)
+	LONG $0x0009840f; WORD $0x0000 // je           LBB14_47, $9(%rip)
+	LONG $0xc1bc0f48               // bsfq         %rcx, %rax
+	LONG $0x000005e9; BYTE $0x00   // jmp          LBB14_48, $5(%rip)
 
-LBB14_57:
-	LONG $0x000040ba; BYTE $0x00 // movl         $64, %edx
+LBB14_47:
+	LONG $0x000040b8; BYTE $0x00 // movl         $64, %eax
 
-LBB14_58:
+LBB14_48:
 	WORD $0x854d; BYTE $0xc0       // testq        %r8, %r8
-	LONG $0x0017840f; WORD $0x0000 // je           LBB14_61, $23(%rip)
-	WORD $0x3948; BYTE $0xc2       // cmpq         %rax, %rdx
-	LONG $0x0321820f; WORD $0x0000 // jb           LBB14_113, $801(%rip)
-	WORD $0x3948; BYTE $0xc3       // cmpq         %rax, %rbx
-	LONG $0xfe1f820f; WORD $0xffff // jb           LBB14_33, $-481(%rip)
-	LONG $0x000157e9; BYTE $0x00   // jmp          LBB14_76, $343(%rip)
+	LONG $0x0017840f; WORD $0x0000 // je           LBB14_51, $23(%rip)
+	WORD $0x3948; BYTE $0xd8       // cmpq         %rbx, %rax
+	LONG $0x0282820f; WORD $0x0000 // jb           LBB14_96, $642(%rip)
+	WORD $0x3948; BYTE $0xda       // cmpq         %rbx, %rdx
+	LONG $0xfe1f820f; WORD $0xffff // jb           LBB14_23, $-481(%rip)
+	LONG $0x0000d1e9; BYTE $0x00   // jmp          LBB14_61, $209(%rip)
 
-LBB14_61:
+LBB14_51:
 	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
-	LONG $0x030a850f; WORD $0x0000 // jne          LBB14_113, $778(%rip)
+	LONG $0x026b850f; WORD $0x0000 // jne          LBB14_96, $619(%rip)
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
-	LONG $0xfe08850f; WORD $0xffff // jne          LBB14_33, $-504(%rip)
-	LONG $0x000150e9; BYTE $0x00   // jmp          LBB14_77, $336(%rip)
+	LONG $0xfe08850f; WORD $0xffff // jne          LBB14_23, $-504(%rip)
+	LONG $0x0000cbe9; BYTE $0x00   // jmp          LBB14_62, $203(%rip)
 
-LBB14_63:
+LBB14_53:
 	WORD $0x3145; BYTE $0xe4       // xorl         %r12d, %r12d
 	LONG $0x20fd8349               // cmpq         $32, %r13
-	LONG $0xfee7830f; WORD $0xffff // jae          LBB14_48, $-281(%rip)
-	LONG $0x000146e9; BYTE $0x00   // jmp          LBB14_78, $326(%rip)
+	LONG $0xfee7830f; WORD $0xffff // jae          LBB14_38, $-281(%rip)
+	LONG $0x0000c1e9; BYTE $0x00   // jmp          LBB14_63, $193(%rip)
 
-LBB14_64:
-	LONG $0xb87d8348; BYTE $0xff   // cmpq         $-1, $-72(%rbp)
-	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_66, $25(%rip)
+LBB14_54:
+	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
+	LONG $0x0019850f; WORD $0x0000 // jne          LBB14_56, $25(%rip)
 	WORD $0x8948; BYTE $0xf0       // movq         %rsi, %rax
-	LONG $0xc8452b48               // subq         $-56(%rbp), %rax
+	LONG $0xd0452b48               // subq         $-48(%rbp), %rax
 	LONG $0xd1bc0f48               // bsfq         %rcx, %rdx
 	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
-	LONG $0xb8558948               // movq         %rdx, $-72(%rbp)
+	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
+	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x10       // movq         %rdx, (%rax)
 
-LBB14_66:
+LBB14_56:
 	WORD $0x8944; BYTE $0xe0       // movl         %r12d, %eax
 	WORD $0xd0f7                   // notl         %eax
 	WORD $0xc821                   // andl         %ecx, %eax
@@ -5049,190 +4946,153 @@ LBB14_66:
 	WORD $0xd321                   // andl         %edx, %ebx
 	WORD $0xd3f7                   // notl         %ebx
 	WORD $0x2141; BYTE $0xd8       // andl         %ebx, %r8d
-	LONG $0xfffeede9; BYTE $0xff   // jmp          LBB14_51, $-275(%rip)
+	LONG $0xfffeede9; BYTE $0xff   // jmp          LBB14_41, $-275(%rip)
 
-LBB14_67:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
-	WORD $0x0148; BYTE $0xc6     // addq         %rax, %rsi
+LBB14_57:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
+	WORD $0x0148; BYTE $0xce     // addq         %rcx, %rsi
 	LONG $0x37048d49             // leaq         (%r15,%rsi), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000244e9; BYTE $0x00 // jmp          LBB14_108, $580(%rip)
+	LONG $0x0001bfe9; BYTE $0x00 // jmp          LBB14_93, $447(%rip)
 
-LBB14_68:
+LBB14_58:
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0xb87d8348; BYTE $0xff               // cmpq         $-1, $-72(%rbp)
-	LONG $0x0232850f; WORD $0x0000             // jne          LBB14_108, $562(%rip)
+	LONG $0xc07d8348; BYTE $0xff               // cmpq         $-1, $-64(%rbp)
+	LONG $0x01ad850f; WORD $0x0000             // jne          LBB14_93, $429(%rip)
 	LONG $0xc9bc0f48                           // bsfq         %rcx, %rcx
-	LONG $0xc8752b48                           // subq         $-56(%rbp), %rsi
+	LONG $0xd0752b48                           // subq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xce                   // addq         %rcx, %rsi
 	WORD $0x014c; BYTE $0xfe                   // addq         %r15, %rsi
-	LONG $0xd04d8b48                           // movq         $-48(%rbp), %rcx
+	LONG $0xc84d8b48                           // movq         $-56(%rbp), %rcx
 	WORD $0x8948; BYTE $0x31                   // movq         %rsi, (%rcx)
-	LONG $0x000218e9; BYTE $0x00               // jmp          LBB14_108, $536(%rip)
+	LONG $0x000193e9; BYTE $0x00               // jmp          LBB14_93, $403(%rip)
 
-LBB14_70:
-	WORD $0x014c; BYTE $0xf6       // addq         %r14, %rsi
-	LONG $0x20ff8349               // cmpq         $32, %r15
-	LONG $0x02b3820f; WORD $0x0000 // jb           LBB14_118, $691(%rip)
-
-LBB14_71:
-	LONG $0x066f0ff3               // movdqu       (%rsi), %xmm0
-	LONG $0x4e6f0ff3; BYTE $0x10   // movdqu       $16(%rsi), %xmm1
-	QUAD $0xfffff8bd156f0f66       // movdqa       $-1859(%rip), %xmm2  /* LCPI14_0(%rip) */
-	QUAD $0xfffff8c51d6f0f66       // movdqa       $-1851(%rip), %xmm3  /* LCPI14_1(%rip) */
-	LONG $0xe06f0f66               // movdqa       %xmm0, %xmm4
-	LONG $0xe2740f66               // pcmpeqb      %xmm2, %xmm4
-	LONG $0xc4d70f66               // pmovmskb     %xmm4, %eax
-	LONG $0xd1740f66               // pcmpeqb      %xmm1, %xmm2
-	LONG $0xcad70f66               // pmovmskb     %xmm2, %ecx
-	LONG $0xc3740f66               // pcmpeqb      %xmm3, %xmm0
-	LONG $0xf8d70f66               // pmovmskb     %xmm0, %edi
-	LONG $0xcb740f66               // pcmpeqb      %xmm3, %xmm1
-	LONG $0xd1d70f66               // pmovmskb     %xmm1, %edx
-	LONG $0x10e1c148               // shlq         $16, %rcx
-	WORD $0x0948; BYTE $0xc8       // orq          %rcx, %rax
-	LONG $0x10e2c148               // shlq         $16, %rdx
-	WORD $0x0948; BYTE $0xd7       // orq          %rdx, %rdi
-	LONG $0x01ff850f; WORD $0x0000 // jne          LBB14_114, $511(%rip)
-	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x0219850f; WORD $0x0000 // jne          LBB14_116, $537(%rip)
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0245840f; WORD $0x0000 // je           LBB14_117, $581(%rip)
-
-LBB14_74:
-	LONG $0xc0bc0f48             // bsfq         %rax, %rax
-	WORD $0x294c; BYTE $0xf6     // subq         %r14, %rsi
-	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
-	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000192e9; BYTE $0x00 // jmp          LBB14_108, $402(%rip)
-
-LBB14_75:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
-	WORD $0x0148; BYTE $0xd6     // addq         %rdx, %rsi
+LBB14_60:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
+	WORD $0x0148; BYTE $0xc6     // addq         %rax, %rsi
 	WORD $0x014c; BYTE $0xfe     // addq         %r15, %rsi
-	LONG $0x000175e9; BYTE $0x00 // jmp          LBB14_107, $373(%rip)
+	LONG $0x000176e9; BYTE $0x00 // jmp          LBB14_92, $374(%rip)
 
-LBB14_76:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
-	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
+LBB14_61:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
+	LONG $0x1e048d48             // leaq         (%rsi,%rbx), %rax
 	LONG $0x01c08348             // addq         $1, %rax
-	LONG $0x000173e9; BYTE $0x00 // jmp          LBB14_108, $371(%rip)
+	LONG $0x000173e9; BYTE $0x00 // jmp          LBB14_93, $371(%rip)
 
-LBB14_77:
+LBB14_62:
 	LONG $0x20c68348 // addq         $32, %rsi
 	LONG $0xe0c58349 // addq         $-32, %r13
 
-LBB14_78:
+LBB14_63:
 	WORD $0x854d; BYTE $0xe4       // testq        %r12, %r12
-	LONG $0x030f850f; WORD $0x0000 // jne          LBB14_139, $783(%rip)
+	LONG $0x018d850f; WORD $0x0000 // jne          LBB14_97, $397(%rip)
 
-LBB14_79:
+LBB14_64:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 
-LBB14_80:
+LBB14_65:
 	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x0152840f; WORD $0x0000 // je           LBB14_108, $338(%rip)
+	LONG $0x0152840f; WORD $0x0000 // je           LBB14_93, $338(%rip)
 	WORD $0xb60f; BYTE $0x0e       // movzbl       (%rsi), %ecx
 	WORD $0xf983; BYTE $0x22       // cmpl         $34, %ecx
-	LONG $0x0155840f; WORD $0x0000 // je           LBB14_109, $341(%rip)
+	LONG $0x0155840f; WORD $0x0000 // je           LBB14_94, $341(%rip)
 	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
-	LONG $0x00f7840f; WORD $0x0000 // je           LBB14_102, $247(%rip)
+	LONG $0x00f7840f; WORD $0x0000 // je           LBB14_87, $247(%rip)
 	WORD $0xf980; BYTE $0x1f       // cmpb         $31, %cl
-	LONG $0x0122860f; WORD $0x0000 // jbe          LBB14_106, $290(%rip)
+	LONG $0x0122860f; WORD $0x0000 // jbe          LBB14_91, $290(%rip)
 	WORD $0xc984                   // testb        %cl, %cl
-	LONG $0x000d880f; WORD $0x0000 // js           LBB14_86, $13(%rip)
+	LONG $0x000d880f; WORD $0x0000 // js           LBB14_71, $13(%rip)
 	LONG $0x01c68348               // addq         $1, %rsi
 	LONG $0xffc58349               // addq         $-1, %r13
-	LONG $0xffffc4e9; BYTE $0xff   // jmp          LBB14_80, $-60(%rip)
+	LONG $0xffffc4e9; BYTE $0xff   // jmp          LBB14_65, $-60(%rip)
 
-LBB14_86:
+LBB14_71:
 	LONG $0x04fd8349               // cmpq         $4, %r13
-	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_88, $7(%rip)
+	LONG $0x0007820f; WORD $0x0000 // jb           LBB14_73, $7(%rip)
 	WORD $0x0e8b                   // movl         (%rsi), %ecx
-	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_92, $40(%rip)
+	LONG $0x000028e9; BYTE $0x00   // jmp          LBB14_77, $40(%rip)
 
-LBB14_88:
+LBB14_73:
 	LONG $0x02fd8349               // cmpq         $2, %r13
-	LONG $0x001b840f; WORD $0x0000 // je           LBB14_91, $27(%rip)
+	LONG $0x001b840f; WORD $0x0000 // je           LBB14_76, $27(%rip)
 	LONG $0x01fd8349               // cmpq         $1, %r13
-	LONG $0x0014840f; WORD $0x0000 // je           LBB14_92, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB14_77, $20(%rip)
 	LONG $0x024eb60f               // movzbl       $2(%rsi), %ecx
 	WORD $0xb70f; BYTE $0x16       // movzwl       (%rsi), %edx
 	WORD $0xe1c1; BYTE $0x10       // shll         $16, %ecx
 	WORD $0xd109                   // orl          %edx, %ecx
-	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_92, $3(%rip)
+	LONG $0x000003e9; BYTE $0x00   // jmp          LBB14_77, $3(%rip)
 
-LBB14_91:
+LBB14_76:
 	WORD $0xb70f; BYTE $0x0e // movzwl       (%rsi), %ecx
 
-LBB14_92:
+LBB14_77:
 	WORD $0xca89                   // movl         %ecx, %edx
 	LONG $0xc0f0e281; WORD $0x00c0 // andl         $12632304, %edx
 	LONG $0x80e0fa81; WORD $0x0080 // cmpl         $8421600, %edx
-	LONG $0x0021850f; WORD $0x0000 // jne          LBB14_95, $33(%rip)
+	LONG $0x0021850f; WORD $0x0000 // jne          LBB14_80, $33(%rip)
 	WORD $0xcf89                   // movl         %ecx, %edi
 	LONG $0x200fe781; WORD $0x0000 // andl         $8207, %edi
 	LONG $0x200dff81; WORD $0x0000 // cmpl         $8205, %edi
-	LONG $0x000d840f; WORD $0x0000 // je           LBB14_95, $13(%rip)
+	LONG $0x000d840f; WORD $0x0000 // je           LBB14_80, $13(%rip)
 	LONG $0x000003ba; BYTE $0x00   // movl         $3, %edx
 	WORD $0xff85                   // testl        %edi, %edi
-	LONG $0x0060850f; WORD $0x0000 // jne          LBB14_101, $96(%rip)
+	LONG $0x0060850f; WORD $0x0000 // jne          LBB14_86, $96(%rip)
 
-LBB14_95:
+LBB14_80:
 	WORD $0xca89                   // movl         %ecx, %edx
 	LONG $0xc0e0e281; WORD $0x0000 // andl         $49376, %edx
 	LONG $0x80c0fa81; WORD $0x0000 // cmpl         $32960, %edx
-	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_97, $16(%rip)
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB14_82, $16(%rip)
 	WORD $0xcf89                   // movl         %ecx, %edi
 	LONG $0x000002ba; BYTE $0x00   // movl         $2, %edx
 	WORD $0xe783; BYTE $0x1e       // andl         $30, %edi
-	LONG $0x003c850f; WORD $0x0000 // jne          LBB14_101, $60(%rip)
+	LONG $0x003c850f; WORD $0x0000 // jne          LBB14_86, $60(%rip)
 
-LBB14_97:
+LBB14_82:
 	WORD $0xca89                   // movl         %ecx, %edx
 	LONG $0xc0f8e281; WORD $0xc0c0 // andl         $-1061109512, %edx
 	LONG $0x80f0fa81; WORD $0x8080 // cmpl         $-2139062032, %edx
-	LONG $0x0067850f; WORD $0x0000 // jne          LBB14_106, $103(%rip)
+	LONG $0x0067850f; WORD $0x0000 // jne          LBB14_91, $103(%rip)
 	WORD $0xca89                   // movl         %ecx, %edx
 	LONG $0x3007e281; WORD $0x0000 // andl         $12295, %edx
-	LONG $0x0059840f; WORD $0x0000 // je           LBB14_106, $89(%rip)
+	LONG $0x0059840f; WORD $0x0000 // je           LBB14_91, $89(%rip)
 	LONG $0x000004ba; BYTE $0x00   // movl         $4, %edx
 	WORD $0xc1f6; BYTE $0x04       // testb        $4, %cl
-	LONG $0x000c840f; WORD $0x0000 // je           LBB14_101, $12(%rip)
+	LONG $0x000c840f; WORD $0x0000 // je           LBB14_86, $12(%rip)
 	LONG $0x3003e181; WORD $0x0000 // andl         $12291, %ecx
-	LONG $0x003f850f; WORD $0x0000 // jne          LBB14_106, $63(%rip)
+	LONG $0x003f850f; WORD $0x0000 // jne          LBB14_91, $63(%rip)
 
-LBB14_101:
+LBB14_86:
 	WORD $0x0148; BYTE $0xd6     // addq         %rdx, %rsi
 	WORD $0x2949; BYTE $0xd5     // subq         %rdx, %r13
-	LONG $0xfffeebe9; BYTE $0xff // jmp          LBB14_80, $-277(%rip)
+	LONG $0xfffeebe9; BYTE $0xff // jmp          LBB14_65, $-277(%rip)
 
-LBB14_102:
+LBB14_87:
 	LONG $0x01fd8349               // cmpq         $1, %r13
-	LONG $0x003c840f; WORD $0x0000 // je           LBB14_108, $60(%rip)
-	LONG $0xb87d8348; BYTE $0xff   // cmpq         $-1, $-72(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_105, $18(%rip)
+	LONG $0x003c840f; WORD $0x0000 // je           LBB14_93, $60(%rip)
+	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
+	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_90, $18(%rip)
 	WORD $0x8948; BYTE $0xf2       // movq         %rsi, %rdx
-	LONG $0xc8552b48               // subq         $-56(%rbp), %rdx
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	LONG $0xb8558948               // movq         %rdx, $-72(%rbp)
+	LONG $0xd0552b48               // subq         $-48(%rbp), %rdx
+	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
+	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
 
-LBB14_105:
+LBB14_90:
 	LONG $0x02c68348             // addq         $2, %rsi
 	LONG $0xfec58349             // addq         $-2, %r13
-	LONG $0xfffeb7e9; BYTE $0xff // jmp          LBB14_80, $-329(%rip)
+	LONG $0xfffeb7e9; BYTE $0xff // jmp          LBB14_65, $-329(%rip)
 
-LBB14_106:
-	LONG $0xc8752b48 // subq         $-56(%rbp), %rsi
+LBB14_91:
+	LONG $0xd0752b48 // subq         $-48(%rbp), %rsi
 
-LBB14_107:
-	LONG $0xd0458b48                           // movq         $-48(%rbp), %rax
+LBB14_92:
+	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
 	WORD $0x8948; BYTE $0x30                   // movq         %rsi, (%rax)
 	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
 
-LBB14_108:
+LBB14_93:
 	LONG $0x28c48348 // addq         $40, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -5242,167 +5102,38 @@ LBB14_108:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB14_109:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
+LBB14_94:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
 	LONG $0x01c68348             // addq         $1, %rsi
-	LONG $0x000133e9; BYTE $0x00 // jmp          LBB14_131, $307(%rip)
-
-LBB14_112:
-	WORD $0x014c; BYTE $0xf6       // addq         %r14, %rsi
-	QUAD $0xffffffffc045c748       // movq         $-1, $-64(%rbp)
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	LONG $0x20ff8349               // cmpq         $32, %r15
-	LONG $0xfdc1830f; WORD $0xffff // jae          LBB14_71, $-575(%rip)
-	LONG $0x00006fe9; BYTE $0x00   // jmp          LBB14_118, $111(%rip)
-
-LBB14_113:
-	LONG $0xc8752b48             // subq         $-56(%rbp), %rsi
-	WORD $0x0148; BYTE $0xd6     // addq         %rdx, %rsi
-	LONG $0xffffade9; BYTE $0xff // jmp          LBB14_107, $-83(%rip)
-
-LBB14_114:
-	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0018850f; WORD $0x0000 // jne          LBB14_116, $24(%rip)
-	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
-	WORD $0x294c; BYTE $0xf1       // subq         %r14, %rcx
-	LONG $0xd7bc0f48               // bsfq         %rdi, %rdx
-	WORD $0x0148; BYTE $0xca       // addq         %rcx, %rdx
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	LONG $0xc0558948               // movq         %rdx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x11       // movq         %rdx, (%rcx)
-
-LBB14_116:
-	WORD $0x8944; BYTE $0xd9       // movl         %r11d, %ecx
-	WORD $0xd1f7                   // notl         %ecx
-	WORD $0xf921                   // andl         %edi, %ecx
-	LONG $0x4b148d41               // leal         (%r11,%rcx,2), %edx
-	WORD $0x1c8d; BYTE $0x09       // leal         (%rcx,%rcx), %ebx
-	WORD $0xd3f7                   // notl         %ebx
-	WORD $0xfb21                   // andl         %edi, %ebx
-	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
-	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
-	WORD $0xcb01                   // addl         %ecx, %ebx
-	LONG $0xc3920f41               // setb         %r11b
-	WORD $0xdb01                   // addl         %ebx, %ebx
-	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
-	WORD $0xd321                   // andl         %edx, %ebx
-	WORD $0xd3f7                   // notl         %ebx
-	WORD $0xd821                   // andl         %ebx, %eax
-	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0xfdbb850f; WORD $0xffff // jne          LBB14_74, $-581(%rip)
-
-LBB14_117:
-	LONG $0x20c68348 // addq         $32, %rsi
-	LONG $0xe0c78349 // addq         $-32, %r15
-
-LBB14_118:
-	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x00be850f; WORD $0x0000 // jne          LBB14_134, $190(%rip)
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0092840f; WORD $0x0000 // je           LBB14_130, $146(%rip)
-
-LBB14_120:
-	WORD $0x894c; BYTE $0xf7                   // movq         %r14, %rdi
-	WORD $0xf748; BYTE $0xd7                   // notq         %rdi
-	LONG $0x01c78348                           // addq         $1, %rdi
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-
-LBB14_121:
-	WORD $0xd231 // xorl         %edx, %edx
-
-LBB14_122:
-	LONG $0x160cb60f               // movzbl       (%rsi,%rdx), %ecx
-	WORD $0xf980; BYTE $0x22       // cmpb         $34, %cl
-	LONG $0x006b840f; WORD $0x0000 // je           LBB14_129, $107(%rip)
-	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
-	LONG $0x0012840f; WORD $0x0000 // je           LBB14_125, $18(%rip)
-	LONG $0x01c28348               // addq         $1, %rdx
-	WORD $0x3949; BYTE $0xd7       // cmpq         %rdx, %r15
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB14_122, $-35(%rip)
-	LONG $0x000062e9; BYTE $0x00   // jmp          LBB14_132, $98(%rip)
-
-LBB14_125:
-	LONG $0xff4f8d49               // leaq         $-1(%r15), %rcx
-	WORD $0x3948; BYTE $0xd1       // cmpq         %rdx, %rcx
-	LONG $0xfefe840f; WORD $0xffff // je           LBB14_108, $-258(%rip)
-	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0012850f; WORD $0x0000 // jne          LBB14_128, $18(%rip)
-	LONG $0x371c8d48               // leaq         (%rdi,%rsi), %rbx
-	WORD $0x0148; BYTE $0xd3       // addq         %rdx, %rbx
-	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
-	LONG $0xc05d8948               // movq         %rbx, $-64(%rbp)
-	WORD $0x8948; BYTE $0x19       // movq         %rbx, (%rcx)
-
-LBB14_128:
-	WORD $0x0148; BYTE $0xd6       // addq         %rdx, %rsi
-	LONG $0x02c68348               // addq         $2, %rsi
-	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
-	WORD $0x2948; BYTE $0xd1       // subq         %rdx, %rcx
-	LONG $0xfec18348               // addq         $-2, %rcx
-	LONG $0xfec78349               // addq         $-2, %r15
-	WORD $0x3949; BYTE $0xd7       // cmpq         %rdx, %r15
-	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
-	LONG $0xff8b850f; WORD $0xffff // jne          LBB14_121, $-117(%rip)
-	LONG $0xfffebbe9; BYTE $0xff   // jmp          LBB14_108, $-325(%rip)
-
-LBB14_129:
-	WORD $0x0148; BYTE $0xd6 // addq         %rdx, %rsi
-	LONG $0x01c68348         // addq         $1, %rsi
-
-LBB14_130:
-	WORD $0x294c; BYTE $0xf6 // subq         %r14, %rsi
-
-LBB14_131:
 	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
-	LONG $0xfffea9e9; BYTE $0xff // jmp          LBB14_108, $-343(%rip)
+	LONG $0xffffe1e9; BYTE $0xff // jmp          LBB14_93, $-31(%rip)
 
-LBB14_132:
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	WORD $0xf980; BYTE $0x22                   // cmpb         $34, %cl
-	LONG $0xfe99850f; WORD $0xffff             // jne          LBB14_108, $-359(%rip)
-	WORD $0x014c; BYTE $0xfe                   // addq         %r15, %rsi
-	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB14_130, $-35(%rip)
+LBB14_96:
+	LONG $0xd0752b48             // subq         $-48(%rbp), %rsi
+	WORD $0x0148; BYTE $0xc6     // addq         %rax, %rsi
+	LONG $0xffffc7e9; BYTE $0xff // jmp          LBB14_92, $-57(%rip)
 
-LBB14_134:
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x006b840f; WORD $0x0000 // je           LBB14_111, $107(%rip)
+LBB14_97:
+	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
+	LONG $0x002d840f; WORD $0x0000 // je           LBB14_95, $45(%rip)
 	LONG $0xc07d8348; BYTE $0xff   // cmpq         $-1, $-64(%rbp)
-	LONG $0x0014850f; WORD $0x0000 // jne          LBB14_137, $20(%rip)
-	WORD $0x894c; BYTE $0xf1       // movq         %r14, %rcx
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_100, $21(%rip)
+	LONG $0xd04d8b48               // movq         $-48(%rbp), %rcx
 	WORD $0xf748; BYTE $0xd1       // notq         %rcx
 	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
+	LONG $0xc8458b48               // movq         $-56(%rbp), %rax
 	LONG $0xc04d8948               // movq         %rcx, $-64(%rbp)
 	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
 
-LBB14_137:
-	LONG $0x01c68348               // addq         $1, %rsi
-	LONG $0xffc78349               // addq         $-1, %r15
-	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0xff12850f; WORD $0xffff // jne          LBB14_120, $-238(%rip)
-	LONG $0xffff9fe9; BYTE $0xff   // jmp          LBB14_130, $-97(%rip)
-
-LBB14_139:
-	WORD $0x854d; BYTE $0xed       // testq        %r13, %r13
-	LONG $0x002d840f; WORD $0x0000 // je           LBB14_111, $45(%rip)
-	LONG $0xb87d8348; BYTE $0xff   // cmpq         $-1, $-72(%rbp)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB14_142, $21(%rip)
-	LONG $0xc84d8b48               // movq         $-56(%rbp), %rcx
-	WORD $0xf748; BYTE $0xd1       // notq         %rcx
-	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
-	LONG $0xd0458b48               // movq         $-48(%rbp), %rax
-	LONG $0xb84d8948               // movq         %rcx, $-72(%rbp)
-	WORD $0x8948; BYTE $0x08       // movq         %rcx, (%rax)
-
-LBB14_142:
+LBB14_100:
 	LONG $0x01c68348             // addq         $1, %rsi
 	LONG $0xffc58349             // addq         $-1, %r13
-	LONG $0xfffcbbe9; BYTE $0xff // jmp          LBB14_79, $-837(%rip)
+	LONG $0xfffe3de9; BYTE $0xff // jmp          LBB14_64, $-451(%rip)
 
-LBB14_111:
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0xfffe11e9; BYTE $0xff               // jmp          LBB14_108, $-495(%rip)
-	LONG $0x00000000                           // .p2align 4, 0x00
+LBB14_95:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff         // movq         $-1, %rax
+	LONG $0xffff93e9; BYTE $0xff                       // jmp          LBB14_93, $-109(%rip)
+	QUAD $0x0000000000000000; WORD $0x0000; BYTE $0x00 // .p2align 4, 0x00
 
 LCPI15_0:
 	LONG $0x43300000 // .long 1127219200
@@ -5787,7 +5518,7 @@ LBB15_61:
 	WORD $0xfe83; BYTE $0x17                   // cmpl         $23, %esi
 	LONG $0x003f8c0f; WORD $0x0000             // jl           LBB15_70, $63(%rip)
 	WORD $0x468d; BYTE $0xea                   // leal         $-22(%rsi), %eax
-	LONG $0xa20d8d48; WORD $0x00c4; BYTE $0x00 // leaq         $50338(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0xa20d8d48; WORD $0x00dd; BYTE $0x00 // leaq         $56738(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x04590ff2; BYTE $0xc1               // mulsd        (%rcx,%rax,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc0               // movsd        %xmm0, $-64(%rbp)
 	LONG $0x000016b8; BYTE $0x00               // movl         $22, %eax
@@ -5797,7 +5528,7 @@ LBB15_67:
 	WORD $0xfe83; BYTE $0xea                   // cmpl         $-22, %esi
 	LONG $0x0052820f; WORD $0x0000             // jb           LBB15_74, $82(%rip)
 	WORD $0xdef7                               // negl         %esi
-	LONG $0x7c058d48; WORD $0x00c4; BYTE $0x00 // leaq         $50300(%rip), %rax  /* _P10_TAB(%rip) */
+	LONG $0x7c058d48; WORD $0x00dd; BYTE $0x00 // leaq         $56700(%rip), %rax  /* _P10_TAB(%rip) */
 	LONG $0x045e0ff2; BYTE $0xf0               // divsd        (%rax,%rsi,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc0               // movsd        %xmm0, $-64(%rbp)
 	LONG $0x00009de9; BYTE $0x00               // jmp          LBB15_78, $157(%rip)
@@ -5812,7 +5543,7 @@ LBB15_71:
 	LONG $0xc82e0f66                           // ucomisd      %xmm0, %xmm1
 	LONG $0x0018870f; WORD $0x0000             // ja           LBB15_74, $24(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0x420d8d48; WORD $0x00c4; BYTE $0x00 // leaq         $50242(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x420d8d48; WORD $0x00dd; BYTE $0x00 // leaq         $56642(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x04590ff2; BYTE $0xc1               // mulsd        (%rcx,%rax,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc0               // movsd        %xmm0, $-64(%rbp)
 	LONG $0x000063e9; BYTE $0x00               // jmp          LBB15_78, $99(%rip)
@@ -5823,7 +5554,7 @@ LBB15_74:
 	LONG $0xc04d8d48               // leaq         $-64(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	LONG $0xa8758948               // movq         %rsi, $-88(%rbp)
-	LONG $0xffdf0be8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8437(%rip)
+	LONG $0xffe29be8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-7525(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x004d840f; WORD $0x0000 // je           LBB15_80, $77(%rip)
 	LONG $0xa8758b48               // movq         $-88(%rbp), %rsi
@@ -5833,7 +5564,7 @@ LBB15_74:
 	LONG $0xb04d8d48               // leaq         $-80(%rbp), %rcx
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
 	WORD $0x558b; BYTE $0xd4       // movl         $-44(%rbp), %edx
-	LONG $0xffdee2e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-8478(%rip)
+	LONG $0xffe272e8; BYTE $0xff   // callq        _atof_eisel_lemire64, $-7566(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x0024840f; WORD $0x0000 // je           LBB15_80, $36(%rip)
 	LONG $0x4d100ff2; BYTE $0xb0   // movsd        $-80(%rbp), %xmm1
@@ -5854,7 +5585,7 @@ LBB15_80:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	LONG $0xc8558b48             // movq         $-56(%rbp), %rdx
 	LONG $0xa04d8b48             // movq         $-96(%rbp), %rcx
-	LONG $0xffe3eae8; BYTE $0xff // callq        _atof_native, $-7190(%rip)
+	LONG $0xffe77ae8; BYTE $0xff // callq        _atof_native, $-6278(%rip)
 	LONG $0x45110ff2; BYTE $0xc0 // movsd        %xmm0, $-64(%rbp)
 	LONG $0x7e0f4866; BYTE $0xc0 // movq         %xmm0, %rax
 	LONG $0x000009e9; BYTE $0x00 // jmp          LBB15_83, $9(%rip)
@@ -6129,17 +5860,18 @@ LBB17_9:
 	BYTE $0xc3               // retq
 	WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-_skip_one:
-	BYTE $0x55                                 // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
-	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
-	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
-	BYTE $0x5d                                 // popq         %rbp
-	LONG $0x000003e9; BYTE $0x00               // jmp          _fsm_exec, $3(%rip)
-	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
+_skip_array:
+	BYTE $0x55                                             // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
+	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
+	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
+	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
+	BYTE $0x5d                                             // popq         %rbp
+	LONG $0x00000de9; BYTE $0x00                           // jmp          _fsm_exec, $13(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _fsm_exec:
 	BYTE $0x55                                 // pushq        %rbp
@@ -6180,7 +5912,7 @@ LBB19_4:
 	LONG $0x007d8b49               // movq         (%r13), %rdi
 	LONG $0x08758b49               // movq         $8(%r13), %rsi
 	WORD $0x894c; BYTE $0xe2       // movq         %r12, %rdx
-	LONG $0xffe861e8; BYTE $0xff   // callq        _advance_ns, $-6047(%rip)
+	LONG $0xffebe1e8; BYTE $0xff   // callq        _advance_ns, $-5151(%rip)
 	WORD $0xc084                   // testb        %al, %al
 	LONG $0x03a7840f; WORD $0x0000 // je           LBB19_57, $935(%rip)
 	WORD $0x6349; BYTE $0x17       // movslq       (%r15), %rdx
@@ -6240,7 +5972,7 @@ LBB19_18:
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
-	LONG $0xffeaabe8; BYTE $0xff   // callq        _advance_string, $-5461(%rip)
+	LONG $0xffee2be8; BYTE $0xff   // callq        _advance_string, $-4565(%rip)
 	WORD $0x8949; BYTE $0xc5       // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0xfef7880f; WORD $0xffff // js           LBB19_2, $-265(%rip)
@@ -6297,7 +6029,7 @@ LBB19_29:
 	WORD $0x014c; BYTE $0xef                   // addq         %r13, %rdi
 	LONG $0x08708b48                           // movq         $8(%rax), %rsi
 	WORD $0x294c; BYTE $0xee                   // subq         %r13, %rsi
-	LONG $0x0006c0e8; BYTE $0x00               // callq        _do_skip_number, $1728(%rip)
+	LONG $0x000690e8; BYTE $0x00               // callq        _do_skip_number, $1680(%rip)
 	LONG $0xff488d48                           // leaq         $-1(%rax), %rcx
 	LONG $0xfec2c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rdx
 	WORD $0x2948; BYTE $0xc2                   // subq         %rax, %rdx
@@ -6335,7 +6067,7 @@ LBB19_34:
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
-	LONG $0xffe958e8; BYTE $0xff   // callq        _advance_string, $-5800(%rip)
+	LONG $0xffecd8e8; BYTE $0xff   // callq        _advance_string, $-4904(%rip)
 	WORD $0x8949; BYTE $0xc5       // movq         %rax, %r13
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0009890f; WORD $0x0000 // jns          LBB19_36, $9(%rip)
@@ -6372,7 +6104,7 @@ LBB19_41:
 	WORD $0x014c; BYTE $0xef       // addq         %r13, %rdi
 	LONG $0x08708b48               // movq         $8(%rax), %rsi
 	WORD $0x294c; BYTE $0xee       // subq         %r13, %rsi
-	LONG $0x0005aee8; BYTE $0x00   // callq        _do_skip_number, $1454(%rip)
+	LONG $0x00057ee8; BYTE $0x00   // callq        _do_skip_number, $1406(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
 	LONG $0x0148880f; WORD $0x0000 // js           LBB19_62, $328(%rip)
 	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
@@ -6690,19 +6422,6 @@ LJTI19_1:
 	LONG $0xfffffec7                           // .long L19_1_set_53
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
-_skip_array:
-	BYTE $0x55                                             // pushq        %rbp
-	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
-	WORD $0x8948; BYTE $0xd0                               // movq         %rdx, %rax
-	WORD $0x8948; BYTE $0xf2                               // movq         %rsi, %rdx
-	WORD $0x8948; BYTE $0xfe                               // movq         %rdi, %rsi
-	QUAD $0x000500000001bf48; WORD $0x0000                 // movabsq      $21474836481, %rdi
-	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
-	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
-	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff8ade9; BYTE $0xff                           // jmp          _fsm_exec, $-1875(%rip)
-	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
-
 _skip_object:
 	BYTE $0x55                                             // pushq        %rbp
 	WORD $0x8948; BYTE $0xe5                               // movq         %rsp, %rbp
@@ -6713,7 +6432,7 @@ _skip_object:
 	WORD $0x8948; BYTE $0x38                               // movq         %rdi, (%rax)
 	WORD $0x8948; BYTE $0xc7                               // movq         %rax, %rdi
 	BYTE $0x5d                                             // popq         %rbp
-	LONG $0xfff87de9; BYTE $0xff                           // jmp          _fsm_exec, $-1923(%rip)
+	LONG $0xfff8ade9; BYTE $0xff                           // jmp          _fsm_exec, $-1875(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
 _skip_string:
@@ -6727,18 +6446,18 @@ _skip_string:
 	WORD $0x8b48; BYTE $0x1e       // movq         (%rsi), %rbx
 	LONG $0xe8558d48               // leaq         $-24(%rbp), %rdx
 	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
-	LONG $0xffe430e8; BYTE $0xff   // callq        _advance_string, $-7120(%rip)
+	LONG $0xffe7e0e8; BYTE $0xff   // callq        _advance_string, $-6176(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0009890f; WORD $0x0000 // jns          LBB22_1, $9(%rip)
+	LONG $0x0009890f; WORD $0x0000 // jns          LBB21_1, $9(%rip)
 	LONG $0xe84d8b48               // movq         $-24(%rbp), %rcx
-	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB22_3, $10(%rip)
+	LONG $0x00000ae9; BYTE $0x00   // jmp          LBB21_3, $10(%rip)
 
-LBB22_1:
+LBB21_1:
 	LONG $0xffc38348         // addq         $-1, %rbx
 	WORD $0x8948; BYTE $0xc1 // movq         %rax, %rcx
 	WORD $0x8948; BYTE $0xd8 // movq         %rbx, %rax
 
-LBB22_3:
+LBB21_3:
 	WORD $0x8949; BYTE $0x0e // movq         %rcx, (%r14)
 	LONG $0x10c48348         // addq         $16, %rsp
 	BYTE $0x5b               // popq         %rbx
@@ -6761,19 +6480,19 @@ _skip_negative:
 	WORD $0x8948; BYTE $0xc7       // movq         %rax, %rdi
 	LONG $0x0000aee8; BYTE $0x00   // callq        _do_skip_number, $174(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x000f880f; WORD $0x0000 // js           LBB23_1, $15(%rip)
+	LONG $0x000f880f; WORD $0x0000 // js           LBB22_1, $15(%rip)
 	WORD $0x0148; BYTE $0xd8       // addq         %rbx, %rax
 	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
 	LONG $0xffc38348               // addq         $-1, %rbx
-	LONG $0x000010e9; BYTE $0x00   // jmp          LBB23_3, $16(%rip)
+	LONG $0x000010e9; BYTE $0x00   // jmp          LBB22_3, $16(%rip)
 
-LBB23_1:
+LBB22_1:
 	WORD $0xf748; BYTE $0xd0                   // notq         %rax
 	WORD $0x0148; BYTE $0xc3                   // addq         %rax, %rbx
 	WORD $0x8949; BYTE $0x1e                   // movq         %rbx, (%r14)
 	LONG $0xfec3c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rbx
 
-LBB23_3:
+LBB22_3:
 	WORD $0x8948; BYTE $0xd8                                 // movq         %rbx, %rax
 	BYTE $0x5b                                               // popq         %rbx
 	WORD $0x5e41                                             // popq         %r14
@@ -6781,25 +6500,25 @@ LBB23_3:
 	BYTE $0xc3                                               // retq
 	QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 4, 0x00
 
-LCPI24_0:
+LCPI23_0:
 	QUAD $0x2f2f2f2f2f2f2f2f; QUAD $0x2f2f2f2f2f2f2f2f // .space 16, '////////////////'
 
-LCPI24_1:
+LCPI23_1:
 	QUAD $0x3a3a3a3a3a3a3a3a; QUAD $0x3a3a3a3a3a3a3a3a // .space 16, '::::::::::::::::'
 
-LCPI24_2:
+LCPI23_2:
 	QUAD $0x2b2b2b2b2b2b2b2b; QUAD $0x2b2b2b2b2b2b2b2b // .space 16, '++++++++++++++++'
 
-LCPI24_3:
+LCPI23_3:
 	QUAD $0x2d2d2d2d2d2d2d2d; QUAD $0x2d2d2d2d2d2d2d2d // .space 16, '----------------'
 
-LCPI24_4:
+LCPI23_4:
 	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
 
-LCPI24_5:
+LCPI23_5:
 	QUAD $0x2e2e2e2e2e2e2e2e; QUAD $0x2e2e2e2e2e2e2e2e // .space 16, '................'
 
-LCPI24_6:
+LCPI23_6:
 	QUAD $0x4545454545454545; QUAD $0x4545454545454545 // .space 16, 'EEEEEEEEEEEEEEEE'
 
 	// .p2align 4, 0x90
@@ -6810,39 +6529,39 @@ _do_skip_number:
 	WORD $0x5641                           // pushq        %r14
 	BYTE $0x53                             // pushq        %rbx
 	WORD $0x8548; BYTE $0xf6               // testq        %rsi, %rsi
-	LONG $0x0256840f; WORD $0x0000         // je           LBB24_1, $598(%rip)
+	LONG $0x0256840f; WORD $0x0000         // je           LBB23_1, $598(%rip)
 	WORD $0x3f80; BYTE $0x30               // cmpb         $48, (%rdi)
-	LONG $0x0035850f; WORD $0x0000         // jne          LBB24_6, $53(%rip)
+	LONG $0x0035850f; WORD $0x0000         // jne          LBB23_6, $53(%rip)
 	LONG $0x000001b8; BYTE $0x00           // movl         $1, %eax
 	LONG $0x01fe8348                       // cmpq         $1, %rsi
-	LONG $0x02d9840f; WORD $0x0000         // je           LBB24_55, $729(%rip)
+	LONG $0x02d9840f; WORD $0x0000         // je           LBB23_55, $729(%rip)
 	WORD $0x4f8a; BYTE $0x01               // movb         $1(%rdi), %cl
 	WORD $0xc180; BYTE $0xd2               // addb         $-46, %cl
 	WORD $0xf980; BYTE $0x37               // cmpb         $55, %cl
-	LONG $0x02ca870f; WORD $0x0000         // ja           LBB24_55, $714(%rip)
+	LONG $0x02ca870f; WORD $0x0000         // ja           LBB23_55, $714(%rip)
 	WORD $0xb60f; BYTE $0xc9               // movzbl       %cl, %ecx
 	QUAD $0x000000800001ba48; WORD $0x0080 // movabsq      $36028797027352577, %rdx
 	LONG $0xcaa30f48                       // btq          %rcx, %rdx
-	LONG $0x02b3830f; WORD $0x0000         // jae          LBB24_55, $691(%rip)
+	LONG $0x02b3830f; WORD $0x0000         // jae          LBB23_55, $691(%rip)
 
-LBB24_6:
+LBB23_6:
 	LONG $0x10fe8348                           // cmpq         $16, %rsi
-	LONG $0x0312820f; WORD $0x0000             // jb           LBB24_7, $786(%rip)
+	LONG $0x0312820f; WORD $0x0000             // jb           LBB23_7, $786(%rip)
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
 	WORD $0xc031                               // xorl         %eax, %eax
-	QUAD $0xffff24056f0f4466; BYTE $0xff       // movdqa       $-220(%rip), %xmm8  /* LCPI24_0(%rip) */
-	QUAD $0xffff2b156f0f4466; BYTE $0xff       // movdqa       $-213(%rip), %xmm10  /* LCPI24_1(%rip) */
-	QUAD $0xffff320d6f0f4466; BYTE $0xff       // movdqa       $-206(%rip), %xmm9  /* LCPI24_2(%rip) */
-	QUAD $0xffffff3a1d6f0f66                   // movdqa       $-198(%rip), %xmm3  /* LCPI24_3(%rip) */
-	QUAD $0xffffff42256f0f66                   // movdqa       $-190(%rip), %xmm4  /* LCPI24_4(%rip) */
-	QUAD $0xffffff4a2d6f0f66                   // movdqa       $-182(%rip), %xmm5  /* LCPI24_5(%rip) */
-	QUAD $0xffffff52356f0f66                   // movdqa       $-174(%rip), %xmm6  /* LCPI24_6(%rip) */
+	QUAD $0xffff24056f0f4466; BYTE $0xff       // movdqa       $-220(%rip), %xmm8  /* LCPI23_0(%rip) */
+	QUAD $0xffff2b156f0f4466; BYTE $0xff       // movdqa       $-213(%rip), %xmm10  /* LCPI23_1(%rip) */
+	QUAD $0xffff320d6f0f4466; BYTE $0xff       // movdqa       $-206(%rip), %xmm9  /* LCPI23_2(%rip) */
+	QUAD $0xffffff3a1d6f0f66                   // movdqa       $-198(%rip), %xmm3  /* LCPI23_3(%rip) */
+	QUAD $0xffffff42256f0f66                   // movdqa       $-190(%rip), %xmm4  /* LCPI23_4(%rip) */
+	QUAD $0xffffff4a2d6f0f66                   // movdqa       $-182(%rip), %xmm5  /* LCPI23_5(%rip) */
+	QUAD $0xffffff52356f0f66                   // movdqa       $-174(%rip), %xmm6  /* LCPI23_6(%rip) */
 	LONG $0xffc1c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r9
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	WORD $0x8949; BYTE $0xf7                   // movq         %rsi, %r15
 	BYTE $0x90                                 // .p2align 4, 0x90
 
-LBB24_9:
+LBB23_9:
 	LONG $0x3c6f0ff3; BYTE $0x07   // movdqu       (%rdi,%rax), %xmm7
 	LONG $0xc76f0f66               // movdqa       %xmm7, %xmm0
 	LONG $0x640f4166; BYTE $0xc0   // pcmpgtb      %xmm8, %xmm0
@@ -6868,7 +6587,7 @@ LBB24_9:
 	WORD $0xd1f7                   // notl         %ecx
 	WORD $0xbc0f; BYTE $0xc9       // bsfl         %ecx, %ecx
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_11, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_11, $20(%rip)
 	LONG $0xffffffba; BYTE $0xff   // movl         $-1, %edx
 	WORD $0xe2d3                   // shll         %cl, %edx
 	WORD $0xd2f7                   // notl         %edx
@@ -6877,168 +6596,168 @@ LBB24_9:
 	WORD $0x2144; BYTE $0xda       // andl         %r11d, %edx
 	WORD $0x8941; BYTE $0xd3       // movl         %edx, %r11d
 
-LBB24_11:
+LBB23_11:
 	WORD $0x538d; BYTE $0xff       // leal         $-1(%rbx), %edx
 	WORD $0xda21                   // andl         %ebx, %edx
-	LONG $0x020e850f; WORD $0x0000 // jne          LBB24_12, $526(%rip)
+	LONG $0x020e850f; WORD $0x0000 // jne          LBB23_12, $526(%rip)
 	LONG $0xff568d41               // leal         $-1(%r14), %edx
 	WORD $0x2144; BYTE $0xf2       // andl         %r14d, %edx
-	LONG $0x0201850f; WORD $0x0000 // jne          LBB24_12, $513(%rip)
+	LONG $0x0201850f; WORD $0x0000 // jne          LBB23_12, $513(%rip)
 	LONG $0xff538d41               // leal         $-1(%r11), %edx
 	WORD $0x2144; BYTE $0xda       // andl         %r11d, %edx
-	LONG $0x01f4850f; WORD $0x0000 // jne          LBB24_12, $500(%rip)
+	LONG $0x01f4850f; WORD $0x0000 // jne          LBB23_12, $500(%rip)
 	WORD $0xdb85                   // testl        %ebx, %ebx
-	LONG $0x0013840f; WORD $0x0000 // je           LBB24_19, $19(%rip)
+	LONG $0x0013840f; WORD $0x0000 // je           LBB23_19, $19(%rip)
 	WORD $0xbc0f; BYTE $0xdb       // bsfl         %ebx, %ebx
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x01f5850f; WORD $0x0000 // jne          LBB24_56, $501(%rip)
+	LONG $0x01f5850f; WORD $0x0000 // jne          LBB23_56, $501(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x8949; BYTE $0xd8       // movq         %rbx, %r8
 
-LBB24_19:
+LBB23_19:
 	WORD $0x8545; BYTE $0xf6       // testl        %r14d, %r14d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_22, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_22, $20(%rip)
 	LONG $0xdebc0f41               // bsfl         %r14d, %ebx
 	LONG $0xfff98349               // cmpq         $-1, %r9
-	LONG $0x01d8850f; WORD $0x0000 // jne          LBB24_56, $472(%rip)
+	LONG $0x01d8850f; WORD $0x0000 // jne          LBB23_56, $472(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x8949; BYTE $0xd9       // movq         %rbx, %r9
 
-LBB24_22:
+LBB23_22:
 	WORD $0x8545; BYTE $0xdb       // testl        %r11d, %r11d
-	LONG $0x0014840f; WORD $0x0000 // je           LBB24_25, $20(%rip)
+	LONG $0x0014840f; WORD $0x0000 // je           LBB23_25, $20(%rip)
 	LONG $0xdbbc0f41               // bsfl         %r11d, %ebx
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x01bb850f; WORD $0x0000 // jne          LBB24_56, $443(%rip)
+	LONG $0x01bb850f; WORD $0x0000 // jne          LBB23_56, $443(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x8949; BYTE $0xda       // movq         %rbx, %r10
 
-LBB24_25:
+LBB23_25:
 	WORD $0xf983; BYTE $0x10       // cmpl         $16, %ecx
-	LONG $0x00c1850f; WORD $0x0000 // jne          LBB24_57, $193(%rip)
+	LONG $0x00c1850f; WORD $0x0000 // jne          LBB23_57, $193(%rip)
 	LONG $0xf0c78349               // addq         $-16, %r15
 	LONG $0x10c08348               // addq         $16, %rax
 	LONG $0x0fff8349               // cmpq         $15, %r15
-	LONG $0xfeeb870f; WORD $0xffff // ja           LBB24_9, $-277(%rip)
+	LONG $0xfeeb870f; WORD $0xffff // ja           LBB23_9, $-277(%rip)
 	LONG $0x070c8d48               // leaq         (%rdi,%rax), %rcx
 	WORD $0x8949; BYTE $0xcb       // movq         %rcx, %r11
 	WORD $0x3948; BYTE $0xf0       // cmpq         %rsi, %rax
-	LONG $0x00a8840f; WORD $0x0000 // je           LBB24_41, $168(%rip)
+	LONG $0x00a8840f; WORD $0x0000 // je           LBB23_41, $168(%rip)
 
-LBB24_28:
+LBB23_28:
 	LONG $0x391c8d4e                           // leaq         (%rcx,%r15), %r11
 	WORD $0x8948; BYTE $0xce                   // movq         %rcx, %rsi
 	WORD $0x2948; BYTE $0xfe                   // subq         %rdi, %rsi
 	WORD $0xc031                               // xorl         %eax, %eax
-	LONG $0xa4358d4c; WORD $0x0001; BYTE $0x00 // leaq         $420(%rip), %r14  /* LJTI24_0(%rip) */
-	LONG $0x000030e9; BYTE $0x00               // jmp          LBB24_29, $48(%rip)
+	LONG $0xa4358d4c; WORD $0x0001; BYTE $0x00 // leaq         $420(%rip), %r14  /* LJTI23_0(%rip) */
+	LONG $0x000030e9; BYTE $0x00               // jmp          LBB23_29, $48(%rip)
 
-LBB24_31:
+LBB23_31:
 	WORD $0xfb83; BYTE $0x65       // cmpl         $101, %ebx
-	LONG $0x009c850f; WORD $0x0000 // jne          LBB24_40, $156(%rip)
+	LONG $0x009c850f; WORD $0x0000 // jne          LBB23_40, $156(%rip)
 
-LBB24_32:
+LBB23_32:
 	LONG $0xfff98349                           // cmpq         $-1, %r9
-	LONG $0x0151850f; WORD $0x0000             // jne          LBB24_58, $337(%rip)
+	LONG $0x0151850f; WORD $0x0000             // jne          LBB23_58, $337(%rip)
 	LONG $0x060c8d4c                           // leaq         (%rsi,%rax), %r9
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
-LBB24_39:
+LBB23_39:
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
-	LONG $0x0060840f; WORD $0x0000 // je           LBB24_41, $96(%rip)
+	LONG $0x0060840f; WORD $0x0000 // je           LBB23_41, $96(%rip)
 
-LBB24_29:
+LBB23_29:
 	LONG $0x011cbe0f               // movsbl       (%rcx,%rax), %ebx
 	WORD $0x538d; BYTE $0xd0       // leal         $-48(%rbx), %edx
 	WORD $0xfa83; BYTE $0x0a       // cmpl         $10, %edx
-	LONG $0xffe3820f; WORD $0xffff // jb           LBB24_39, $-29(%rip)
+	LONG $0xffe3820f; WORD $0xffff // jb           LBB23_39, $-29(%rip)
 	WORD $0x538d; BYTE $0xd5       // leal         $-43(%rbx), %edx
 	WORD $0xfa83; BYTE $0x1a       // cmpl         $26, %edx
-	LONG $0xffb4870f; WORD $0xffff // ja           LBB24_31, $-76(%rip)
+	LONG $0xffb4870f; WORD $0xffff // ja           LBB23_31, $-76(%rip)
 	LONG $0x96146349               // movslq       (%r14,%rdx,4), %rdx
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	JMP  DX
 
-LBB24_37:
+LBB23_37:
 	LONG $0xfffa8349               // cmpq         $-1, %r10
-	LONG $0x0105850f; WORD $0x0000 // jne          LBB24_58, $261(%rip)
+	LONG $0x0105850f; WORD $0x0000 // jne          LBB23_58, $261(%rip)
 	LONG $0x06148d4c               // leaq         (%rsi,%rax), %r10
-	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB24_39, $-69(%rip)
+	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB23_39, $-69(%rip)
 
-LBB24_35:
+LBB23_35:
 	LONG $0xfff88349               // cmpq         $-1, %r8
-	LONG $0x00f2850f; WORD $0x0000 // jne          LBB24_58, $242(%rip)
+	LONG $0x00f2850f; WORD $0x0000 // jne          LBB23_58, $242(%rip)
 	LONG $0x06048d4c               // leaq         (%rsi,%rax), %r8
-	LONG $0xffffa8e9; BYTE $0xff   // jmp          LBB24_39, $-88(%rip)
+	LONG $0xffffa8e9; BYTE $0xff   // jmp          LBB23_39, $-88(%rip)
 
-LBB24_1:
+LBB23_1:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0x00008fe9; BYTE $0x00               // jmp          LBB24_55, $143(%rip)
+	LONG $0x00008fe9; BYTE $0x00               // jmp          LBB23_55, $143(%rip)
 
-LBB24_57:
+LBB23_57:
 	WORD $0x8941; BYTE $0xcb // movl         %ecx, %r11d
 	WORD $0x0149; BYTE $0xfb // addq         %rdi, %r11
 	WORD $0x0149; BYTE $0xc3 // addq         %rax, %r11
 
-LBB24_41:
+LBB23_41:
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xc0                   // testq        %r8, %r8
-	LONG $0x001b850f; WORD $0x0000             // jne          LBB24_42, $27(%rip)
-	LONG $0x000071e9; BYTE $0x00               // jmp          LBB24_55, $113(%rip)
+	LONG $0x001b850f; WORD $0x0000             // jne          LBB23_42, $27(%rip)
+	LONG $0x000071e9; BYTE $0x00               // jmp          LBB23_55, $113(%rip)
 
-LBB24_40:
+LBB23_40:
 	WORD $0x0148; BYTE $0xc1                   // addq         %rax, %rcx
 	WORD $0x8949; BYTE $0xcb                   // movq         %rcx, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x854d; BYTE $0xc0                   // testq        %r8, %r8
-	LONG $0x005b840f; WORD $0x0000             // je           LBB24_55, $91(%rip)
+	LONG $0x005b840f; WORD $0x0000             // je           LBB23_55, $91(%rip)
 
-LBB24_42:
+LBB23_42:
 	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
-	LONG $0x0052840f; WORD $0x0000 // je           LBB24_55, $82(%rip)
+	LONG $0x0052840f; WORD $0x0000 // je           LBB23_55, $82(%rip)
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0049840f; WORD $0x0000 // je           LBB24_55, $73(%rip)
+	LONG $0x0049840f; WORD $0x0000 // je           LBB23_55, $73(%rip)
 	WORD $0x2949; BYTE $0xfb       // subq         %rdi, %r11
 	LONG $0xff438d49               // leaq         $-1(%r11), %rax
 	WORD $0x3949; BYTE $0xc0       // cmpq         %rax, %r8
-	LONG $0x0033840f; WORD $0x0000 // je           LBB24_47, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000 // je           LBB23_47, $51(%rip)
 	WORD $0x3949; BYTE $0xc2       // cmpq         %rax, %r10
-	LONG $0x002a840f; WORD $0x0000 // je           LBB24_47, $42(%rip)
+	LONG $0x002a840f; WORD $0x0000 // je           LBB23_47, $42(%rip)
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x0021840f; WORD $0x0000 // je           LBB24_47, $33(%rip)
+	LONG $0x0021840f; WORD $0x0000 // je           LBB23_47, $33(%rip)
 	WORD $0x854d; BYTE $0xd2       // testq        %r10, %r10
-	LONG $0x00258e0f; WORD $0x0000 // jle          LBB24_51, $37(%rip)
+	LONG $0x00258e0f; WORD $0x0000 // jle          LBB23_51, $37(%rip)
 	LONG $0xff428d49               // leaq         $-1(%r10), %rax
 	WORD $0x3949; BYTE $0xc1       // cmpq         %rax, %r9
-	LONG $0x0018840f; WORD $0x0000 // je           LBB24_51, $24(%rip)
+	LONG $0x0018840f; WORD $0x0000 // je           LBB23_51, $24(%rip)
 	WORD $0xf749; BYTE $0xd2       // notq         %r10
 	WORD $0x894c; BYTE $0xd0       // movq         %r10, %rax
-	LONG $0x000006e9; BYTE $0x00   // jmp          LBB24_55, $6(%rip)
+	LONG $0x000006e9; BYTE $0x00   // jmp          LBB23_55, $6(%rip)
 
-LBB24_47:
+LBB23_47:
 	WORD $0xf749; BYTE $0xdb // negq         %r11
 	WORD $0x894c; BYTE $0xd8 // movq         %r11, %rax
 
-LBB24_55:
+LBB23_55:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	BYTE $0xc3   // retq
 
-LBB24_51:
+LBB23_51:
 	WORD $0x894c; BYTE $0xc0       // movq         %r8, %rax
 	WORD $0x094c; BYTE $0xc8       // orq          %r9, %rax
 	WORD $0x990f; BYTE $0xc0       // setns        %al
-	LONG $0x0014880f; WORD $0x0000 // js           LBB24_54, $20(%rip)
+	LONG $0x0014880f; WORD $0x0000 // js           LBB23_54, $20(%rip)
 	WORD $0x394d; BYTE $0xc8       // cmpq         %r9, %r8
-	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB24_54, $11(%rip)
+	LONG $0x000b8c0f; WORD $0x0000 // jl           LBB23_54, $11(%rip)
 	WORD $0xf749; BYTE $0xd0       // notq         %r8
 	WORD $0x894c; BYTE $0xc0       // movq         %r8, %rax
-	LONG $0xffffd6e9; BYTE $0xff   // jmp          LBB24_55, $-42(%rip)
+	LONG $0xffffd6e9; BYTE $0xff   // jmp          LBB23_55, $-42(%rip)
 
-LBB24_54:
+LBB23_54:
 	LONG $0xff498d49             // leaq         $-1(%r9), %rcx
 	WORD $0x3949; BYTE $0xc8     // cmpq         %rcx, %r8
 	WORD $0xf749; BYTE $0xd1     // notq         %r9
@@ -7046,67 +6765,67 @@ LBB24_54:
 	WORD $0xc084                 // testb        %al, %al
 	LONG $0xcb440f4d             // cmoveq       %r11, %r9
 	WORD $0x894c; BYTE $0xc8     // movq         %r9, %rax
-	LONG $0xffffbae9; BYTE $0xff // jmp          LBB24_55, $-70(%rip)
+	LONG $0xffffbae9; BYTE $0xff // jmp          LBB23_55, $-70(%rip)
 
-LBB24_12:
+LBB23_12:
 	WORD $0xbc0f; BYTE $0xca     // bsfl         %edx, %ecx
-	LONG $0x000010e9; BYTE $0x00 // jmp          LBB24_13, $16(%rip)
+	LONG $0x000010e9; BYTE $0x00 // jmp          LBB23_13, $16(%rip)
 
-LBB24_58:
+LBB23_58:
 	WORD $0x2948; BYTE $0xcf     // subq         %rcx, %rdi
 	WORD $0xf748; BYTE $0xd0     // notq         %rax
 	WORD $0x0148; BYTE $0xf8     // addq         %rdi, %rax
-	LONG $0xffffa4e9; BYTE $0xff // jmp          LBB24_55, $-92(%rip)
+	LONG $0xffffa4e9; BYTE $0xff // jmp          LBB23_55, $-92(%rip)
 
-LBB24_56:
+LBB23_56:
 	WORD $0xd989 // movl         %ebx, %ecx
 
-LBB24_13:
+LBB23_13:
 	WORD $0xf748; BYTE $0xd0     // notq         %rax
 	WORD $0x2948; BYTE $0xc8     // subq         %rcx, %rax
-	LONG $0xffff97e9; BYTE $0xff // jmp          LBB24_55, $-105(%rip)
+	LONG $0xffff97e9; BYTE $0xff // jmp          LBB23_55, $-105(%rip)
 
-LBB24_7:
+LBB23_7:
 	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
 	WORD $0x8948; BYTE $0xf9                   // movq         %rdi, %rcx
 	WORD $0x8949; BYTE $0xf7                   // movq         %rsi, %r15
 	LONG $0xffc1c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r9
 	LONG $0xffc2c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r10
-	LONG $0xfffe49e9; BYTE $0xff               // jmp          LBB24_28, $-439(%rip)
+	LONG $0xfffe49e9; BYTE $0xff               // jmp          LBB23_28, $-439(%rip)
 
 	// .p2align 2, 0x90
-	// .set L24_0_set_37, LBB24_37-LJTI24_0
-	// .set L24_0_set_40, LBB24_40-LJTI24_0
-	// .set L24_0_set_35, LBB24_35-LJTI24_0
-	// .set L24_0_set_32, LBB24_32-LJTI24_0
-LJTI24_0:
-	LONG $0xfffffeb6         // .long L24_0_set_37
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xfffffeb6         // .long L24_0_set_37
-	LONG $0xfffffec9         // .long L24_0_set_35
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xffffff06         // .long L24_0_set_40
-	LONG $0xfffffe6a         // .long L24_0_set_32
+	// .set L23_0_set_37, LBB23_37-LJTI23_0
+	// .set L23_0_set_40, LBB23_40-LJTI23_0
+	// .set L23_0_set_35, LBB23_35-LJTI23_0
+	// .set L23_0_set_32, LBB23_32-LJTI23_0
+LJTI23_0:
+	LONG $0xfffffeb6         // .long L23_0_set_37
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xfffffeb6         // .long L23_0_set_37
+	LONG $0xfffffec9         // .long L23_0_set_35
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xffffff06         // .long L23_0_set_40
+	LONG $0xfffffe6a         // .long L23_0_set_32
 	QUAD $0x9090909090909090 // .p2align 4, 0x90
 
 _skip_positive:
@@ -7160,22 +6879,22 @@ _skip_number:
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 	WORD $0x2948; BYTE $0xc6       // subq         %rax, %rsi
-	LONG $0x003b840f; WORD $0x0000 // je           LBB26_6, $59(%rip)
+	LONG $0x003b840f; WORD $0x0000 // je           LBB25_6, $59(%rip)
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0x000c830f; WORD $0x0000 // jae          LBB26_3, $12(%rip)
+	LONG $0x000c830f; WORD $0x0000 // jae          LBB25_3, $12(%rip)
 	WORD $0x038a                   // movb         (%rbx), %al
 	WORD $0xd004                   // addb         $-48, %al
 	WORD $0x093c                   // cmpb         $9, %al
-	LONG $0x0038870f; WORD $0x0000 // ja           LBB26_8, $56(%rip)
+	LONG $0x0038870f; WORD $0x0000 // ja           LBB25_8, $56(%rip)
 
-LBB26_3:
+LBB25_3:
 	WORD $0x8948; BYTE $0xdf       // movq         %rbx, %rdi
 	LONG $0xfffb51e8; BYTE $0xff   // callq        _do_skip_number, $-1199(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x0021880f; WORD $0x0000 // js           LBB26_7, $33(%rip)
+	LONG $0x0021880f; WORD $0x0000 // js           LBB25_7, $33(%rip)
 	WORD $0x0148; BYTE $0xc3       // addq         %rax, %rbx
 
-LBB26_5:
+LBB25_5:
 	WORD $0x294c; BYTE $0xe3 // subq         %r12, %rbx
 	WORD $0x8949; BYTE $0x1e // movq         %rbx, (%r14)
 	WORD $0x894c; BYTE $0xf8 // movq         %r15, %rax
@@ -7186,18 +6905,30 @@ LBB26_5:
 	BYTE $0x5d               // popq         %rbp
 	BYTE $0xc3               // retq
 
-LBB26_6:
+LBB25_6:
 	LONG $0xffc7c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r15
-	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB26_5, $-30(%rip)
+	LONG $0xffffe2e9; BYTE $0xff               // jmp          LBB25_5, $-30(%rip)
 
-LBB26_7:
+LBB25_7:
 	WORD $0xf748; BYTE $0xd0 // notq         %rax
 	WORD $0x0148; BYTE $0xc3 // addq         %rax, %rbx
 
-LBB26_8:
+LBB25_8:
 	LONG $0xfec7c749; WORD $0xffff; BYTE $0xff // movq         $-2, %r15
-	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB26_5, $-48(%rip)
+	LONG $0xffffd0e9; BYTE $0xff               // jmp          LBB25_5, $-48(%rip)
 	LONG $0x90909090; BYTE $0x90               // .p2align 4, 0x90
+
+_skip_one:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
+	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
+	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
+	LONG $0x0100c748; WORD $0x0000; BYTE $0x00 // movq         $1, (%rax)
+	WORD $0x8948; BYTE $0xc7                   // movq         %rax, %rdi
+	BYTE $0x5d                                 // popq         %rbp
+	LONG $0xfff273e9; BYTE $0xff               // jmp          _fsm_exec, $-3469(%rip)
+	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
 _validate_one:
 	BYTE $0x55                                               // pushq        %rbp
@@ -7209,10 +6940,1528 @@ _validate_one:
 	LONG $0x000020b9; BYTE $0x00                             // movl         $32, %ecx
 	WORD $0x8948; BYTE $0xc7                                 // movq         %rax, %rdi
 	BYTE $0x5d                                               // popq         %rbp
-	LONG $0xfff23ee9; BYTE $0xff                             // jmp          _fsm_exec, $-3522(%rip)
+	LONG $0xfff24ee9; BYTE $0xff                             // jmp          _fsm_exec, $-3506(%rip)
 	QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 4, 0x00
 
 LCPI28_0:
+	QUAD $0x2c2c2c2c2c2c2c2c; QUAD $0x2c2c2c2c2c2c2c2c // .space 16, ',,,,,,,,,,,,,,,,'
+
+LCPI28_1:
+	QUAD $0xdfdfdfdfdfdfdfdf; QUAD $0xdfdfdfdfdfdfdfdf // .space 16, '\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf\xdf'
+
+LCPI28_2:
+	QUAD $0x5d5d5d5d5d5d5d5d; QUAD $0x5d5d5d5d5d5d5d5d // .space 16, ']]]]]]]]]]]]]]]]'
+
+LCPI28_3:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI28_4:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+LCPI28_5:
+	QUAD $0x7b7b7b7b7b7b7b7b; QUAD $0x7b7b7b7b7b7b7b7b // .space 16, '{{{{{{{{{{{{{{{{'
+
+LCPI28_6:
+	QUAD $0x7d7d7d7d7d7d7d7d; QUAD $0x7d7d7d7d7d7d7d7d // .space 16, '}}}}}}}}}}}}}}}}'
+
+LCPI28_7:
+	QUAD $0x5b5b5b5b5b5b5b5b; QUAD $0x5b5b5b5b5b5b5b5b // .space 16, '[[[[[[[[[[[[[[[['
+
+	// .p2align 4, 0x90
+_skip_one_fast:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x5741                               // pushq        %r15
+	WORD $0x5641                               // pushq        %r14
+	WORD $0x5541                               // pushq        %r13
+	WORD $0x5441                               // pushq        %r12
+	BYTE $0x53                                 // pushq        %rbx
+	LONG $0x58ec8348                           // subq         $88, %rsp
+	WORD $0x8949; BYTE $0xf6                   // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xfc                   // movq         %rdi, %r12
+	WORD $0x8b48; BYTE $0x3f                   // movq         (%rdi), %rdi
+	LONG $0x24748b49; BYTE $0x08               // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                   // movq         %r14, %rdx
+	LONG $0xffdde9e8; BYTE $0xff               // callq        _advance_ns, $-8727(%rip)
+	WORD $0x8b49; BYTE $0x16                   // movq         (%r14), %rdx
+	LONG $0xff428d4c                           // leaq         $-1(%rdx), %r8
+	WORD $0xbe0f; BYTE $0xc8                   // movsbl       %al, %ecx
+	WORD $0xf983; BYTE $0x7b                   // cmpl         $123, %ecx
+	LONG $0x011a870f; WORD $0x0000             // ja           LBB28_19, $282(%rip)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0x9c358d48; WORD $0x000b; BYTE $0x00 // leaq         $2972(%rip), %rsi  /* LJTI28_0(%rip) */
+	LONG $0x8e0c6348                           // movslq       (%rsi,%rcx,4), %rcx
+	WORD $0x0148; BYTE $0xf1                   // addq         %rsi, %rcx
+	JMP  CX
+
+LBB28_2:
+	LONG $0x24048b49               // movq         (%r12), %rax
+	LONG $0x244c8b49; BYTE $0x08   // movq         $8(%r12), %rcx
+	WORD $0x8948; BYTE $0xce       // movq         %rcx, %rsi
+	WORD $0x2948; BYTE $0xd6       // subq         %rdx, %rsi
+	LONG $0x10fe8348               // cmpq         $16, %rsi
+	LONG $0x0b23820f; WORD $0x0000 // jb           LBB28_88, $2851(%rip)
+	WORD $0x8948; BYTE $0xd6       // movq         %rdx, %rsi
+	WORD $0xf748; BYTE $0xde       // negq         %rsi
+	QUAD $0xffffff08056f0f66       // movdqa       $-248(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xffffff100d6f0f66       // movdqa       $-240(%rip), %xmm1  /* LCPI28_1(%rip) */
+	QUAD $0xffffff18156f0f66       // movdqa       $-232(%rip), %xmm2  /* LCPI28_2(%rip) */
+	QUAD $0x9090909090909090       // .p2align 4, 0x90
+
+LBB28_4:
+	LONG $0x1c6f0ff3; BYTE $0x10   // movdqu       (%rax,%rdx), %xmm3
+	LONG $0xe36f0f66               // movdqa       %xmm3, %xmm4
+	LONG $0xe0740f66               // pcmpeqb      %xmm0, %xmm4
+	LONG $0xd9db0f66               // pand         %xmm1, %xmm3
+	LONG $0xda740f66               // pcmpeqb      %xmm2, %xmm3
+	LONG $0xdceb0f66               // por          %xmm4, %xmm3
+	LONG $0xfbd70f66               // pmovmskb     %xmm3, %edi
+	WORD $0xff85                   // testl        %edi, %edi
+	LONG $0x006c850f; WORD $0x0000 // jne          LBB28_14, $108(%rip)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x313c8d48               // leaq         (%rcx,%rsi), %rdi
+	LONG $0xf0c78348               // addq         $-16, %rdi
+	LONG $0xf0c68348               // addq         $-16, %rsi
+	LONG $0x0fff8348               // cmpq         $15, %rdi
+	LONG $0xffc1870f; WORD $0xffff // ja           LBB28_4, $-63(%rip)
+	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
+	WORD $0x2948; BYTE $0xf2       // subq         %rsi, %rdx
+	WORD $0x0148; BYTE $0xf1       // addq         %rsi, %rcx
+	WORD $0x8948; BYTE $0xce       // movq         %rcx, %rsi
+	WORD $0x8548; BYTE $0xf6       // testq        %rsi, %rsi
+	LONG $0x0035840f; WORD $0x0000 // je           LBB28_13, $53(%rip)
+
+LBB28_7:
+	LONG $0x323c8d48 // leaq         (%rdx,%rsi), %rdi
+	WORD $0xc931     // xorl         %ecx, %ecx
+
+LBB28_8:
+	LONG $0x0a1cb60f               // movzbl       (%rdx,%rcx), %ebx
+	WORD $0xfb80; BYTE $0x2c       // cmpb         $44, %bl
+	LONG $0x09fb840f; WORD $0x0000 // je           LBB28_85, $2555(%rip)
+	WORD $0xfb80; BYTE $0x7d       // cmpb         $125, %bl
+	LONG $0x09f2840f; WORD $0x0000 // je           LBB28_85, $2546(%rip)
+	WORD $0xfb80; BYTE $0x5d       // cmpb         $93, %bl
+	LONG $0x09e9840f; WORD $0x0000 // je           LBB28_85, $2537(%rip)
+	LONG $0x01c18348               // addq         $1, %rcx
+	WORD $0x3948; BYTE $0xce       // cmpq         %rcx, %rsi
+	LONG $0xffd4850f; WORD $0xffff // jne          LBB28_8, $-44(%rip)
+	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
+
+LBB28_13:
+	WORD $0x2948; BYTE $0xc2     // subq         %rax, %rdx
+	LONG $0x0009d7e9; BYTE $0x00 // jmp          LBB28_86, $2519(%rip)
+
+LBB28_14:
+	LONG $0xc7bc0f66         // bsfw         %di, %ax
+	WORD $0xb70f; BYTE $0xc0 // movzwl       %ax, %eax
+	WORD $0x2948; BYTE $0xf0 // subq         %rsi, %rax
+
+LBB28_15:
+	WORD $0x8949; BYTE $0x06 // movq         %rax, (%r14)
+
+LBB28_16:
+	WORD $0x894c; BYTE $0xc0 // movq         %r8, %rax
+
+LBB28_17:
+	LONG $0x58c48348 // addq         $88, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB28_18:
+	LONG $0x03c28348               // addq         $3, %rdx
+	LONG $0x24543b49; BYTE $0x08   // cmpq         $8(%r12), %rdx
+	LONG $0xffe2830f; WORD $0xffff // jae          LBB28_17, $-30(%rip)
+	LONG $0x0009a4e9; BYTE $0x00   // jmp          LBB28_86, $2468(%rip)
+
+LBB28_19:
+	WORD $0x894d; BYTE $0x06                   // movq         %r8, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xffffcee9; BYTE $0xff               // jmp          LBB28_17, $-50(%rip)
+
+LBB28_20:
+	LONG $0x24048b49               // movq         (%r12), %rax
+	LONG $0x244c8b4d; BYTE $0x08   // movq         $8(%r12), %r9
+	LONG $0x10148d4c               // leaq         (%rax,%rdx), %r10
+	WORD $0x2949; BYTE $0xd1       // subq         %rdx, %r9
+	LONG $0x20f98349               // cmpq         $32, %r9
+	LONG $0x0a21820f; WORD $0x0000 // jb           LBB28_89, $2593(%rip)
+	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
+	QUAD $0xfffffe28056f0f66       // movdqa       $-472(%rip), %xmm0  /* LCPI28_3(%rip) */
+	QUAD $0xfffffe300d6f0f66       // movdqa       $-464(%rip), %xmm1  /* LCPI28_4(%rip) */
+	WORD $0x3145; BYTE $0xed       // xorl         %r13d, %r13d
+	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
+	LONG $0x00002be9; BYTE $0x00   // jmp          LBB28_22, $43(%rip)
+	LONG $0x90909090; BYTE $0x90   // .p2align 4, 0x90
+
+LBB28_24:
+	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x00a5850f; WORD $0x0000 // jne          LBB28_79, $165(%rip)
+
+LBB28_25:
+	LONG $0x20c58349               // addq         $32, %r13
+	LONG $0x390c8d4b               // leaq         (%r9,%r15), %rcx
+	LONG $0xe0c18348               // addq         $-32, %rcx
+	LONG $0xe0c78349               // addq         $-32, %r15
+	LONG $0x1ff98348               // cmpq         $31, %rcx
+	LONG $0x093a860f; WORD $0x0000 // jbe          LBB28_26, $2362(%rip)
+
+LBB28_22:
+	LONG $0x6f0f43f3; WORD $0x2a14             // movdqu       (%r10,%r13), %xmm2
+	LONG $0x6f0f43f3; WORD $0x2a5c; BYTE $0x10 // movdqu       $16(%r10,%r13), %xmm3
+	LONG $0xe26f0f66                           // movdqa       %xmm2, %xmm4
+	LONG $0xe0740f66                           // pcmpeqb      %xmm0, %xmm4
+	LONG $0xfcd70f66                           // pmovmskb     %xmm4, %edi
+	LONG $0xe36f0f66                           // movdqa       %xmm3, %xmm4
+	LONG $0xe0740f66                           // pcmpeqb      %xmm0, %xmm4
+	LONG $0xccd70f66                           // pmovmskb     %xmm4, %ecx
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf9                   // orq          %rdi, %rcx
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0xd9740f66                           // pcmpeqb      %xmm1, %xmm3
+	LONG $0xfbd70f66                           // pmovmskb     %xmm3, %edi
+	LONG $0x10e7c148                           // shlq         $16, %rdi
+	WORD $0x0948; BYTE $0xf7                   // orq          %rsi, %rdi
+	WORD $0x8948; BYTE $0xfe                   // movq         %rdi, %rsi
+	WORD $0x094c; BYTE $0xde                   // orq          %r11, %rsi
+	LONG $0xff8b840f; WORD $0xffff             // je           LBB28_24, $-117(%rip)
+	WORD $0x8944; BYTE $0xde                   // movl         %r11d, %esi
+	WORD $0xd6f7                               // notl         %esi
+	WORD $0xfe21                               // andl         %edi, %esi
+	LONG $0x36248d44                           // leal         (%rsi,%rsi), %r12d
+	WORD $0x0945; BYTE $0xdc                   // orl          %r11d, %r12d
+	WORD $0x8944; BYTE $0xe3                   // movl         %r12d, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	WORD $0xfb21                               // andl         %edi, %ebx
+	LONG $0xaaaae381; WORD $0xaaaa             // andl         $-1431655766, %ebx
+	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
+	WORD $0xf301                               // addl         %esi, %ebx
+	LONG $0xc3920f41                           // setb         %r11b
+	WORD $0xdb01                               // addl         %ebx, %ebx
+	LONG $0x5555f381; WORD $0x5555             // xorl         $1431655765, %ebx
+	WORD $0x2144; BYTE $0xe3                   // andl         %r12d, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	WORD $0xd921                               // andl         %ebx, %ecx
+	WORD $0x8548; BYTE $0xc9                   // testq        %rcx, %rcx
+	LONG $0xff5b840f; WORD $0xffff             // je           LBB28_25, $-165(%rip)
+
+LBB28_79:
+	WORD $0xbc0f; BYTE $0xc1     // bsfl         %ecx, %eax
+	WORD $0x0148; BYTE $0xd0     // addq         %rdx, %rax
+	WORD $0x014c; BYTE $0xe8     // addq         %r13, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xfffec8e9; BYTE $0xff // jmp          LBB28_15, $-312(%rip)
+
+LBB28_29:
+	LONG $0xc045894c                       // movq         %r8, $-64(%rbp)
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	LONG $0x244c8b49; BYTE $0x08           // movq         $8(%r12), %rcx
+	WORD $0x2948; BYTE $0xd1               // subq         %rdx, %rcx
+	LONG $0x24140349                       // addq         (%r12), %rdx
+	WORD $0x3145; BYTE $0xc9               // xorl         %r9d, %r9d
+	QUAD $0xfffd37156f0f4466; BYTE $0xff   // movdqa       $-713(%rip), %xmm10  /* LCPI28_4(%rip) */
+	QUAD $0xfffffd1f0d6f0f66               // movdqa       $-737(%rip), %xmm1  /* LCPI28_3(%rip) */
+	LONG $0x760f4566; BYTE $0xc9           // pcmpeqd      %xmm9, %xmm9
+	QUAD $0xfffffd521d6f0f66               // movdqa       $-686(%rip), %xmm3  /* LCPI28_7(%rip) */
+	QUAD $0xfffffcfa256f0f66               // movdqa       $-774(%rip), %xmm4  /* LCPI28_2(%rip) */
+	QUAD $0x333333333333ba49; WORD $0x3333 // movabsq      $3689348814741910323, %r10
+	LONG $0xc0570f45                       // xorps        %xmm8, %xmm8
+	WORD $0x3145; BYTE $0xff               // xorl         %r15d, %r15d
+	WORD $0x3145; BYTE $0xdb               // xorl         %r11d, %r11d
+	WORD $0xff31                           // xorl         %edi, %edi
+	LONG $0x40f98348                       // cmpq         $64, %rcx
+	LONG $0xd04d8948                       // movq         %rcx, $-48(%rbp)
+	LONG $0x029b8c0f; WORD $0x0000         // jl           LBB28_38, $667(%rip)
+
+LBB28_32:
+	LONG $0x026f0ff3                           // movdqu       (%rdx), %xmm0
+	LONG $0x6a6f0ff3; BYTE $0x10               // movdqu       $16(%rdx), %xmm5
+	LONG $0x7a6f0ff3; BYTE $0x20               // movdqu       $32(%rdx), %xmm7
+	LONG $0x726f0ff3; BYTE $0x30               // movdqu       $48(%rdx), %xmm6
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xd70f4466; BYTE $0xc2               // pmovmskb     %xmm2, %r8d
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xdad70f66                           // pmovmskb     %xmm2, %ebx
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0x30e6c148                           // shlq         $48, %rsi
+	LONG $0x20e3c148                           // shlq         $32, %rbx
+	WORD $0x0948; BYTE $0xf3                   // orq          %rsi, %rbx
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xd9                   // orq          %rbx, %rcx
+	WORD $0x0949; BYTE $0xc8                   // orq          %rcx, %r8
+	WORD $0x894c; BYTE $0xc1                   // movq         %r8, %rcx
+	WORD $0x094c; BYTE $0xf9                   // orq          %r15, %rcx
+	LONG $0x0012850f; WORD $0x0000             // jne          LBB28_34, $18(%rip)
+	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
+	WORD $0xc931                               // xorl         %ecx, %ecx
+	LONG $0xc84d8948                           // movq         %rcx, $-56(%rbp)
+	LONG $0x00004be9; BYTE $0x00               // jmp          LBB28_35, $75(%rip)
+
+LBB28_34:
+	WORD $0x894c; BYTE $0xf9               // movq         %r15, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	WORD $0x894c; BYTE $0xf0               // movq         %r14, %rax
+	WORD $0x894d; BYTE $0xce               // movq         %r9, %r14
+	LONG $0x090c8d4c                       // leaq         (%rcx,%rcx), %r9
+	WORD $0x094d; BYTE $0xf9               // orq          %r15, %r9
+	WORD $0x894c; BYTE $0xce               // movq         %r9, %rsi
+	WORD $0xf748; BYTE $0xd6               // notq         %rsi
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2149; BYTE $0xd8               // andq         %rbx, %r8
+	WORD $0x2149; BYTE $0xf0               // andq         %rsi, %r8
+	WORD $0xf631                           // xorl         %esi, %esi
+	WORD $0x0149; BYTE $0xc8               // addq         %rcx, %r8
+	LONG $0xc6920f40                       // setb         %sil
+	LONG $0xc8758948                       // movq         %rsi, $-56(%rbp)
+	WORD $0x014d; BYTE $0xc0               // addq         %r8, %r8
+	WORD $0x314d; BYTE $0xe8               // xorq         %r13, %r8
+	WORD $0x214d; BYTE $0xc8               // andq         %r9, %r8
+	WORD $0x894d; BYTE $0xf1               // movq         %r14, %r9
+	WORD $0x8949; BYTE $0xc6               // movq         %rax, %r14
+	WORD $0xf749; BYTE $0xd0               // notq         %r8
+
+LBB28_35:
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0x30e1c148                           // shlq         $48, %rcx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0x20e6c148                           // shlq         $32, %rsi
+	WORD $0x0948; BYTE $0xce                   // orq          %rcx, %rsi
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf1                   // orq          %rsi, %rcx
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	WORD $0x0948; BYTE $0xce                   // orq          %rcx, %rsi
+	WORD $0x214c; BYTE $0xc6                   // andq         %r8, %rsi
+	LONG $0x6e0f4866; BYTE $0xd6               // movq         %rsi, %xmm2
+	LONG $0x3a0f4166; WORD $0xd144; BYTE $0x00 // pclmulqdq    $0, %xmm9, %xmm2
+	LONG $0x7e0f4966; BYTE $0xd0               // movq         %xmm2, %r8
+	WORD $0x314d; BYTE $0xc8                   // xorq         %r9, %r8
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xd70f4466; BYTE $0xca               // pmovmskb     %xmm2, %r9d
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xdad70f66                           // pmovmskb     %xmm2, %ebx
+	LONG $0x30e3c148                           // shlq         $48, %rbx
+	LONG $0x20e6c148                           // shlq         $32, %rsi
+	WORD $0x0948; BYTE $0xde                   // orq          %rbx, %rsi
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf1                   // orq          %rsi, %rcx
+	WORD $0x0949; BYTE $0xc9                   // orq          %rcx, %r9
+	WORD $0x894d; BYTE $0xc7                   // movq         %r8, %r15
+	WORD $0xf749; BYTE $0xd7                   // notq         %r15
+	WORD $0x214d; BYTE $0xf9                   // andq         %r15, %r9
+	LONG $0xc4740f66                           // pcmpeqb      %xmm4, %xmm0
+	LONG $0xf0d70f66                           // pmovmskb     %xmm0, %esi
+	LONG $0xec740f66                           // pcmpeqb      %xmm4, %xmm5
+	LONG $0xddd70f66                           // pmovmskb     %xmm5, %ebx
+	LONG $0xfc740f66                           // pcmpeqb      %xmm4, %xmm7
+	LONG $0xcfd70f66                           // pmovmskb     %xmm7, %ecx
+	LONG $0xf4740f66                           // pcmpeqb      %xmm4, %xmm6
+	LONG $0xd70f4466; BYTE $0xee               // pmovmskb     %xmm6, %r13d
+	LONG $0x30e5c149                           // shlq         $48, %r13
+	LONG $0x20e1c148                           // shlq         $32, %rcx
+	WORD $0x094c; BYTE $0xe9                   // orq          %r13, %rcx
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xcb                   // orq          %rcx, %rbx
+	WORD $0x0948; BYTE $0xde                   // orq          %rbx, %rsi
+	QUAD $0x555555555555bd49; WORD $0x5555     // movabsq      $6148914691236517205, %r13
+	WORD $0x214c; BYTE $0xfe                   // andq         %r15, %rsi
+	LONG $0x0074840f; WORD $0x0000             // je           LBB28_30, $116(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
+
+LBB28_36:
+	LONG $0xff7e8d4c                       // leaq         $-1(%rsi), %r15
+	WORD $0x894c; BYTE $0xf9               // movq         %r15, %rcx
+	WORD $0x214c; BYTE $0xc9               // andq         %r9, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	WORD $0xd148; BYTE $0xeb               // shrq         %rbx
+	WORD $0x214c; BYTE $0xeb               // andq         %r13, %rbx
+	WORD $0x2948; BYTE $0xd9               // subq         %rbx, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	WORD $0x214c; BYTE $0xd3               // andq         %r10, %rbx
+	LONG $0x02e9c148                       // shrq         $2, %rcx
+	WORD $0x214c; BYTE $0xd1               // andq         %r10, %rcx
+	WORD $0x0148; BYTE $0xd9               // addq         %rbx, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	LONG $0x04ebc148                       // shrq         $4, %rbx
+	WORD $0x0148; BYTE $0xcb               // addq         %rcx, %rbx
+	QUAD $0x0f0f0f0f0f0fb948; WORD $0x0f0f // movabsq      $1085102592571150095, %rcx
+	WORD $0x2148; BYTE $0xcb               // andq         %rcx, %rbx
+	QUAD $0x010101010101b948; WORD $0x0101 // movabsq      $72340172838076673, %rcx
+	LONG $0xd9af0f48                       // imulq        %rcx, %rbx
+	LONG $0x38ebc148                       // shrq         $56, %rbx
+	WORD $0x014c; BYTE $0xdb               // addq         %r11, %rbx
+	WORD $0x3948; BYTE $0xfb               // cmpq         %rdi, %rbx
+	LONG $0x05ca860f; WORD $0x0000         // jbe          LBB28_78, $1482(%rip)
+	LONG $0x01c78348                       // addq         $1, %rdi
+	WORD $0x214c; BYTE $0xfe               // andq         %r15, %rsi
+	LONG $0xff98850f; WORD $0xffff         // jne          LBB28_36, $-104(%rip)
+
+LBB28_30:
+	LONG $0x3ff8c149                       // sarq         $63, %r8
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	WORD $0xd148; BYTE $0xe9               // shrq         %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	WORD $0x2949; BYTE $0xc9               // subq         %rcx, %r9
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	WORD $0x214c; BYTE $0xd1               // andq         %r10, %rcx
+	LONG $0x02e9c149                       // shrq         $2, %r9
+	WORD $0x214d; BYTE $0xd1               // andq         %r10, %r9
+	WORD $0x0149; BYTE $0xc9               // addq         %rcx, %r9
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	LONG $0x04e9c148                       // shrq         $4, %rcx
+	WORD $0x014c; BYTE $0xc9               // addq         %r9, %rcx
+	QUAD $0x0f0f0f0f0f0fbe48; WORD $0x0f0f // movabsq      $1085102592571150095, %rsi
+	WORD $0x2148; BYTE $0xf1               // andq         %rsi, %rcx
+	QUAD $0x010101010101be48; WORD $0x0101 // movabsq      $72340172838076673, %rsi
+	LONG $0xceaf0f48                       // imulq        %rsi, %rcx
+	LONG $0x38e9c148                       // shrq         $56, %rcx
+	WORD $0x0149; BYTE $0xcb               // addq         %rcx, %r11
+	LONG $0x40c28348                       // addq         $64, %rdx
+	LONG $0xd04d8b48                       // movq         $-48(%rbp), %rcx
+	LONG $0xc0c18348                       // addq         $-64, %rcx
+	WORD $0x894d; BYTE $0xc1               // movq         %r8, %r9
+	LONG $0xc87d8b4c                       // movq         $-56(%rbp), %r15
+	LONG $0x40f98348                       // cmpq         $64, %rcx
+	LONG $0xd04d8948                       // movq         %rcx, $-48(%rbp)
+	LONG $0xfd658d0f; WORD $0xffff         // jge          LBB28_32, $-667(%rip)
+
+LBB28_38:
+	LONG $0xc84d894c               // movq         %r9, $-56(%rbp)
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x06348e0f; WORD $0x0000 // jle          LBB28_90, $1588(%rip)
+	WORD $0x894c; BYTE $0xfb       // movq         %r15, %rbx
+	LONG $0x45110f44; BYTE $0xb0   // movups       %xmm8, $-80(%rbp)
+	LONG $0x45110f44; BYTE $0xa0   // movups       %xmm8, $-96(%rbp)
+	LONG $0x45110f44; BYTE $0x90   // movups       %xmm8, $-112(%rbp)
+	LONG $0x45110f44; BYTE $0x80   // movups       %xmm8, $-128(%rbp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0x003a820f; WORD $0x0000 // jb           LBB28_43, $58(%rip)
+	LONG $0xd07d8348; BYTE $0x10   // cmpq         $16, $-48(%rbp)
+	LONG $0x00458c0f; WORD $0x0000 // jl           LBB28_44, $69(%rip)
+	LONG $0xd0758b48               // movq         $-48(%rbp), %rsi
+	LONG $0x80458d4c               // leaq         $-128(%rbp), %r8
+
+LBB28_42:
+	LONG $0x026f0ff3               // movdqu       (%rdx), %xmm0
+	LONG $0x7f0f41f3; BYTE $0x00   // movdqu       %xmm0, (%r8)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c08349               // addq         $16, %r8
+	LONG $0xf04e8d4c               // leaq         $-16(%rsi), %r9
+	LONG $0x1ffe8348               // cmpq         $31, %rsi
+	WORD $0x894c; BYTE $0xce       // movq         %r9, %rsi
+	LONG $0xffde8f0f; WORD $0xffff // jg           LBB28_42, $-34(%rip)
+	LONG $0x00001ee9; BYTE $0x00   // jmp          LBB28_45, $30(%rip)
+
+LBB28_43:
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	WORD $0x8949; BYTE $0xdf               // movq         %rbx, %r15
+	LONG $0xc84d8b4c                       // movq         $-56(%rbp), %r9
+	LONG $0xfffcdde9; BYTE $0xff           // jmp          LBB28_32, $-803(%rip)
+
+LBB28_44:
+	LONG $0x80458d4c // leaq         $-128(%rbp), %r8
+	LONG $0xd04d8b4c // movq         $-48(%rbp), %r9
+
+LBB28_45:
+	LONG $0x08f98349               // cmpq         $8, %r9
+	LONG $0x00688c0f; WORD $0x0000 // jl           LBB28_46, $104(%rip)
+	WORD $0x8b48; BYTE $0x0a       // movq         (%rdx), %rcx
+	WORD $0x8949; BYTE $0x08       // movq         %rcx, (%r8)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c08349               // addq         $8, %r8
+	LONG $0xf8c18349               // addq         $-8, %r9
+	LONG $0x04f98349               // cmpq         $4, %r9
+	LONG $0x00568d0f; WORD $0x0000 // jge          LBB28_52, $86(%rip)
+
+LBB28_47:
+	LONG $0x02f98349               // cmpq         $2, %r9
+	LONG $0x00138c0f; WORD $0x0000 // jl           LBB28_49, $19(%rip)
+
+LBB28_48:
+	WORD $0xb70f; BYTE $0x0a // movzwl       (%rdx), %ecx
+	LONG $0x08894166         // movw         %cx, (%r8)
+	LONG $0x02c28348         // addq         $2, %rdx
+	LONG $0x02c08349         // addq         $2, %r8
+	LONG $0xfec18349         // addq         $-2, %r9
+
+LBB28_49:
+	WORD $0x8948; BYTE $0xd6               // movq         %rdx, %rsi
+	LONG $0x80558d48                       // leaq         $-128(%rbp), %rdx
+	WORD $0x854d; BYTE $0xc9               // testq        %r9, %r9
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	WORD $0x8949; BYTE $0xdf               // movq         %rbx, %r15
+	LONG $0xc84d8b4c                       // movq         $-56(%rbp), %r9
+	LONG $0xfc718e0f; WORD $0xffff         // jle          LBB28_32, $-911(%rip)
+	WORD $0x0e8a                           // movb         (%rsi), %cl
+	WORD $0x8841; BYTE $0x08               // movb         %cl, (%r8)
+	LONG $0x80558d48                       // leaq         $-128(%rbp), %rdx
+	LONG $0xfffc63e9; BYTE $0xff           // jmp          LBB28_32, $-925(%rip)
+
+LBB28_46:
+	LONG $0x04f98349               // cmpq         $4, %r9
+	LONG $0xffaa8c0f; WORD $0xffff // jl           LBB28_47, $-86(%rip)
+
+LBB28_52:
+	WORD $0x0a8b                   // movl         (%rdx), %ecx
+	WORD $0x8941; BYTE $0x08       // movl         %ecx, (%r8)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c08349               // addq         $4, %r8
+	LONG $0xfcc18349               // addq         $-4, %r9
+	LONG $0x02f98349               // cmpq         $2, %r9
+	LONG $0xff998d0f; WORD $0xffff // jge          LBB28_48, $-103(%rip)
+	LONG $0xffffa7e9; BYTE $0xff   // jmp          LBB28_49, $-89(%rip)
+
+LBB28_53:
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x24543b49; BYTE $0x08   // cmpq         $8(%r12), %rdx
+	LONG $0xfa91830f; WORD $0xffff // jae          LBB28_17, $-1391(%rip)
+	LONG $0x000453e9; BYTE $0x00   // jmp          LBB28_86, $1107(%rip)
+
+LBB28_54:
+	LONG $0xc045894c                       // movq         %r8, $-64(%rbp)
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	LONG $0x244c8b49; BYTE $0x08           // movq         $8(%r12), %rcx
+	WORD $0x2948; BYTE $0xd1               // subq         %rdx, %rcx
+	LONG $0x24140349                       // addq         (%r12), %rdx
+	WORD $0xc031                           // xorl         %eax, %eax
+	QUAD $0xfff8f6156f0f4466; BYTE $0xff   // movdqa       $-1802(%rip), %xmm10  /* LCPI28_4(%rip) */
+	QUAD $0xfffff8de0d6f0f66               // movdqa       $-1826(%rip), %xmm1  /* LCPI28_3(%rip) */
+	LONG $0x760f4566; BYTE $0xc9           // pcmpeqd      %xmm9, %xmm9
+	QUAD $0xfffff8f11d6f0f66               // movdqa       $-1807(%rip), %xmm3  /* LCPI28_5(%rip) */
+	QUAD $0xfffff8f9256f0f66               // movdqa       $-1799(%rip), %xmm4  /* LCPI28_6(%rip) */
+	QUAD $0x333333333333ba49; WORD $0x3333 // movabsq      $3689348814741910323, %r10
+	LONG $0xc0570f45                       // xorps        %xmm8, %xmm8
+	WORD $0x3145; BYTE $0xff               // xorl         %r15d, %r15d
+	WORD $0x3145; BYTE $0xdb               // xorl         %r11d, %r11d
+	WORD $0xff31                           // xorl         %edi, %edi
+	LONG $0x40f98348                       // cmpq         $64, %rcx
+	LONG $0xd04d8948                       // movq         %rcx, $-48(%rbp)
+	LONG $0x028a8c0f; WORD $0x0000         // jl           LBB28_63, $650(%rip)
+
+LBB28_57:
+	LONG $0x026f0ff3                           // movdqu       (%rdx), %xmm0
+	LONG $0x6a6f0ff3; BYTE $0x10               // movdqu       $16(%rdx), %xmm5
+	LONG $0x7a6f0ff3; BYTE $0x20               // movdqu       $32(%rdx), %xmm7
+	LONG $0x726f0ff3; BYTE $0x30               // movdqu       $48(%rdx), %xmm6
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xd70f4466; BYTE $0xc2               // pmovmskb     %xmm2, %r8d
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xdad70f66                           // pmovmskb     %xmm2, %ebx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0x740f4166; BYTE $0xd2               // pcmpeqb      %xmm10, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0x30e6c148                           // shlq         $48, %rsi
+	LONG $0x20e1c148                           // shlq         $32, %rcx
+	WORD $0x0948; BYTE $0xf1                   // orq          %rsi, %rcx
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xcb                   // orq          %rcx, %rbx
+	WORD $0x0949; BYTE $0xd8                   // orq          %rbx, %r8
+	WORD $0x894c; BYTE $0xc1                   // movq         %r8, %rcx
+	WORD $0x094c; BYTE $0xf9                   // orq          %r15, %rcx
+	LONG $0x0012850f; WORD $0x0000             // jne          LBB28_59, $18(%rip)
+	LONG $0xffc0c749; WORD $0xffff; BYTE $0xff // movq         $-1, %r8
+	WORD $0xc931                               // xorl         %ecx, %ecx
+	LONG $0xc84d8948                           // movq         %rcx, $-56(%rbp)
+	LONG $0x00003fe9; BYTE $0x00               // jmp          LBB28_60, $63(%rip)
+
+LBB28_59:
+	WORD $0x894c; BYTE $0xf9               // movq         %r15, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	LONG $0x090c8d4c                       // leaq         (%rcx,%rcx), %r9
+	WORD $0x094d; BYTE $0xf9               // orq          %r15, %r9
+	WORD $0x894c; BYTE $0xce               // movq         %r9, %rsi
+	WORD $0xf748; BYTE $0xd6               // notq         %rsi
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2149; BYTE $0xd8               // andq         %rbx, %r8
+	WORD $0x2149; BYTE $0xf0               // andq         %rsi, %r8
+	WORD $0xf631                           // xorl         %esi, %esi
+	WORD $0x0149; BYTE $0xc8               // addq         %rcx, %r8
+	LONG $0xc6920f40                       // setb         %sil
+	LONG $0xc8758948                       // movq         %rsi, $-56(%rbp)
+	WORD $0x014d; BYTE $0xc0               // addq         %r8, %r8
+	WORD $0x314d; BYTE $0xe8               // xorq         %r13, %r8
+	WORD $0x214d; BYTE $0xc8               // andq         %r9, %r8
+	WORD $0xf749; BYTE $0xd0               // notq         %r8
+
+LBB28_60:
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0x30e1c148                           // shlq         $48, %rcx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0x20e6c148                           // shlq         $32, %rsi
+	WORD $0x0948; BYTE $0xce                   // orq          %rcx, %rsi
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf1                   // orq          %rsi, %rcx
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	WORD $0x0948; BYTE $0xce                   // orq          %rcx, %rsi
+	WORD $0x214c; BYTE $0xc6                   // andq         %r8, %rsi
+	LONG $0x6e0f4866; BYTE $0xd6               // movq         %rsi, %xmm2
+	LONG $0x3a0f4166; WORD $0xd144; BYTE $0x00 // pclmulqdq    $0, %xmm9, %xmm2
+	LONG $0x7e0f4966; BYTE $0xd0               // movq         %xmm2, %r8
+	WORD $0x3149; BYTE $0xc0                   // xorq         %rax, %r8
+	LONG $0xd06f0f66                           // movdqa       %xmm0, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xd70f4466; BYTE $0xca               // pmovmskb     %xmm2, %r9d
+	LONG $0xd56f0f66                           // movdqa       %xmm5, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xcad70f66                           // pmovmskb     %xmm2, %ecx
+	LONG $0xd76f0f66                           // movdqa       %xmm7, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xf2d70f66                           // pmovmskb     %xmm2, %esi
+	LONG $0xd66f0f66                           // movdqa       %xmm6, %xmm2
+	LONG $0xd3740f66                           // pcmpeqb      %xmm3, %xmm2
+	LONG $0xdad70f66                           // pmovmskb     %xmm2, %ebx
+	LONG $0x30e3c148                           // shlq         $48, %rbx
+	LONG $0x20e6c148                           // shlq         $32, %rsi
+	WORD $0x0948; BYTE $0xde                   // orq          %rbx, %rsi
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xf1                   // orq          %rsi, %rcx
+	WORD $0x0949; BYTE $0xc9                   // orq          %rcx, %r9
+	WORD $0x894d; BYTE $0xc7                   // movq         %r8, %r15
+	WORD $0xf749; BYTE $0xd7                   // notq         %r15
+	WORD $0x214d; BYTE $0xf9                   // andq         %r15, %r9
+	LONG $0xc4740f66                           // pcmpeqb      %xmm4, %xmm0
+	LONG $0xf0d70f66                           // pmovmskb     %xmm0, %esi
+	LONG $0xec740f66                           // pcmpeqb      %xmm4, %xmm5
+	LONG $0xddd70f66                           // pmovmskb     %xmm5, %ebx
+	LONG $0xfc740f66                           // pcmpeqb      %xmm4, %xmm7
+	LONG $0xcfd70f66                           // pmovmskb     %xmm7, %ecx
+	LONG $0xf4740f66                           // pcmpeqb      %xmm4, %xmm6
+	LONG $0xd70f4466; BYTE $0xee               // pmovmskb     %xmm6, %r13d
+	LONG $0x30e5c149                           // shlq         $48, %r13
+	LONG $0x20e1c148                           // shlq         $32, %rcx
+	WORD $0x094c; BYTE $0xe9                   // orq          %r13, %rcx
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xcb                   // orq          %rcx, %rbx
+	WORD $0x0948; BYTE $0xde                   // orq          %rbx, %rsi
+	QUAD $0x555555555555bd49; WORD $0x5555     // movabsq      $6148914691236517205, %r13
+	WORD $0x214c; BYTE $0xfe                   // andq         %r15, %rsi
+	LONG $0x006f840f; WORD $0x0000             // je           LBB28_55, $111(%rip)
+	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB28_61:
+	LONG $0xff7e8d4c                       // leaq         $-1(%rsi), %r15
+	WORD $0x894c; BYTE $0xf9               // movq         %r15, %rcx
+	WORD $0x214c; BYTE $0xc9               // andq         %r9, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	WORD $0xd148; BYTE $0xeb               // shrq         %rbx
+	WORD $0x214c; BYTE $0xeb               // andq         %r13, %rbx
+	WORD $0x2948; BYTE $0xd9               // subq         %rbx, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	WORD $0x214c; BYTE $0xd3               // andq         %r10, %rbx
+	LONG $0x02e9c148                       // shrq         $2, %rcx
+	WORD $0x214c; BYTE $0xd1               // andq         %r10, %rcx
+	WORD $0x0148; BYTE $0xd9               // addq         %rbx, %rcx
+	WORD $0x8948; BYTE $0xcb               // movq         %rcx, %rbx
+	LONG $0x04ebc148                       // shrq         $4, %rbx
+	WORD $0x0148; BYTE $0xcb               // addq         %rcx, %rbx
+	QUAD $0x0f0f0f0f0f0fb948; WORD $0x0f0f // movabsq      $1085102592571150095, %rcx
+	WORD $0x2148; BYTE $0xcb               // andq         %rcx, %rbx
+	QUAD $0x010101010101b948; WORD $0x0101 // movabsq      $72340172838076673, %rcx
+	LONG $0xd9af0f48                       // imulq        %rcx, %rbx
+	LONG $0x38ebc148                       // shrq         $56, %rbx
+	WORD $0x014c; BYTE $0xdb               // addq         %r11, %rbx
+	WORD $0x3948; BYTE $0xfb               // cmpq         %rdi, %rbx
+	LONG $0x019a860f; WORD $0x0000         // jbe          LBB28_78, $410(%rip)
+	LONG $0x01c78348                       // addq         $1, %rdi
+	WORD $0x214c; BYTE $0xfe               // andq         %r15, %rsi
+	LONG $0xff98850f; WORD $0xffff         // jne          LBB28_61, $-104(%rip)
+
+LBB28_55:
+	LONG $0x3ff8c149                       // sarq         $63, %r8
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	WORD $0xd148; BYTE $0xe9               // shrq         %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	WORD $0x2949; BYTE $0xc9               // subq         %rcx, %r9
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	WORD $0x214c; BYTE $0xd1               // andq         %r10, %rcx
+	LONG $0x02e9c149                       // shrq         $2, %r9
+	WORD $0x214d; BYTE $0xd1               // andq         %r10, %r9
+	WORD $0x0149; BYTE $0xc9               // addq         %rcx, %r9
+	WORD $0x894c; BYTE $0xc9               // movq         %r9, %rcx
+	LONG $0x04e9c148                       // shrq         $4, %rcx
+	WORD $0x014c; BYTE $0xc9               // addq         %r9, %rcx
+	QUAD $0x0f0f0f0f0f0fbe48; WORD $0x0f0f // movabsq      $1085102592571150095, %rsi
+	WORD $0x2148; BYTE $0xf1               // andq         %rsi, %rcx
+	QUAD $0x010101010101be48; WORD $0x0101 // movabsq      $72340172838076673, %rsi
+	LONG $0xceaf0f48                       // imulq        %rsi, %rcx
+	LONG $0x38e9c148                       // shrq         $56, %rcx
+	WORD $0x0149; BYTE $0xcb               // addq         %rcx, %r11
+	LONG $0x40c28348                       // addq         $64, %rdx
+	LONG $0xd04d8b48                       // movq         $-48(%rbp), %rcx
+	LONG $0xc0c18348                       // addq         $-64, %rcx
+	WORD $0x894c; BYTE $0xc0               // movq         %r8, %rax
+	LONG $0xc87d8b4c                       // movq         $-56(%rbp), %r15
+	LONG $0x40f98348                       // cmpq         $64, %rcx
+	LONG $0xd04d8948                       // movq         %rcx, $-48(%rbp)
+	LONG $0xfd768d0f; WORD $0xffff         // jge          LBB28_57, $-650(%rip)
+
+LBB28_63:
+	WORD $0x8548; BYTE $0xc9       // testq        %rcx, %rcx
+	LONG $0x02088e0f; WORD $0x0000 // jle          LBB28_90, $520(%rip)
+	WORD $0x894c; BYTE $0xfb       // movq         %r15, %rbx
+	LONG $0x45110f44; BYTE $0xb0   // movups       %xmm8, $-80(%rbp)
+	LONG $0x45110f44; BYTE $0xa0   // movups       %xmm8, $-96(%rbp)
+	LONG $0x45110f44; BYTE $0x90   // movups       %xmm8, $-112(%rbp)
+	LONG $0x45110f44; BYTE $0x80   // movups       %xmm8, $-128(%rbp)
+	WORD $0xd189                   // movl         %edx, %ecx
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0fc1f981; WORD $0x0000 // cmpl         $4033, %ecx
+	LONG $0x003a820f; WORD $0x0000 // jb           LBB28_68, $58(%rip)
+	LONG $0xd07d8348; BYTE $0x10   // cmpq         $16, $-48(%rbp)
+	LONG $0x00418c0f; WORD $0x0000 // jl           LBB28_69, $65(%rip)
+	LONG $0xd0758b48               // movq         $-48(%rbp), %rsi
+	LONG $0x80458d4c               // leaq         $-128(%rbp), %r8
+
+LBB28_67:
+	LONG $0x026f0ff3               // movdqu       (%rdx), %xmm0
+	LONG $0x7f0f41f3; BYTE $0x00   // movdqu       %xmm0, (%r8)
+	LONG $0x10c28348               // addq         $16, %rdx
+	LONG $0x10c08349               // addq         $16, %r8
+	LONG $0xf04e8d4c               // leaq         $-16(%rsi), %r9
+	LONG $0x1ffe8348               // cmpq         $31, %rsi
+	WORD $0x894c; BYTE $0xce       // movq         %r9, %rsi
+	LONG $0xffde8f0f; WORD $0xffff // jg           LBB28_67, $-34(%rip)
+	LONG $0x00001ae9; BYTE $0x00   // jmp          LBB28_70, $26(%rip)
+
+LBB28_68:
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	WORD $0x8949; BYTE $0xdf               // movq         %rbx, %r15
+	LONG $0xfffcf6e9; BYTE $0xff           // jmp          LBB28_57, $-778(%rip)
+
+LBB28_69:
+	LONG $0x80458d4c // leaq         $-128(%rbp), %r8
+	LONG $0xd04d8b4c // movq         $-48(%rbp), %r9
+
+LBB28_70:
+	LONG $0x08f98349               // cmpq         $8, %r9
+	LONG $0x00648c0f; WORD $0x0000 // jl           LBB28_71, $100(%rip)
+	WORD $0x8b48; BYTE $0x0a       // movq         (%rdx), %rcx
+	WORD $0x8949; BYTE $0x08       // movq         %rcx, (%r8)
+	LONG $0x08c28348               // addq         $8, %rdx
+	LONG $0x08c08349               // addq         $8, %r8
+	LONG $0xf8c18349               // addq         $-8, %r9
+	LONG $0x04f98349               // cmpq         $4, %r9
+	LONG $0x00528d0f; WORD $0x0000 // jge          LBB28_77, $82(%rip)
+
+LBB28_72:
+	LONG $0x02f98349               // cmpq         $2, %r9
+	LONG $0x00138c0f; WORD $0x0000 // jl           LBB28_74, $19(%rip)
+
+LBB28_73:
+	WORD $0xb70f; BYTE $0x0a // movzwl       (%rdx), %ecx
+	LONG $0x08894166         // movw         %cx, (%r8)
+	LONG $0x02c28348         // addq         $2, %rdx
+	LONG $0x02c08349         // addq         $2, %r8
+	LONG $0xfec18349         // addq         $-2, %r9
+
+LBB28_74:
+	WORD $0x8948; BYTE $0xd6               // movq         %rdx, %rsi
+	LONG $0x80558d48                       // leaq         $-128(%rbp), %rdx
+	WORD $0x854d; BYTE $0xc9               // testq        %r9, %r9
+	QUAD $0x555555555555bd49; WORD $0x5555 // movabsq      $6148914691236517205, %r13
+	WORD $0x8949; BYTE $0xdf               // movq         %rbx, %r15
+	LONG $0xfc8e8e0f; WORD $0xffff         // jle          LBB28_57, $-882(%rip)
+	WORD $0x0e8a                           // movb         (%rsi), %cl
+	WORD $0x8841; BYTE $0x08               // movb         %cl, (%r8)
+	LONG $0x80558d48                       // leaq         $-128(%rbp), %rdx
+	LONG $0xfffc80e9; BYTE $0xff           // jmp          LBB28_57, $-896(%rip)
+
+LBB28_71:
+	LONG $0x04f98349               // cmpq         $4, %r9
+	LONG $0xffae8c0f; WORD $0xffff // jl           LBB28_72, $-82(%rip)
+
+LBB28_77:
+	WORD $0x0a8b                   // movl         (%rdx), %ecx
+	WORD $0x8941; BYTE $0x08       // movl         %ecx, (%r8)
+	LONG $0x04c28348               // addq         $4, %rdx
+	LONG $0x04c08349               // addq         $4, %r8
+	LONG $0xfcc18349               // addq         $-4, %r9
+	LONG $0x02f98349               // cmpq         $2, %r9
+	LONG $0xff9d8d0f; WORD $0xffff // jge          LBB28_73, $-99(%rip)
+	LONG $0xffffabe9; BYTE $0xff   // jmp          LBB28_74, $-85(%rip)
+
+LBB28_78:
+	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
+	LONG $0xcebc0f48                           // bsfq         %rsi, %rcx
+	LONG $0xd04d2b48                           // subq         $-48(%rbp), %rcx
+	WORD $0x0148; BYTE $0xc8                   // addq         %rcx, %rax
+	LONG $0x01c08348                           // addq         $1, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0x244c8b49; BYTE $0x08               // movq         $8(%r12), %rcx
+	WORD $0x3948; BYTE $0xc8                   // cmpq         %rcx, %rax
+	LONG $0xc1470f48                           // cmovaq       %rcx, %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xc04d8b48                           // movq         $-64(%rbp), %rcx
+	LONG $0xc8470f48                           // cmovaq       %rax, %rcx
+	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
+	LONG $0xfff63fe9; BYTE $0xff               // jmp          LBB28_17, $-2497(%rip)
+
+LBB28_85:
+	WORD $0x2948; BYTE $0xc2 // subq         %rax, %rdx
+	WORD $0x0148; BYTE $0xca // addq         %rcx, %rdx
+
+LBB28_86:
+	WORD $0x8949; BYTE $0x16     // movq         %rdx, (%r14)
+	LONG $0xfff62ee9; BYTE $0xff // jmp          LBB28_16, $-2514(%rip)
+
+LBB28_26:
+	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
+	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
+	LONG $0x00ae850f; WORD $0x0000 // jne          LBB28_91, $174(%rip)
+	WORD $0x014d; BYTE $0xea       // addq         %r13, %r10
+	WORD $0x014d; BYTE $0xf9       // addq         %r15, %r9
+
+LBB28_28:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x854d; BYTE $0xc9                   // testq        %r9, %r9
+	LONG $0x0024850f; WORD $0x0000             // jne          LBB28_82, $36(%rip)
+	LONG $0xfff60ae9; BYTE $0xff               // jmp          LBB28_17, $-2550(%rip)
+
+LBB28_80:
+	LONG $0xfec1c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rcx
+	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
+	WORD $0x0149; BYTE $0xc2                   // addq         %rax, %r10
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
+	LONG $0xf5eb840f; WORD $0xffff             // je           LBB28_17, $-2581(%rip)
+
+LBB28_82:
+	LONG $0x02b60f41                           // movzbl       (%r10), %eax
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0xffd5840f; WORD $0xffff             // je           LBB28_80, $-43(%rip)
+	WORD $0x223c                               // cmpb         $34, %al
+	LONG $0x0024840f; WORD $0x0000             // je           LBB28_87, $36(%rip)
+	LONG $0xffc1c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rcx
+	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
+	WORD $0x0149; BYTE $0xc2                   // addq         %rax, %r10
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
+	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_82, $-51(%rip)
+	LONG $0xfff5b3e9; BYTE $0xff               // jmp          LBB28_17, $-2637(%rip)
+
+LBB28_87:
+	WORD $0x2949; BYTE $0xd2     // subq         %rdx, %r10
+	LONG $0x01c28349             // addq         $1, %r10
+	WORD $0x894d; BYTE $0x16     // movq         %r10, (%r14)
+	LONG $0xfff5a1e9; BYTE $0xff // jmp          LBB28_16, $-2655(%rip)
+
+LBB28_88:
+	WORD $0x0148; BYTE $0xc2       // addq         %rax, %rdx
+	WORD $0x8548; BYTE $0xf6       // testq        %rsi, %rsi
+	LONG $0xf54b850f; WORD $0xffff // jne          LBB28_7, $-2741(%rip)
+	LONG $0xfff57be9; BYTE $0xff   // jmp          LBB28_13, $-2693(%rip)
+
+LBB28_89:
+	WORD $0x8948; BYTE $0xc2     // movq         %rax, %rdx
+	LONG $0xffff6ce9; BYTE $0xff // jmp          LBB28_28, $-148(%rip)
+
+LBB28_90:
+	LONG $0x244c8b49; BYTE $0x08               // movq         $8(%r12), %rcx
+	WORD $0x8949; BYTE $0x0e                   // movq         %rcx, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xfff577e9; BYTE $0xff               // jmp          LBB28_17, $-2697(%rip)
+
+LBB28_91:
+	WORD $0x394d; BYTE $0xe9                   // cmpq         %r13, %r9
+	LONG $0x000c850f; WORD $0x0000             // jne          LBB28_93, $12(%rip)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xfff562e9; BYTE $0xff               // jmp          LBB28_17, $-2718(%rip)
+
+LBB28_93:
+	WORD $0x014d; BYTE $0xea     // addq         %r13, %r10
+	LONG $0x01c28349             // addq         $1, %r10
+	WORD $0xf749; BYTE $0xd5     // notq         %r13
+	WORD $0x014d; BYTE $0xe9     // addq         %r13, %r9
+	LONG $0xffff31e9; BYTE $0xff // jmp          LBB28_28, $-207(%rip)
+	WORD $0x9090; BYTE $0x90     // .p2align 2, 0x90
+
+	// .set L28_0_set_17, LBB28_17-LJTI28_0
+	// .set L28_0_set_19, LBB28_19-LJTI28_0
+	// .set L28_0_set_20, LBB28_20-LJTI28_0
+	// .set L28_0_set_2, LBB28_2-LJTI28_0
+	// .set L28_0_set_29, LBB28_29-LJTI28_0
+	// .set L28_0_set_53, LBB28_53-LJTI28_0
+	// .set L28_0_set_18, LBB28_18-LJTI28_0
+	// .set L28_0_set_54, LBB28_54-LJTI28_0
+LJTI28_0:
+	LONG $0xfffff54d                           // .long L28_0_set_17
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff57f                           // .long L28_0_set_20
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff46d                           // .long L28_0_set_2
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff67f                           // .long L28_0_set_29
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffffaad                           // .long L28_0_set_53
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff55c                           // .long L28_0_set_18
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff55c                           // .long L28_0_set_18
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffff570                           // .long L28_0_set_19
+	LONG $0xfffffac1                           // .long L28_0_set_54
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
+
+_get_by_path:
+	BYTE $0x55                     // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5       // movq         %rsp, %rbp
+	WORD $0x5741                   // pushq        %r15
+	WORD $0x5641                   // pushq        %r14
+	WORD $0x5541                   // pushq        %r13
+	WORD $0x5441                   // pushq        %r12
+	BYTE $0x53                     // pushq        %rbx
+	LONG $0x28ec8348               // subq         $40, %rsp
+	WORD $0x8949; BYTE $0xf6       // movq         %rsi, %r14
+	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
+	LONG $0x08428b48               // movq         $8(%rdx), %rax
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x063d840f; WORD $0x0000 // je           LBB29_78, $1597(%rip)
+	WORD $0x8b4c; BYTE $0x3a       // movq         (%rdx), %r15
+	LONG $0x04e0c148               // shlq         $4, %rax
+	WORD $0x014c; BYTE $0xf8       // addq         %r15, %rax
+	LONG $0xb0458948               // movq         %rax, $-80(%rbp)
+
+LBB29_2:
+	LONG $0x243c8b49                                                     // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08                                         // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2                                             // movq         %r14, %rdx
+	LONG $0xffcfede8; BYTE $0xff                                         // callq        _advance_ns, $-12307(%rip)
+	WORD $0x8b49; BYTE $0x0f                                             // movq         (%r15), %rcx
+	WORD $0x498a; BYTE $0x17                                             // movb         $23(%rcx), %cl
+	WORD $0xe180; BYTE $0x1f                                             // andb         $31, %cl
+	WORD $0xf980; BYTE $0x18                                             // cmpb         $24, %cl
+	LONG $0x059b850f; WORD $0x0000                                       // jne          LBB29_72, $1435(%rip)
+	WORD $0x7b3c                                                         // cmpb         $123, %al
+	LONG $0xc87d894c                                                     // movq         %r15, $-56(%rbp)
+	LONG $0x0610850f; WORD $0x0000                                       // jne          LBB29_79, $1552(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_4:
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08   // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2       // movq         %r14, %rdx
+	LONG $0xffcfafe8; BYTE $0xff   // callq        _advance_ns, $-12369(%rip)
+	WORD $0x223c                   // cmpb         $34, %al
+	LONG $0x05e8850f; WORD $0x0000 // jne          LBB29_79, $1512(%rip)
+	LONG $0x08478b49               // movq         $8(%r15), %rax
+	WORD $0x8b4c; BYTE $0x28       // movq         (%rax), %r13
+	LONG $0x08788b4c               // movq         $8(%rax), %r15
+	QUAD $0xffffffffb845c748       // movq         $-1, $-72(%rbp)
+	WORD $0x8b49; BYTE $0x1e       // movq         (%r14), %rbx
+	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
+	WORD $0x8948; BYTE $0xde       // movq         %rbx, %rsi
+	LONG $0xb8558d48               // leaq         $-72(%rbp), %rdx
+	LONG $0x001a62e8; BYTE $0x00   // callq        _advance_string_default, $6754(%rip)
+	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
+	LONG $0x05d4880f; WORD $0x0000 // js           LBB29_81, $1492(%rip)
+	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
+	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
+	LONG $0xfff98348               // cmpq         $-1, %rcx
+	LONG $0x0009840f; WORD $0x0000 // je           LBB29_8, $9(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x014a8e0f; WORD $0x0000 // jle          LBB29_25, $330(%rip)
+
+LBB29_8:
+	WORD $0x8948; BYTE $0xd9       // movq         %rbx, %rcx
+	WORD $0xf748; BYTE $0xd1       // notq         %rcx
+	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	WORD $0x394c; BYTE $0xf8       // cmpq         %r15, %rax
+	LONG $0x0043850f; WORD $0x0000 // jne          LBB29_12, $67(%rip)
+	WORD $0x0148; BYTE $0xfb       // addq         %rdi, %rbx
+	WORD $0x894c; BYTE $0xe9       // movq         %r13, %rcx
+	WORD $0x8948; BYTE $0xd8       // movq         %rbx, %rax
+
+	// .p2align 4, 0x90
+LBB29_10:
+	LONG $0x10ff8349               // cmpq         $16, %r15
+	LONG $0x0086820f; WORD $0x0000 // jb           LBB29_16, $134(%rip)
+	LONG $0x006f0ff3               // movdqu       (%rax), %xmm0
+	LONG $0x6f0f41f3; WORD $0x004d // movdqu       (%r13), %xmm1
+	LONG $0xc8740f66               // pcmpeqb      %xmm0, %xmm1
+	LONG $0xd1d70f66               // pmovmskb     %xmm1, %edx
+	LONG $0x10c08348               // addq         $16, %rax
+	LONG $0x10c58349               // addq         $16, %r13
+	LONG $0xf0c78349               // addq         $-16, %r15
+	LONG $0x10c18348               // addq         $16, %rcx
+	LONG $0x10c38348               // addq         $16, %rbx
+	LONG $0xfffa8366               // cmpw         $-1, %dx
+	LONG $0xffc6840f; WORD $0xffff // je           LBB29_10, $-58(%rip)
+
+LBB29_12:
+	WORD $0xdb31 // xorl         %ebx, %ebx
+
+LBB29_13:
+	LONG $0xc87d8b4c                     // movq         $-56(%rbp), %r15
+	LONG $0x24748b49; BYTE $0x08         // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2             // movq         %r14, %rdx
+	LONG $0xffcef3e8; BYTE $0xff         // callq        _advance_ns, $-12557(%rip)
+	WORD $0x3a3c                         // cmpb         $58, %al
+	LONG $0x052c850f; WORD $0x0000       // jne          LBB29_79, $1324(%rip)
+	WORD $0x8548; BYTE $0xdb             // testq        %rbx, %rbx
+	LONG $0x0502850f; WORD $0x0000       // jne          LBB29_77, $1282(%rip)
+	WORD $0x894c; BYTE $0xe7             // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6             // movq         %r14, %rsi
+	LONG $0xfff0c7e8; BYTE $0xff         // callq        _skip_one_fast, $-3897(%rip)
+	LONG $0x243c8b49                     // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08         // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2             // movq         %r14, %rdx
+	LONG $0xffcec6e8; BYTE $0xff         // callq        _advance_ns, $-12602(%rip)
+	WORD $0x2c3c                         // cmpb         $44, %al
+	LONG $0xfefe840f; WORD $0xffff       // je           LBB29_4, $-258(%rip)
+	LONG $0x0004fae9; BYTE $0x00         // jmp          LBB29_79, $1274(%rip)
+	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_16:
+	LONG $0x0fffe381; WORD $0x0000 // andl         $4095, %ebx
+	LONG $0x0ff0fb81; WORD $0x0000 // cmpl         $4080, %ebx
+	LONG $0x0044870f; WORD $0x0000 // ja           LBB29_20, $68(%rip)
+	LONG $0x0fffe181; WORD $0x0000 // andl         $4095, %ecx
+	LONG $0x0ff1f981; WORD $0x0000 // cmpl         $4081, %ecx
+	LONG $0x0032830f; WORD $0x0000 // jae          LBB29_20, $50(%rip)
+	LONG $0x006f0ff3               // movdqu       (%rax), %xmm0
+	LONG $0x6f0f41f3; WORD $0x004d // movdqu       (%r13), %xmm1
+	LONG $0xc8740f66               // pcmpeqb      %xmm0, %xmm1
+	LONG $0xc1d70f66               // pmovmskb     %xmm1, %eax
+	LONG $0xfff88366               // cmpw         $-1, %ax
+	LONG $0x0051840f; WORD $0x0000 // je           LBB29_24, $81(%rip)
+	WORD $0xd0f7                   // notl         %eax
+	LONG $0xc0bc0f66               // bsfw         %ax, %ax
+	WORD $0xb70f; BYTE $0xc0       // movzwl       %ax, %eax
+	WORD $0xdb31                   // xorl         %ebx, %ebx
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	WORD $0x960f; BYTE $0xc3       // setbe        %bl
+	LONG $0xffff56e9; BYTE $0xff   // jmp          LBB29_13, $-170(%rip)
+
+LBB29_20:
+	LONG $0x000001bb; BYTE $0x00           // movl         $1, %ebx
+	WORD $0x854d; BYTE $0xff               // testq        %r15, %r15
+	LONG $0xff48840f; WORD $0xffff         // je           LBB29_13, $-184(%rip)
+	WORD $0xc931                           // xorl         %ecx, %ecx
+	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB29_22:
+	LONG $0x0814b60f               // movzbl       (%rax,%rcx), %edx
+	LONG $0x0d543a41; BYTE $0x00   // cmpb         (%r13,%rcx), %dl
+	LONG $0xff2b850f; WORD $0xffff // jne          LBB29_12, $-213(%rip)
+	LONG $0x01c18348               // addq         $1, %rcx
+	WORD $0x3949; BYTE $0xcf       // cmpq         %rcx, %r15
+	LONG $0xffe4850f; WORD $0xffff // jne          LBB29_22, $-28(%rip)
+	LONG $0xffff1be9; BYTE $0xff   // jmp          LBB29_13, $-229(%rip)
+
+LBB29_24:
+	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
+	LONG $0xffff11e9; BYTE $0xff // jmp          LBB29_13, $-239(%rip)
+
+LBB29_25:
+	QUAD $0x00000000d045c748       // movq         $0, $-48(%rbp)
+	LONG $0x243c8b49               // movq         (%r12), %rdi
+	LONG $0x1f1c8d4c               // leaq         (%rdi,%rbx), %r11
+	LONG $0x07048d4c               // leaq         (%rdi,%rax), %r8
+	LONG $0xffc08349               // addq         $-1, %r8
+	LONG $0xffc08348               // addq         $-1, %rax
+	LONG $0x2f148d4f               // leaq         (%r15,%r13), %r10
+	WORD $0x3948; BYTE $0xc3       // cmpq         %rax, %rbx
+	LONG $0x03928d0f; WORD $0x0000 // jge          LBB29_69, $914(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x03898e0f; WORD $0x0000 // jle          LBB29_69, $905(%rip)
+	LONG $0xc045894c               // movq         %r8, $-64(%rbp)
+
+LBB29_28:
+	WORD $0x8a41; BYTE $0x03                   // movb         (%r11), %al
+	WORD $0x5c3c                               // cmpb         $92, %al
+	LONG $0x005c850f; WORD $0x0000             // jne          LBB29_33, $92(%rip)
+	WORD $0x894c; BYTE $0xc2                   // movq         %r8, %rdx
+	WORD $0x294c; BYTE $0xda                   // subq         %r11, %rdx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x8548; BYTE $0xd2                   // testq        %rdx, %rdx
+	LONG $0x044d8e0f; WORD $0x0000             // jle          LBB29_84, $1101(%rip)
+	LONG $0x4bb60f41; BYTE $0x01               // movzbl       $1(%r11), %ecx
+	LONG $0xf2358d48; WORD $0x0090; BYTE $0x00 // leaq         $37106(%rip), %rsi  /* __UnquoteTab(%rip) */
+	WORD $0x1c8a; BYTE $0x31                   // movb         (%rcx,%rsi), %bl
+	WORD $0xfb80; BYTE $0xff                   // cmpb         $-1, %bl
+	LONG $0x0045840f; WORD $0x0000             // je           LBB29_35, $69(%rip)
+	WORD $0xdb84                               // testb        %bl, %bl
+	LONG $0x0419840f; WORD $0x0000             // je           LBB29_82, $1049(%rip)
+	WORD $0x5d88; BYTE $0xd0                   // movb         %bl, $-48(%rbp)
+	LONG $0x02c38349                           // addq         $2, %r11
+	LONG $0x000001ba; BYTE $0x00               // movl         $1, %edx
+	LONG $0x2a048d48                           // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xd04d8d48                           // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
+	LONG $0x013b820f; WORD $0x0000             // jb           LBB29_46, $315(%rip)
+	LONG $0x00018ae9; BYTE $0x00               // jmp          LBB29_54, $394(%rip)
+
+LBB29_33:
+	LONG $0x00453a41               // cmpb         (%r13), %al
+	LONG $0xfe68850f; WORD $0xffff // jne          LBB29_12, $-408(%rip)
+	LONG $0x01c38349               // addq         $1, %r11
+	LONG $0x01c58349               // addq         $1, %r13
+	LONG $0x00017ce9; BYTE $0x00   // jmp          LBB29_55, $380(%rip)
+
+LBB29_35:
+	LONG $0x04fa8348                           // cmpq         $4, %rdx
+	LONG $0x03e28c0f; WORD $0x0000             // jl           LBB29_83, $994(%rip)
+	LONG $0x024b8d4d                           // leaq         $2(%r11), %r9
+	LONG $0x02738b41                           // movl         $2(%r11), %esi
+	WORD $0xf389                               // movl         %esi, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	LONG $0xcfd08e8d; WORD $0xcfcf             // leal         $-808464432(%rsi), %ecx
+	LONG $0x8080e381; WORD $0x8080             // andl         $-2139062144, %ebx
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	WORD $0xcb85                               // testl        %ecx, %ebx
+	LONG $0x039f850f; WORD $0x0000             // jne          LBB29_86, $927(%rip)
+	LONG $0x19198e8d; WORD $0x1919             // leal         $421075225(%rsi), %ecx
+	WORD $0xf109                               // orl          %esi, %ecx
+	LONG $0x8080c1f7; WORD $0x8080             // testl        $-2139062144, %ecx
+	LONG $0x038b850f; WORD $0x0000             // jne          LBB29_86, $907(%rip)
+	WORD $0xf189                               // movl         %esi, %ecx
+	LONG $0x7f7fe181; WORD $0x7f7f             // andl         $2139062143, %ecx
+	LONG $0xc0c0bf41; WORD $0xc0c0             // movl         $-1061109568, %r15d
+	WORD $0x2941; BYTE $0xcf                   // subl         %ecx, %r15d
+	LONG $0x46818d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rcx), %r8d
+	WORD $0x2141; BYTE $0xdf                   // andl         %ebx, %r15d
+	WORD $0x8545; BYTE $0xc7                   // testl        %r8d, %r15d
+	LONG $0x0367850f; WORD $0x0000             // jne          LBB29_86, $871(%rip)
+	LONG $0xe0e0b841; WORD $0xe0e0             // movl         $-522133280, %r8d
+	WORD $0x2941; BYTE $0xc8                   // subl         %ecx, %r8d
+	LONG $0x3939c181; WORD $0x3939             // addl         $960051513, %ecx
+	WORD $0x2144; BYTE $0xc3                   // andl         %r8d, %ebx
+	WORD $0xcb85                               // testl        %ecx, %ebx
+	LONG $0x0370850f; WORD $0x0000             // jne          LBB29_85, $880(%rip)
+	WORD $0xce0f                               // bswapl       %esi
+	WORD $0xf089                               // movl         %esi, %eax
+	WORD $0xe8c1; BYTE $0x04                   // shrl         $4, %eax
+	WORD $0xd0f7                               // notl         %eax
+	LONG $0x01010125; BYTE $0x01               // andl         $16843009, %eax
+	WORD $0x048d; BYTE $0xc0                   // leal         (%rax,%rax,8), %eax
+	LONG $0x0f0fe681; WORD $0x0f0f             // andl         $252645135, %esi
+	WORD $0xc601                               // addl         %eax, %esi
+	WORD $0xf389                               // movl         %esi, %ebx
+	WORD $0xebc1; BYTE $0x04                   // shrl         $4, %ebx
+	WORD $0xf309                               // orl          %esi, %ebx
+	WORD $0xd889                               // movl         %ebx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xcb                   // movzbl       %bl, %ecx
+	WORD $0xc109                               // orl          %eax, %ecx
+	LONG $0x064b8d4d                           // leaq         $6(%r11), %r9
+	WORD $0xf983; BYTE $0x7f                   // cmpl         $127, %ecx
+	LONG $0xc0458b4c                           // movq         $-64(%rbp), %r8
+	LONG $0x00d0860f; WORD $0x0000             // jbe          LBB29_57, $208(%rip)
+	LONG $0x07fff981; WORD $0x0000             // cmpl         $2047, %ecx
+	LONG $0x00d1860f; WORD $0x0000             // jbe          LBB29_58, $209(%rip)
+	WORD $0xde89                               // movl         %ebx, %esi
+	LONG $0x0000e681; WORD $0x00f8             // andl         $16252928, %esi
+	LONG $0x0000fe81; WORD $0x00d8             // cmpl         $14155776, %esi
+	LONG $0x00db840f; WORD $0x0000             // je           LBB29_59, $219(%rip)
+	WORD $0xe8c1; BYTE $0x0c                   // shrl         $12, %eax
+	WORD $0xe00c                               // orb          $-32, %al
+	WORD $0x4588; BYTE $0xd0                   // movb         %al, $-48(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd1                   // movb         %cl, $-47(%rbp)
+	WORD $0xe380; BYTE $0x3f                   // andb         $63, %bl
+	WORD $0xcb80; BYTE $0x80                   // orb          $-128, %bl
+	WORD $0x5d88; BYTE $0xd2                   // movb         %bl, $-46(%rbp)
+	LONG $0x000003ba; BYTE $0x00               // movl         $3, %edx
+	WORD $0xc389                               // movl         %eax, %ebx
+
+LBB29_44:
+	WORD $0x894d; BYTE $0xcb       // movq         %r9, %r11
+	LONG $0x2a048d48               // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348               // addq         $-48, %rax
+	LONG $0xd04d8d48               // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5       // cmpq         %r10, %r13
+	LONG $0x0054830f; WORD $0x0000 // jae          LBB29_54, $84(%rip)
+
+LBB29_46:
+	WORD $0x3948; BYTE $0xc8       // cmpq         %rcx, %rax
+	LONG $0x0047860f; WORD $0x0000 // jbe          LBB29_53, $71(%rip)
+	LONG $0x005d3841               // cmpb         %bl, (%r13)
+	LONG $0x003d850f; WORD $0x0000 // jne          LBB29_53, $61(%rip)
+	LONG $0x01c58349               // addq         $1, %r13
+	LONG $0xd1558d48               // leaq         $-47(%rbp), %rdx
+	WORD $0x894c; BYTE $0xee       // movq         %r13, %rsi
+
+LBB29_49:
+	WORD $0x8949; BYTE $0xf5       // movq         %rsi, %r13
+	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
+	WORD $0x394c; BYTE $0xd6       // cmpq         %r10, %rsi
+	LONG $0x0027830f; WORD $0x0000 // jae          LBB29_54, $39(%rip)
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0x001e830f; WORD $0x0000 // jae          LBB29_54, $30(%rip)
+	LONG $0x5db60f41; BYTE $0x00   // movzbl       (%r13), %ebx
+	LONG $0x01758d49               // leaq         $1(%r13), %rsi
+	LONG $0x01518d48               // leaq         $1(%rcx), %rdx
+	WORD $0x193a                   // cmpb         (%rcx), %bl
+	LONG $0xffd3840f; WORD $0xffff // je           LBB29_49, $-45(%rip)
+	LONG $0x000004e9; BYTE $0x00   // jmp          LBB29_54, $4(%rip)
+
+LBB29_53:
+	LONG $0xd04d8d48 // leaq         $-48(%rbp), %rcx
+
+LBB29_54:
+	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
+	LONG $0xfcdf850f; WORD $0xffff // jne          LBB29_12, $-801(%rip)
+
+LBB29_55:
+	WORD $0x394d; BYTE $0xc3       // cmpq         %r8, %r11
+	LONG $0x0182830f; WORD $0x0000 // jae          LBB29_69, $386(%rip)
+	WORD $0x394d; BYTE $0xd5       // cmpq         %r10, %r13
+	LONG $0xfdf4820f; WORD $0xffff // jb           LBB29_28, $-524(%rip)
+	LONG $0x000174e9; BYTE $0x00   // jmp          LBB29_69, $372(%rip)
+
+LBB29_57:
+	WORD $0x5d88; BYTE $0xd0     // movb         %bl, $-48(%rbp)
+	LONG $0x000001ba; BYTE $0x00 // movl         $1, %edx
+	LONG $0xffff67e9; BYTE $0xff // jmp          LBB29_44, $-153(%rip)
+
+LBB29_58:
+	WORD $0xe9c1; BYTE $0x06     // shrl         $6, %ecx
+	WORD $0xc980; BYTE $0xc0     // orb          $-64, %cl
+	WORD $0x4d88; BYTE $0xd0     // movb         %cl, $-48(%rbp)
+	WORD $0xe380; BYTE $0x3f     // andb         $63, %bl
+	WORD $0xcb80; BYTE $0x80     // orb          $-128, %bl
+	WORD $0x5d88; BYTE $0xd1     // movb         %bl, $-47(%rbp)
+	LONG $0x000002ba; BYTE $0x00 // movl         $2, %edx
+	WORD $0xcb89                 // movl         %ecx, %ebx
+	LONG $0xffff49e9; BYTE $0xff // jmp          LBB29_44, $-183(%rip)
+
+LBB29_59:
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0x06fa8348                           // cmpq         $6, %rdx
+	LONG $0x02248c0f; WORD $0x0000             // jl           LBB29_85, $548(%rip)
+	LONG $0xdbfff981; WORD $0x0000             // cmpl         $56319, %ecx
+	LONG $0x0218870f; WORD $0x0000             // ja           LBB29_85, $536(%rip)
+	LONG $0x5c398041                           // cmpb         $92, (%r9)
+	LONG $0x020e850f; WORD $0x0000             // jne          LBB29_85, $526(%rip)
+	LONG $0x077b8041; BYTE $0x75               // cmpb         $117, $7(%r11)
+	LONG $0x0203850f; WORD $0x0000             // jne          LBB29_85, $515(%rip)
+	LONG $0x084b8d4d                           // leaq         $8(%r11), %r9
+	LONG $0x08538b41                           // movl         $8(%r11), %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xd3f7                               // notl         %ebx
+	LONG $0xcfd0b28d; WORD $0xcfcf             // leal         $-808464432(%rdx), %esi
+	LONG $0x8080e381; WORD $0x8080             // andl         $-2139062144, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x01c0850f; WORD $0x0000             // jne          LBB29_86, $448(%rip)
+	LONG $0x1919b28d; WORD $0x1919             // leal         $421075225(%rdx), %esi
+	WORD $0xd609                               // orl          %edx, %esi
+	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
+	LONG $0x01ac850f; WORD $0x0000             // jne          LBB29_86, $428(%rip)
+	WORD $0xd689                               // movl         %edx, %esi
+	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
+	LONG $0xc0c0b841; WORD $0xc0c0             // movl         $-1061109568, %r8d
+	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
+	LONG $0x46be8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r15d
+	WORD $0x2141; BYTE $0xd8                   // andl         %ebx, %r8d
+	WORD $0x8545; BYTE $0xf8                   // testl        %r15d, %r8d
+	LONG $0x0188850f; WORD $0x0000             // jne          LBB29_86, $392(%rip)
+	LONG $0xe0e0b841; WORD $0xe0e0             // movl         $-522133280, %r8d
+	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
+	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
+	WORD $0x2144; BYTE $0xc3                   // andl         %r8d, %ebx
+	WORD $0xf385                               // testl        %esi, %ebx
+	LONG $0x016e850f; WORD $0x0000             // jne          LBB29_86, $366(%rip)
+	WORD $0xca0f                               // bswapl       %edx
+	WORD $0xd689                               // movl         %edx, %esi
+	WORD $0xeec1; BYTE $0x04                   // shrl         $4, %esi
+	WORD $0xd6f7                               // notl         %esi
+	LONG $0x0101e681; WORD $0x0101             // andl         $16843009, %esi
+	WORD $0x348d; BYTE $0xf6                   // leal         (%rsi,%rsi,8), %esi
+	LONG $0x0f0fe281; WORD $0x0f0f             // andl         $252645135, %edx
+	WORD $0xf201                               // addl         %esi, %edx
+	WORD $0xd389                               // movl         %edx, %ebx
+	WORD $0xebc1; BYTE $0x04                   // shrl         $4, %ebx
+	WORD $0xd309                               // orl          %edx, %ebx
+	WORD $0xda89                               // movl         %ebx, %edx
+	LONG $0x0000e281; WORD $0x00fc             // andl         $16515072, %edx
+	LONG $0x0000fa81; WORD $0x00dc             // cmpl         $14417920, %edx
+	LONG $0x015c850f; WORD $0x0000             // jne          LBB29_85, $348(%rip)
+	WORD $0xd889                               // movl         %ebx, %eax
+	WORD $0xe8c1; BYTE $0x08                   // shrl         $8, %eax
+	LONG $0x00ff0025; BYTE $0x00               // andl         $65280, %eax
+	WORD $0xb60f; BYTE $0xd3                   // movzbl       %bl, %edx
+	WORD $0xc209                               // orl          %eax, %edx
+	WORD $0xe1c1; BYTE $0x0a                   // shll         $10, %ecx
+	WORD $0x048d; BYTE $0x0a                   // leal         (%rdx,%rcx), %eax
+	WORD $0xd101                               // addl         %edx, %ecx
+	LONG $0x2400c181; WORD $0xfca0             // addl         $-56613888, %ecx
+	WORD $0xcb89                               // movl         %ecx, %ebx
+	WORD $0xebc1; BYTE $0x12                   // shrl         $18, %ebx
+	WORD $0xcb80; BYTE $0xf0                   // orb          $-16, %bl
+	WORD $0x5d88; BYTE $0xd0                   // movb         %bl, $-48(%rbp)
+	WORD $0xca89                               // movl         %ecx, %edx
+	WORD $0xeac1; BYTE $0x0c                   // shrl         $12, %edx
+	WORD $0xe280; BYTE $0x3f                   // andb         $63, %dl
+	WORD $0xca80; BYTE $0x80                   // orb          $-128, %dl
+	WORD $0x5588; BYTE $0xd1                   // movb         %dl, $-47(%rbp)
+	WORD $0xe9c1; BYTE $0x06                   // shrl         $6, %ecx
+	WORD $0xe180; BYTE $0x3f                   // andb         $63, %cl
+	WORD $0xc980; BYTE $0x80                   // orb          $-128, %cl
+	WORD $0x4d88; BYTE $0xd2                   // movb         %cl, $-46(%rbp)
+	WORD $0x3f24                               // andb         $63, %al
+	WORD $0x800c                               // orb          $-128, %al
+	WORD $0x4588; BYTE $0xd3                   // movb         %al, $-45(%rbp)
+	LONG $0x0cc38349                           // addq         $12, %r11
+	LONG $0x000004ba; BYTE $0x00               // movl         $4, %edx
+	LONG $0xc0458b4c                           // movq         $-64(%rbp), %r8
+	LONG $0x2a048d48                           // leaq         (%rdx,%rbp), %rax
+	LONG $0xd0c08348                           // addq         $-48, %rax
+	LONG $0xd04d8d48                           // leaq         $-48(%rbp), %rcx
+	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
+	LONG $0xfe1d820f; WORD $0xffff             // jb           LBB29_46, $-483(%rip)
+	LONG $0xfffe6ce9; BYTE $0xff               // jmp          LBB29_54, $-404(%rip)
+
+LBB29_69:
+	WORD $0x314d; BYTE $0xc3                   // xorq         %r8, %r11
+	WORD $0x314d; BYTE $0xd5                   // xorq         %r10, %r13
+	WORD $0xdb31                               // xorl         %ebx, %ebx
+	WORD $0x094d; BYTE $0xdd                   // orq          %r11, %r13
+	WORD $0x940f; BYTE $0xc3                   // sete         %bl
+	LONG $0xfffb43e9; BYTE $0xff               // jmp          LBB29_13, $-1213(%rip)
+	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+
+LBB29_72:
+	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
+	LONG $0x0078850f; WORD $0x0000 // jne          LBB29_79, $120(%rip)
+	WORD $0x5b3c                   // cmpb         $91, %al
+	LONG $0x0070850f; WORD $0x0000 // jne          LBB29_79, $112(%rip)
+	LONG $0x08478b49               // movq         $8(%r15), %rax
+	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
+	LONG $0x01c38348               // addq         $1, %rbx
+	LONG $0x90909090               // .p2align 4, 0x90
+
+LBB29_75:
+	LONG $0xffc38348                       // addq         $-1, %rbx
+	WORD $0x8548; BYTE $0xdb               // testq        %rbx, %rbx
+	LONG $0x00338e0f; WORD $0x0000         // jle          LBB29_77, $51(%rip)
+	WORD $0x894c; BYTE $0xe7               // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6               // movq         %r14, %rsi
+	LONG $0xffebf8e8; BYTE $0xff           // callq        _skip_one_fast, $-5128(%rip)
+	LONG $0x243c8b49                       // movq         (%r12), %rdi
+	LONG $0x24748b49; BYTE $0x08           // movq         $8(%r12), %rsi
+	WORD $0x894c; BYTE $0xf2               // movq         %r14, %rdx
+	LONG $0xffc9f7e8; BYTE $0xff           // callq        _advance_ns, $-13833(%rip)
+	WORD $0x2c3c                           // cmpb         $44, %al
+	LONG $0xffcf840f; WORD $0xffff         // je           LBB29_75, $-49(%rip)
+	LONG $0x00002be9; BYTE $0x00           // jmp          LBB29_79, $43(%rip)
+	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+
+LBB29_77:
+	LONG $0x10c78349               // addq         $16, %r15
+	LONG $0xb0458b48               // movq         $-80(%rbp), %rax
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	LONG $0xf9d1850f; WORD $0xffff // jne          LBB29_2, $-1583(%rip)
+
+LBB29_78:
+	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
+	WORD $0x894c; BYTE $0xf6     // movq         %r14, %rsi
+	LONG $0xffebb4e8; BYTE $0xff // callq        _skip_one_fast, $-5196(%rip)
+	LONG $0x00000be9; BYTE $0x00 // jmp          LBB29_80, $11(%rip)
+
+LBB29_79:
+	LONG $0xff068349                           // addq         $-1, (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_80:
+	LONG $0x28c48348 // addq         $40, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB29_81:
+	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
+	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB29_80, $-35(%rip)
+
+LBB29_86:
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000017e9; BYTE $0x00               // jmp          LBB29_85, $23(%rip)
+
+LBB29_82:
+	LONG $0x01c38349                           // addq         $1, %r11
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB29_84, $4(%rip)
+
+LBB29_83:
+	LONG $0x01c38349 // addq         $1, %r11
+
+LBB29_84:
+	WORD $0x894d; BYTE $0xd9 // movq         %r11, %r9
+
+LBB29_85:
+	WORD $0x2949; BYTE $0xf9     // subq         %rdi, %r9
+	WORD $0x894d; BYTE $0x0e     // movq         %r9, (%r14)
+	LONG $0xffffafe9; BYTE $0xff // jmp          LBB29_80, $-81(%rip)
+	WORD $0x0000; BYTE $0x00     // .p2align 4, 0x00
+
+LCPI30_0:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
 
 	// .p2align 4, 0x90
@@ -7230,34 +8479,34 @@ _f32toa:
 	WORD $0xe9c1; BYTE $0x17                   // shrl         $23, %ecx
 	WORD $0xb60f; BYTE $0xd1                   // movzbl       %cl, %edx
 	LONG $0x00fffa81; WORD $0x0000             // cmpl         $255, %edx
-	LONG $0x0ddf840f; WORD $0x0000             // je           LBB28_1, $3551(%rip)
+	LONG $0x0ddf840f; WORD $0x0000             // je           LBB30_1, $3551(%rip)
 	WORD $0x07c6; BYTE $0x2d                   // movb         $45, (%rdi)
 	WORD $0x8941; BYTE $0xc2                   // movl         %eax, %r10d
 	LONG $0x1feac141                           // shrl         $31, %r10d
 	LONG $0x170c8d4e                           // leaq         (%rdi,%r10), %r9
 	LONG $0xffffffa9; BYTE $0x7f               // testl        $2147483647, %eax
-	LONG $0x01a9840f; WORD $0x0000             // je           LBB28_3, $425(%rip)
+	LONG $0x01a9840f; WORD $0x0000             // je           LBB30_3, $425(%rip)
 	LONG $0x7fffff25; BYTE $0x00               // andl         $8388607, %eax
 	WORD $0xd285                               // testl        %edx, %edx
-	LONG $0x0dc0840f; WORD $0x0000             // je           LBB28_5, $3520(%rip)
+	LONG $0x0dc0840f; WORD $0x0000             // je           LBB30_5, $3520(%rip)
 	LONG $0x00988d44; WORD $0x8000; BYTE $0x00 // leal         $8388608(%rax), %r11d
 	LONG $0x6a828d44; WORD $0xffff; BYTE $0xff // leal         $-150(%rdx), %r8d
 	WORD $0x4a8d; BYTE $0x81                   // leal         $-127(%rdx), %ecx
 	WORD $0xf983; BYTE $0x17                   // cmpl         $23, %ecx
-	LONG $0x001c870f; WORD $0x0000             // ja           LBB28_10, $28(%rip)
+	LONG $0x001c870f; WORD $0x0000             // ja           LBB30_10, $28(%rip)
 	LONG $0x000096b9; BYTE $0x00               // movl         $150, %ecx
 	WORD $0xd129                               // subl         %edx, %ecx
 	LONG $0xffc6c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rsi
 	WORD $0xd348; BYTE $0xe6                   // shlq         %cl, %rsi
 	WORD $0xd6f7                               // notl         %esi
 	WORD $0x8544; BYTE $0xde                   // testl        %r11d, %esi
-	LONG $0x0326840f; WORD $0x0000             // je           LBB28_12, $806(%rip)
+	LONG $0x0326840f; WORD $0x0000             // je           LBB30_12, $806(%rip)
 
-LBB28_10:
+LBB30_10:
 	LONG $0xc84d894c // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948 // movq         %rdi, $-48(%rbp)
 
-LBB28_6:
+LBB30_6:
 	WORD $0x8945; BYTE $0xdf                   // movl         %r11d, %r15d
 	LONG $0x01e78341                           // andl         $1, %r15d
 	WORD $0xc085                               // testl        %eax, %eax
@@ -7282,7 +8531,7 @@ LBB28_6:
 	WORD $0x2944; BYTE $0xf2                   // subl         %r14d, %edx
 	WORD $0xc180; BYTE $0x01                   // addb         $1, %cl
 	WORD $0xe0d3                               // shll         %cl, %eax
-	LONG $0x65358d48; WORD $0x00b2; BYTE $0x00 // leaq         $45669(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
+	LONG $0x35358d48; WORD $0x00b6; BYTE $0x00 // leaq         $46645(%rip), %rsi  /* _pow10_ceil_sig_f32.g(%rip) */
 	LONG $0xd62c8b4c                           // movq         (%rsi,%rdx,8), %r13
 	WORD $0xf749; BYTE $0xe5                   // mulq         %r13
 	WORD $0x8949; BYTE $0xd0                   // movq         %rdx, %r8
@@ -7312,7 +8561,7 @@ LBB28_6:
 	WORD $0x0145; BYTE $0xfc                   // addl         %r15d, %r12d
 	WORD $0x2944; BYTE $0xf9                   // subl         %r15d, %ecx
 	WORD $0xfb83; BYTE $0x28                   // cmpl         $40, %ebx
-	LONG $0x0042820f; WORD $0x0000             // jb           LBB28_31, $66(%rip)
+	LONG $0x0042820f; WORD $0x0000             // jb           LBB30_31, $66(%rip)
 	WORD $0x8944; BYTE $0xc8                   // movl         %r9d, %eax
 	LONG $0xcccccdba; BYTE $0xcc               // movl         $3435973837, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -7329,9 +8578,9 @@ LBB28_6:
 	WORD $0x3948; BYTE $0xfe                   // cmpq         %rdi, %rsi
 	LONG $0xc0960f41                           // setbe        %r8b
 	WORD $0x3845; BYTE $0xc3                   // cmpb         %r8b, %r11b
-	LONG $0x00b7840f; WORD $0x0000             // je           LBB28_8, $183(%rip)
+	LONG $0x00b7840f; WORD $0x0000             // je           LBB30_8, $183(%rip)
 
-LBB28_31:
+LBB30_31:
 	WORD $0x894d; BYTE $0xc8       // movq         %r9, %r8
 	LONG $0x02e8c149               // shrq         $2, %r8
 	WORD $0x8944; BYTE $0xca       // movl         %r9d, %edx
@@ -7342,84 +8591,84 @@ LBB28_31:
 	WORD $0xcf39                   // cmpl         %ecx, %edi
 	WORD $0x960f; BYTE $0xc0       // setbe        %al
 	WORD $0x3040; BYTE $0xf0       // xorb         %sil, %al
-	LONG $0x0048840f; WORD $0x0000 // je           LBB28_32, $72(%rip)
+	LONG $0x0048840f; WORD $0x0000 // je           LBB30_32, $72(%rip)
 	WORD $0xca83; BYTE $0x02       // orl          $2, %edx
 	LONG $0x000001b8; BYTE $0x00   // movl         $1, %eax
 	WORD $0xd339                   // cmpl         %edx, %ebx
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
-	LONG $0x000e870f; WORD $0x0000 // ja           LBB28_35, $14(%rip)
+	LONG $0x000e870f; WORD $0x0000 // ja           LBB30_35, $14(%rip)
 	WORD $0x940f; BYTE $0xc0       // sete         %al
 	LONG $0x02e9c041               // shrb         $2, %r9b
 	WORD $0x2041; BYTE $0xc1       // andb         %al, %r9b
 	LONG $0xc1b60f41               // movzbl       %r9b, %eax
 
-LBB28_35:
+LBB30_35:
 	WORD $0x0144; BYTE $0xc0       // addl         %r8d, %eax
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x0030830f; WORD $0x0000 // jae          LBB28_37, $48(%rip)
-	LONG $0x000075e9; BYTE $0x00   // jmp          LBB28_40, $117(%rip)
+	LONG $0x0030830f; WORD $0x0000 // jae          LBB30_37, $48(%rip)
+	LONG $0x000075e9; BYTE $0x00   // jmp          LBB30_40, $117(%rip)
 
-LBB28_3:
+LBB30_3:
 	LONG $0x3001c641             // movb         $48, (%r9)
 	WORD $0x2941; BYTE $0xf9     // subl         %edi, %r9d
 	LONG $0x01c18341             // addl         $1, %r9d
 	WORD $0x8944; BYTE $0xc8     // movl         %r9d, %eax
-	LONG $0x000728e9; BYTE $0x00 // jmp          LBB28_153, $1832(%rip)
+	LONG $0x000728e9; BYTE $0x00 // jmp          LBB30_153, $1832(%rip)
 
-LBB28_32:
+LBB30_32:
 	WORD $0xf939                   // cmpl         %edi, %ecx
 	LONG $0xffd88341               // sbbl         $-1, %r8d
 	WORD $0x8944; BYTE $0xc0       // movl         %r8d, %eax
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0x004a820f; WORD $0x0000 // jb           LBB28_40, $74(%rip)
+	LONG $0x004a820f; WORD $0x0000 // jb           LBB30_40, $74(%rip)
 
-LBB28_37:
+LBB30_37:
 	LONG $0x0006bd41; WORD $0x0000 // movl         $6, %r13d
 	LONG $0x0f42403d; BYTE $0x00   // cmpl         $1000000, %eax
-	LONG $0x0077820f; WORD $0x0000 // jb           LBB28_45, $119(%rip)
+	LONG $0x0077820f; WORD $0x0000 // jb           LBB30_45, $119(%rip)
 	LONG $0x0007bd41; WORD $0x0000 // movl         $7, %r13d
 	LONG $0x9896803d; BYTE $0x00   // cmpl         $10000000, %eax
-	LONG $0x0066820f; WORD $0x0000 // jb           LBB28_45, $102(%rip)
+	LONG $0x0066820f; WORD $0x0000 // jb           LBB30_45, $102(%rip)
 	LONG $0xf5e1003d; BYTE $0x05   // cmpl         $100000000, %eax
 	LONG $0x0009bd41; WORD $0x0000 // movl         $9, %r13d
-	LONG $0x000052e9; BYTE $0x00   // jmp          LBB28_44, $82(%rip)
+	LONG $0x000052e9; BYTE $0x00   // jmp          LBB30_44, $82(%rip)
 
-LBB28_8:
+LBB30_8:
 	WORD $0x8844; BYTE $0xc0       // movb         %r8b, %al
 	WORD $0xd001                   // addl         %edx, %eax
 	LONG $0x01c68341               // addl         $1, %r14d
 	LONG $0xc8658b4c               // movq         $-56(%rbp), %r12
 	LONG $0x0186a03d; BYTE $0x00   // cmpl         $100000, %eax
-	LONG $0xffb6830f; WORD $0xffff // jae          LBB28_37, $-74(%rip)
+	LONG $0xffb6830f; WORD $0xffff // jae          LBB30_37, $-74(%rip)
 
-LBB28_40:
+LBB30_40:
 	LONG $0x0001bd41; WORD $0x0000 // movl         $1, %r13d
 	WORD $0xf883; BYTE $0x0a       // cmpl         $10, %eax
-	LONG $0x002f820f; WORD $0x0000 // jb           LBB28_45, $47(%rip)
+	LONG $0x002f820f; WORD $0x0000 // jb           LBB30_45, $47(%rip)
 	LONG $0x0002bd41; WORD $0x0000 // movl         $2, %r13d
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0x0020820f; WORD $0x0000 // jb           LBB28_45, $32(%rip)
+	LONG $0x0020820f; WORD $0x0000 // jb           LBB30_45, $32(%rip)
 	LONG $0x0003bd41; WORD $0x0000 // movl         $3, %r13d
 	LONG $0x0003e83d; BYTE $0x00   // cmpl         $1000, %eax
-	LONG $0x000f820f; WORD $0x0000 // jb           LBB28_45, $15(%rip)
+	LONG $0x000f820f; WORD $0x0000 // jb           LBB30_45, $15(%rip)
 	LONG $0x0027103d; BYTE $0x00   // cmpl         $10000, %eax
 	LONG $0x0005bd41; WORD $0x0000 // movl         $5, %r13d
 
-LBB28_44:
+LBB30_44:
 	LONG $0x00dd8341 // sbbl         $0, %r13d
 
-LBB28_45:
+LBB30_45:
 	LONG $0x2e0c8d47                           // leal         (%r14,%r13), %r9d
 	LONG $0x2e0c8d43                           // leal         (%r14,%r13), %ecx
 	WORD $0xc183; BYTE $0x05                   // addl         $5, %ecx
 	WORD $0xf983; BYTE $0x1b                   // cmpl         $27, %ecx
-	LONG $0x006d820f; WORD $0x0000             // jb           LBB28_70, $109(%rip)
+	LONG $0x006d820f; WORD $0x0000             // jb           LBB30_70, $109(%rip)
 	WORD $0x8944; BYTE $0xea                   // movl         %r13d, %edx
 	LONG $0x140c8d49                           // leaq         (%r12,%rdx), %rcx
 	LONG $0x01c18348                           // addq         $1, %rcx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x00ca820f; WORD $0x0000             // jb           LBB28_47, $202(%rip)
+	LONG $0x00ca820f; WORD $0x0000             // jb           LBB30_47, $202(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdeaf0f48                           // imulq        %rsi, %rbx
@@ -7427,27 +8676,27 @@ LBB28_45:
 	LONG $0xf0c36944; WORD $0xffd8; BYTE $0xff // imull        $-10000, %ebx, %r8d
 	WORD $0x0141; BYTE $0xc0                   // addl         %eax, %r8d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0x0348840f; WORD $0x0000             // je           LBB28_49, $840(%rip)
+	LONG $0x0348840f; WORD $0x0000             // je           LBB30_49, $840(%rip)
 	WORD $0x8944; BYTE $0xc0                   // movl         %r8d, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0x2941; BYTE $0xf0                   // subl         %esi, %r8d
-	LONG $0xca358d48; WORD $0x003c; BYTE $0x00 // leaq         $15562(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x9a358d48; WORD $0x0040; BYTE $0x00 // leaq         $16538(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x3cb70f42; BYTE $0x46               // movzwl       (%rsi,%r8,2), %edi
 	LONG $0xfe798966                           // movw         %di, $-2(%rcx)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0xfc418966                           // movw         %ax, $-4(%rcx)
 	WORD $0x3145; BYTE $0xc0                   // xorl         %r8d, %r8d
-	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB28_51, $794(%rip)
+	LONG $0x00031ae9; BYTE $0x00               // jmp          LBB30_51, $794(%rip)
 
-LBB28_70:
+LBB30_70:
 	WORD $0x8945; BYTE $0xe8                   // movl         %r13d, %r8d
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
-	LONG $0x0120880f; WORD $0x0000             // js           LBB28_71, $288(%rip)
+	LONG $0x0120880f; WORD $0x0000             // js           LBB30_71, $288(%rip)
 	LONG $0x04148d4b                           // leaq         (%r12,%r8), %rdx
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x017b820f; WORD $0x0000             // jb           LBB28_124, $379(%rip)
+	LONG $0x017b820f; WORD $0x0000             // jb           LBB30_124, $379(%rip)
 	WORD $0xc189                               // movl         %eax, %ecx
 	LONG $0xb71759be; BYTE $0xd1               // movl         $3518437209, %esi
 	LONG $0xf1af0f48                           // imulq        %rcx, %rsi
@@ -7458,7 +8707,7 @@ LBB28_70:
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf86b; BYTE $0x64                   // imull        $100, %eax, %edi
 	WORD $0xf929                               // subl         %edi, %ecx
-	LONG $0x683d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15464(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0x383d8d48; WORD $0x0040; BYTE $0x00 // leaq         $16440(%rip), %rdi  /* _Digits(%rip) */
 	LONG $0x4f0cb70f                           // movzwl       (%rdi,%rcx,2), %ecx
 	LONG $0xfe4a8966                           // movw         %cx, $-2(%rdx)
 	LONG $0xfc4a8d48                           // leaq         $-4(%rdx), %rcx
@@ -7467,41 +8716,41 @@ LBB28_70:
 	WORD $0xf089                               // movl         %esi, %eax
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64                   // cmpl         $100, %eax
-	LONG $0x013a830f; WORD $0x0000             // jae          LBB28_128, $314(%rip)
+	LONG $0x013a830f; WORD $0x0000             // jae          LBB30_128, $314(%rip)
 
-LBB28_127:
+LBB30_127:
 	WORD $0xc389                 // movl         %eax, %ebx
-	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB28_130, $364(%rip)
+	LONG $0x00016ce9; BYTE $0x00 // jmp          LBB30_130, $364(%rip)
 
-LBB28_47:
+LBB30_47:
 	WORD $0x3145; BYTE $0xc0       // xorl         %r8d, %r8d
 	WORD $0xc389                   // movl         %eax, %ebx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x02a2830f; WORD $0x0000 // jae          LBB28_54, $674(%rip)
+	LONG $0x02a2830f; WORD $0x0000 // jae          LBB30_54, $674(%rip)
 
-LBB28_53:
+LBB30_53:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB28_56, $740(%rip)
+	LONG $0x0002e4e9; BYTE $0x00 // jmp          LBB30_56, $740(%rip)
 
-LBB28_12:
+LBB30_12:
 	WORD $0xd341; BYTE $0xeb                   // shrl         %cl, %r11d
 	LONG $0xa0fb8141; WORD $0x0186; BYTE $0x00 // cmpl         $100000, %r11d
-	LONG $0x01bd820f; WORD $0x0000             // jb           LBB28_18, $445(%rip)
+	LONG $0x01bd820f; WORD $0x0000             // jb           LBB30_18, $445(%rip)
 	LONG $0x000006b9; BYTE $0x00               // movl         $6, %ecx
 	LONG $0x40fb8141; WORD $0x0f42; BYTE $0x00 // cmpl         $1000000, %r11d
-	LONG $0x0022820f; WORD $0x0000             // jb           LBB28_16, $34(%rip)
+	LONG $0x0022820f; WORD $0x0000             // jb           LBB30_16, $34(%rip)
 	LONG $0x000007b9; BYTE $0x00               // movl         $7, %ecx
 	LONG $0x80fb8141; WORD $0x9896; BYTE $0x00 // cmpl         $10000000, %r11d
-	LONG $0x0010820f; WORD $0x0000             // jb           LBB28_16, $16(%rip)
+	LONG $0x0010820f; WORD $0x0000             // jb           LBB30_16, $16(%rip)
 	LONG $0x00fb8141; WORD $0xf5e1; BYTE $0x05 // cmpl         $100000000, %r11d
 	LONG $0x000009b9; BYTE $0x00               // movl         $9, %ecx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 
-LBB28_16:
+LBB30_16:
 	WORD $0x014c; BYTE $0xc9 // addq         %r9, %rcx
 
-LBB28_17:
+LBB30_17:
 	WORD $0x8944; BYTE $0xd8                   // movl         %r11d, %eax
 	LONG $0xb71759ba; BYTE $0xd1               // movl         $3518437209, %edx
 	LONG $0xd0af0f48                           // imulq        %rax, %rdx
@@ -7512,7 +8761,7 @@ LBB28_17:
 	LONG $0x25eec148                           // shrq         $37, %rsi
 	WORD $0xde6b; BYTE $0x64                   // imull        $100, %esi, %ebx
 	WORD $0xd829                               // subl         %ebx, %eax
-	LONG $0xae1d8d48; WORD $0x003b; BYTE $0x00 // leaq         $15278(%rip), %rbx  /* _Digits(%rip) */
+	LONG $0x7e1d8d48; WORD $0x003f; BYTE $0x00 // leaq         $16254(%rip), %rbx  /* _Digits(%rip) */
 	LONG $0x4304b70f                           // movzwl       (%rbx,%rax,2), %eax
 	LONG $0xfe418966                           // movw         %ax, $-2(%rcx)
 	LONG $0x7304b70f                           // movzwl       (%rbx,%rsi,2), %eax
@@ -7521,22 +8770,22 @@ LBB28_17:
 	LONG $0xfcc18348                           // addq         $-4, %rcx
 	WORD $0x8941; BYTE $0xd3                   // movl         %edx, %r11d
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0172830f; WORD $0x0000             // jae          LBB28_25, $370(%rip)
-	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB28_27, $439(%rip)
+	LONG $0x0172830f; WORD $0x0000             // jae          LBB30_25, $370(%rip)
+	LONG $0x0001b7e9; BYTE $0x00               // jmp          LBB30_27, $439(%rip)
 
-LBB28_71:
+LBB30_71:
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x05ee8f0f; WORD $0x0000             // jg           LBB28_84, $1518(%rip)
+	LONG $0x05ee8f0f; WORD $0x0000             // jg           LBB30_84, $1518(%rip)
 	LONG $0x04c74166; WORD $0x3024; BYTE $0x2e // movw         $11824, (%r12)
 	LONG $0x02c48349                           // addq         $2, %r12
 	WORD $0x8545; BYTE $0xc9                   // testl        %r9d, %r9d
-	LONG $0x05da890f; WORD $0x0000             // jns          LBB28_84, $1498(%rip)
+	LONG $0x05da890f; WORD $0x0000             // jns          LBB30_84, $1498(%rip)
 	WORD $0x8945; BYTE $0xeb                   // movl         %r13d, %r11d
 	WORD $0xf741; BYTE $0xd3                   // notl         %r11d
 	WORD $0x2945; BYTE $0xf3                   // subl         %r14d, %r11d
 	WORD $0xc931                               // xorl         %ecx, %ecx
 	LONG $0x1ffb8341                           // cmpl         $31, %r11d
-	LONG $0x05a9820f; WORD $0x0000             // jb           LBB28_82, $1449(%rip)
+	LONG $0x05a9820f; WORD $0x0000             // jb           LBB30_82, $1449(%rip)
 	WORD $0x894c; BYTE $0xe7                   // movq         %r12, %rdi
 	LONG $0x01c38349                           // addq         $1, %r11
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
@@ -7548,22 +8797,22 @@ LBB28_71:
 	WORD $0x8945; BYTE $0xe7                   // movl         %r12d, %r15d
 	LONG $0x07e78341                           // andl         $7, %r15d
 	LONG $0xe0fa8148; WORD $0x0000; BYTE $0x00 // cmpq         $224, %rdx
-	LONG $0x0487830f; WORD $0x0000             // jae          LBB28_76, $1159(%rip)
+	LONG $0x0487830f; WORD $0x0000             // jae          LBB30_76, $1159(%rip)
 	WORD $0xd231                               // xorl         %edx, %edx
-	LONG $0x000525e9; BYTE $0x00               // jmp          LBB28_78, $1317(%rip)
+	LONG $0x000525e9; BYTE $0x00               // jmp          LBB30_78, $1317(%rip)
 
-LBB28_124:
+LBB30_124:
 	WORD $0x8948; BYTE $0xd1       // movq         %rdx, %rcx
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
 	WORD $0xf883; BYTE $0x64       // cmpl         $100, %eax
-	LONG $0xfec6820f; WORD $0xffff // jb           LBB28_127, $-314(%rip)
+	LONG $0xfec6820f; WORD $0xffff // jb           LBB30_127, $-314(%rip)
 
-LBB28_128:
+LBB30_128:
 	LONG $0xffc18348                           // addq         $-1, %rcx
-	LONG $0x001d8d4c; WORD $0x003b; BYTE $0x00 // leaq         $15104(%rip), %r11  /* _Digits(%rip) */
+	LONG $0xd01d8d4c; WORD $0x003e; BYTE $0x00 // leaq         $16080(%rip), %r11  /* _Digits(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_129:
+LBB30_129:
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0x1fde6948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rsi, %rbx
 	LONG $0x25ebc148                           // shrq         $37, %rbx
@@ -7575,29 +8824,29 @@ LBB28_129:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x00270f3d; BYTE $0x00               // cmpl         $9999, %eax
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_129, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_129, $-46(%rip)
 
-LBB28_130:
+LBB30_130:
 	WORD $0x634d; BYTE $0xf1                   // movslq       %r9d, %r14
 	WORD $0xfb83; BYTE $0x0a                   // cmpl         $10, %ebx
-	LONG $0x0023820f; WORD $0x0000             // jb           LBB28_132, $35(%rip)
+	LONG $0x0023820f; WORD $0x0000             // jb           LBB30_132, $35(%rip)
 	WORD $0xd889                               // movl         %ebx, %eax
-	LONG $0xbd0d8d48; WORD $0x003a; BYTE $0x00 // leaq         $15037(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x8d0d8d48; WORD $0x003e; BYTE $0x00 // leaq         $16013(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
 	WORD $0x014d; BYTE $0xf4                   // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0                   // cmpq         %r14, %r8
-	LONG $0x00188c0f; WORD $0x0000             // jl           LBB28_134, $24(%rip)
-	LONG $0x0003f3e9; BYTE $0x00               // jmp          LBB28_151, $1011(%rip)
+	LONG $0x00188c0f; WORD $0x0000             // jl           LBB30_134, $24(%rip)
+	LONG $0x0003f3e9; BYTE $0x00               // jmp          LBB30_151, $1011(%rip)
 
-LBB28_132:
+LBB30_132:
 	WORD $0xc380; BYTE $0x30       // addb         $48, %bl
 	LONG $0x241c8841               // movb         %bl, (%r12)
 	WORD $0x014d; BYTE $0xf4       // addq         %r14, %r12
 	WORD $0x394d; BYTE $0xf0       // cmpq         %r14, %r8
-	LONG $0x03e08d0f; WORD $0x0000 // jge          LBB28_151, $992(%rip)
+	LONG $0x03e08d0f; WORD $0x0000 // jge          LBB30_151, $992(%rip)
 
-LBB28_134:
+LBB30_134:
 	LONG $0x2a048d4b               // leaq         (%r10,%r13), %rax
 	LONG $0x000c8d49               // leaq         (%r8,%rax), %rcx
 	LONG $0x01c18348               // addq         $1, %rcx
@@ -7607,35 +8856,35 @@ LBB28_134:
 	WORD $0x014c; BYTE $0xc0       // addq         %r8, %rax
 	WORD $0x2949; BYTE $0xc6       // subq         %rax, %r14
 	LONG $0x08fe8349               // cmpq         $8, %r14
-	LONG $0x03aa820f; WORD $0x0000 // jb           LBB28_150, $938(%rip)
+	LONG $0x03aa820f; WORD $0x0000 // jb           LBB30_150, $938(%rip)
 	LONG $0x20fe8349               // cmpq         $32, %r14
-	LONG $0x0202830f; WORD $0x0000 // jae          LBB28_140, $514(%rip)
+	LONG $0x0202830f; WORD $0x0000 // jae          LBB30_140, $514(%rip)
 	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
-	LONG $0x000323e9; BYTE $0x00   // jmp          LBB28_137, $803(%rip)
+	LONG $0x000323e9; BYTE $0x00   // jmp          LBB30_137, $803(%rip)
 
-LBB28_18:
+LBB30_18:
 	LONG $0x000001b8; BYTE $0x00               // movl         $1, %eax
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0021820f; WORD $0x0000             // jb           LBB28_21, $33(%rip)
+	LONG $0x0021820f; WORD $0x0000             // jb           LBB30_21, $33(%rip)
 	LONG $0x000002b8; BYTE $0x00               // movl         $2, %eax
 	LONG $0x64fb8341                           // cmpl         $100, %r11d
-	LONG $0x0012820f; WORD $0x0000             // jb           LBB28_21, $18(%rip)
+	LONG $0x0012820f; WORD $0x0000             // jb           LBB30_21, $18(%rip)
 	LONG $0x000003b8; BYTE $0x00               // movl         $3, %eax
 	LONG $0xe8fb8141; WORD $0x0003; BYTE $0x00 // cmpl         $1000, %r11d
-	LONG $0x0337830f; WORD $0x0000             // jae          LBB28_23, $823(%rip)
+	LONG $0x0337830f; WORD $0x0000             // jae          LBB30_23, $823(%rip)
 
-LBB28_21:
+LBB30_21:
 	WORD $0x014c; BYTE $0xc8       // addq         %r9, %rax
 	WORD $0x8948; BYTE $0xc1       // movq         %rax, %rcx
 	LONG $0x64fb8341               // cmpl         $100, %r11d
-	LONG $0x004a820f; WORD $0x0000 // jb           LBB28_27, $74(%rip)
+	LONG $0x004a820f; WORD $0x0000 // jb           LBB30_27, $74(%rip)
 
-LBB28_25:
+LBB30_25:
 	LONG $0xffc18348                                       // addq         $-1, %rcx
-	LONG $0x0d058d4c; WORD $0x003a; BYTE $0x00             // leaq         $14861(%rip), %r8  /* _Digits(%rip) */
+	LONG $0xdd058d4c; WORD $0x003d; BYTE $0x00             // leaq         $15837(%rip), %r8  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_26:
+LBB30_26:
 	WORD $0x8944; BYTE $0xde                   // movl         %r11d, %esi
 	WORD $0x8944; BYTE $0xdb                   // movl         %r11d, %ebx
 	LONG $0x1fdb694c; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rbx, %r11
@@ -7647,38 +8896,38 @@ LBB28_26:
 	LONG $0xff518966                           // movw         %dx, $-1(%rcx)
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffe81; WORD $0x0000             // cmpl         $9999, %esi
-	LONG $0xffce870f; WORD $0xffff             // ja           LBB28_26, $-50(%rip)
+	LONG $0xffce870f; WORD $0xffff             // ja           LBB30_26, $-50(%rip)
 
-LBB28_27:
+LBB30_27:
 	LONG $0x0afb8341                           // cmpl         $10, %r11d
-	LONG $0x0019820f; WORD $0x0000             // jb           LBB28_29, $25(%rip)
+	LONG $0x0019820f; WORD $0x0000             // jb           LBB30_29, $25(%rip)
 	WORD $0x8944; BYTE $0xd9                   // movl         %r11d, %ecx
-	LONG $0xba158d48; WORD $0x0039; BYTE $0x00 // leaq         $14778(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x8a158d48; WORD $0x003d; BYTE $0x00 // leaq         $15754(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x09894166                           // movw         %cx, (%r9)
 	WORD $0xf829                               // subl         %edi, %eax
-	LONG $0x000301e9; BYTE $0x00               // jmp          LBB28_153, $769(%rip)
+	LONG $0x000301e9; BYTE $0x00               // jmp          LBB30_153, $769(%rip)
 
-LBB28_29:
+LBB30_29:
 	LONG $0x30c38041             // addb         $48, %r11b
 	WORD $0x8845; BYTE $0x19     // movb         %r11b, (%r9)
 	WORD $0xf829                 // subl         %edi, %eax
-	LONG $0x0002f3e9; BYTE $0x00 // jmp          LBB28_153, $755(%rip)
+	LONG $0x0002f3e9; BYTE $0x00 // jmp          LBB30_153, $755(%rip)
 
-LBB28_49:
+LBB30_49:
 	LONG $0x0004b841; WORD $0x0000 // movl         $4, %r8d
 
-LBB28_51:
+LBB30_51:
 	LONG $0xfcc18348               // addq         $-4, %rcx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xfd5e820f; WORD $0xffff // jb           LBB28_53, $-674(%rip)
+	LONG $0xfd5e820f; WORD $0xffff // jb           LBB30_53, $-674(%rip)
 
-LBB28_54:
+LBB30_54:
 	LONG $0xffc18348                                                     // addq         $-1, %rcx
-	LONG $0x7f1d8d4c; WORD $0x0039; BYTE $0x00                           // leaq         $14719(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x4f1d8d4c; WORD $0x003d; BYTE $0x00                           // leaq         $15695(%rip), %r11  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_55:
+LBB30_55:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -7690,83 +8939,83 @@ LBB28_55:
 	LONG $0xfec18348                           // addq         $-2, %rcx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd1870f; WORD $0xffff             // ja           LBB28_55, $-47(%rip)
+	LONG $0xffd1870f; WORD $0xffff             // ja           LBB30_55, $-47(%rip)
 
-LBB28_56:
+LBB30_56:
 	LONG $0x244c8d49; BYTE $0x01               // leaq         $1(%r12), %rcx
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001f820f; WORD $0x0000             // jb           LBB28_58, $31(%rip)
+	LONG $0x001f820f; WORD $0x0000             // jb           LBB30_58, $31(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
-	LONG $0x2a3d8d48; WORD $0x0039; BYTE $0x00 // leaq         $14634(%rip), %rdi  /* _Digits(%rip) */
+	LONG $0xfa3d8d48; WORD $0x003c; BYTE $0x00 // leaq         $15610(%rip), %rdi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x77                   // movb         (%rdi,%rsi,2), %al
 	LONG $0x01775c8a                           // movb         $1(%rdi,%rsi,2), %bl
 	LONG $0x24448841; BYTE $0x01               // movb         %al, $1(%r12)
 	LONG $0x245c8841; BYTE $0x02               // movb         %bl, $2(%r12)
-	LONG $0x000004e9; BYTE $0x00               // jmp          LBB28_59, $4(%rip)
+	LONG $0x000004e9; BYTE $0x00               // jmp          LBB30_59, $4(%rip)
 
-LBB28_58:
+LBB30_58:
 	WORD $0x3004 // addb         $48, %al
 	WORD $0x0188 // movb         %al, (%rcx)
 
-LBB28_59:
+LBB30_59:
 	WORD $0x294d; BYTE $0xc2     // subq         %r8, %r10
 	WORD $0x014d; BYTE $0xea     // addq         %r13, %r10
 	LONG $0x000001bb; BYTE $0x00 // movl         $1, %ebx
 	WORD $0x294c; BYTE $0xc3     // subq         %r8, %rbx
 	WORD $0x9090                 // .p2align 4, 0x90
 
-LBB28_60:
+LBB30_60:
 	LONG $0xffc38348               // addq         $-1, %rbx
 	LONG $0x123c8041; BYTE $0x30   // cmpb         $48, (%r10,%rdx)
 	LONG $0xff528d4d               // leaq         $-1(%r10), %r10
-	LONG $0xffed840f; WORD $0xffff // je           LBB28_60, $-19(%rip)
+	LONG $0xffed840f; WORD $0xffff // je           LBB30_60, $-19(%rip)
 	LONG $0x24048841               // movb         %al, (%r12)
 	WORD $0x0148; BYTE $0xd3       // addq         %rdx, %rbx
 	LONG $0x02fb8348               // cmpq         $2, %rbx
-	LONG $0x00468c0f; WORD $0x0000 // jl           LBB28_62, $70(%rip)
+	LONG $0x00468c0f; WORD $0x0000 // jl           LBB30_62, $70(%rip)
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x02c08348               // addq         $2, %rax
 	WORD $0x01c6; BYTE $0x2e       // movb         $46, (%rcx)
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00438e0f; WORD $0x0000 // jle          LBB28_65, $67(%rip)
+	LONG $0x00438e0f; WORD $0x0000 // jle          LBB30_65, $67(%rip)
 
-LBB28_66:
+LBB30_66:
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0x2b0140c6               // movb         $43, $1(%rax)
 	WORD $0x8944; BYTE $0xc9       // movl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0x00448c0f; WORD $0x0000 // jl           LBB28_69, $68(%rip)
+	LONG $0x00448c0f; WORD $0x0000 // jl           LBB30_69, $68(%rip)
 
-LBB28_68:
+LBB30_68:
 	WORD $0x6348; BYTE $0xc9                   // movslq       %ecx, %rcx
-	LONG $0xa7158d48; WORD $0x0038; BYTE $0x00 // leaq         $14503(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x77158d48; WORD $0x003c; BYTE $0x00 // leaq         $15479(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x02488966                           // movw         %cx, $2(%rax)
 	LONG $0x04c08348                           // addq         $4, %rax
-	LONG $0x0001e9e9; BYTE $0x00               // jmp          LBB28_152, $489(%rip)
+	LONG $0x0001e9e9; BYTE $0x00               // jmp          LBB30_152, $489(%rip)
 
-LBB28_62:
+LBB30_62:
 	LONG $0x12048d49               // leaq         (%r10,%rdx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x00c6; BYTE $0x65       // movb         $101, (%rax)
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB28_66, $-67(%rip)
+	LONG $0xffbd8f0f; WORD $0xffff // jg           LBB30_66, $-67(%rip)
 
-LBB28_65:
+LBB30_65:
 	LONG $0x2d0140c6               // movb         $45, $1(%rax)
 	LONG $0x000001b9; BYTE $0x00   // movl         $1, %ecx
 	WORD $0x2944; BYTE $0xc9       // subl         %r9d, %ecx
 	WORD $0xf983; BYTE $0x0a       // cmpl         $10, %ecx
-	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB28_68, $-68(%rip)
+	LONG $0xffbc8d0f; WORD $0xffff // jge          LBB30_68, $-68(%rip)
 
-LBB28_69:
+LBB30_69:
 	WORD $0xc180; BYTE $0x30     // addb         $48, %cl
 	WORD $0x4888; BYTE $0x02     // movb         %cl, $2(%rax)
 	LONG $0x03c08348             // addq         $3, %rax
-	LONG $0x0001b1e9; BYTE $0x00 // jmp          LBB28_152, $433(%rip)
+	LONG $0x0001b1e9; BYTE $0x00 // jmp          LBB30_152, $433(%rip)
 
-LBB28_140:
+LBB30_140:
 	WORD $0x894d; BYTE $0xf1       // movq         %r14, %r9
 	LONG $0xe0e18349               // andq         $-32, %r9
 	LONG $0xe0418d49               // leaq         $-32(%r9), %rax
@@ -7776,21 +9025,21 @@ LBB28_140:
 	WORD $0x8941; BYTE $0xdb       // movl         %ebx, %r11d
 	LONG $0x07e38341               // andl         $7, %r11d
 	LONG $0x00e03d48; WORD $0x0000 // cmpq         $224, %rax
-	LONG $0x0007830f; WORD $0x0000 // jae          LBB28_142, $7(%rip)
+	LONG $0x0007830f; WORD $0x0000 // jae          LBB30_142, $7(%rip)
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	LONG $0x0000a3e9; BYTE $0x00   // jmp          LBB28_144, $163(%rip)
+	LONG $0x0000a3e9; BYTE $0x00   // jmp          LBB30_144, $163(%rip)
 
-LBB28_142:
+LBB30_142:
 	LONG $0x02048d4b               // leaq         (%r10,%r8), %rax
 	WORD $0x014c; BYTE $0xe8       // addq         %r13, %rax
 	LONG $0x00f00548; WORD $0x0000 // addq         $240, %rax
 	LONG $0xf8e38348               // andq         $-8, %rbx
 	WORD $0xf748; BYTE $0xdb       // negq         %rbx
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	QUAD $0xfffff830056f0f66       // movdqa       $-2000(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff830056f0f66       // movdqa       $-2000(%rip), %xmm0  /* LCPI30_0(%rip) */
 
 	// .p2align 4, 0x90
-LBB28_143:
+LBB30_143:
 	QUAD $0xffff1008847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-240(%rax,%rcx)
 	QUAD $0xffff2008847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-224(%rax,%rcx)
 	QUAD $0xffff3008847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-208(%rax,%rcx)
@@ -7809,34 +9058,34 @@ LBB28_143:
 	LONG $0x047f0ff3; BYTE $0x08               // movdqu       %xmm0, (%rax,%rcx)
 	LONG $0x00c18148; WORD $0x0001; BYTE $0x00 // addq         $256, %rcx
 	LONG $0x08c38348                           // addq         $8, %rbx
-	LONG $0xff7b850f; WORD $0xffff             // jne          LBB28_143, $-133(%rip)
+	LONG $0xff7b850f; WORD $0xffff             // jne          LBB30_143, $-133(%rip)
 
-LBB28_144:
+LBB30_144:
 	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x003a840f; WORD $0x0000 // je           LBB28_147, $58(%rip)
+	LONG $0x003a840f; WORD $0x0000 // je           LBB30_147, $58(%rip)
 	WORD $0x014c; BYTE $0xd1       // addq         %r10, %rcx
 	WORD $0x014c; BYTE $0xc1       // addq         %r8, %rcx
 	LONG $0x29048d4a               // leaq         (%rcx,%r13), %rax
 	LONG $0x10c08348               // addq         $16, %rax
 	LONG $0x05e3c149               // shlq         $5, %r11
 	WORD $0xc931                   // xorl         %ecx, %ecx
-	QUAD $0xfffff786056f0f66       // movdqa       $-2170(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff786056f0f66       // movdqa       $-2170(%rip), %xmm0  /* LCPI30_0(%rip) */
 	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_146:
+LBB30_146:
 	LONG $0x447f0ff3; WORD $0xf008 // movdqu       %xmm0, $-16(%rax,%rcx)
 	LONG $0x047f0ff3; BYTE $0x08   // movdqu       %xmm0, (%rax,%rcx)
 	LONG $0x20c18348               // addq         $32, %rcx
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0xffe8850f; WORD $0xffff // jne          LBB28_146, $-24(%rip)
+	LONG $0xffe8850f; WORD $0xffff // jne          LBB30_146, $-24(%rip)
 
-LBB28_147:
+LBB30_147:
 	WORD $0x394d; BYTE $0xce       // cmpq         %r9, %r14
-	LONG $0x008f840f; WORD $0x0000 // je           LBB28_151, $143(%rip)
+	LONG $0x008f840f; WORD $0x0000 // je           LBB30_151, $143(%rip)
 	LONG $0x18c6f641               // testb        $24, %r14b
-	LONG $0x006b840f; WORD $0x0000 // je           LBB28_149, $107(%rip)
+	LONG $0x006b840f; WORD $0x0000 // je           LBB30_149, $107(%rip)
 
-LBB28_137:
+LBB30_137:
 	WORD $0x894d; BYTE $0xf3               // movq         %r14, %r11
 	LONG $0xf8e38349                       // andq         $-8, %r11
 	WORD $0x014c; BYTE $0xda               // addq         %r11, %rdx
@@ -7849,42 +9098,42 @@ LBB28_137:
 	QUAD $0x303030303030b848; WORD $0x3030 // movabsq      $3472328296227680304, %rax
 
 	// .p2align 4, 0x90
-LBB28_138:
+LBB30_138:
 	LONG $0x1a048949               // movq         %rax, (%r10,%rbx)
 	LONG $0x08c38348               // addq         $8, %rbx
 	WORD $0x3948; BYTE $0xd9       // cmpq         %rbx, %rcx
-	LONG $0xffef850f; WORD $0xffff // jne          LBB28_138, $-17(%rip)
+	LONG $0xffef850f; WORD $0xffff // jne          LBB30_138, $-17(%rip)
 	WORD $0x394d; BYTE $0xde       // cmpq         %r11, %r14
-	LONG $0x0036850f; WORD $0x0000 // jne          LBB28_150, $54(%rip)
-	LONG $0x000041e9; BYTE $0x00   // jmp          LBB28_151, $65(%rip)
+	LONG $0x0036850f; WORD $0x0000 // jne          LBB30_150, $54(%rip)
+	LONG $0x000041e9; BYTE $0x00   // jmp          LBB30_151, $65(%rip)
 
-LBB28_23:
+LBB30_23:
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
 	WORD $0x894c; BYTE $0xc9                   // movq         %r9, %rcx
 	LONG $0x00d98348                           // sbbq         $0, %rcx
 	LONG $0x05c18348                           // addq         $5, %rcx
 	LONG $0x10fb8141; WORD $0x0027; BYTE $0x00 // cmpl         $10000, %r11d
-	LONG $0xfaf4830f; WORD $0xffff             // jae          LBB28_17, $-1292(%rip)
+	LONG $0xfaf4830f; WORD $0xffff             // jae          LBB30_17, $-1292(%rip)
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
-	LONG $0xfffcb2e9; BYTE $0xff               // jmp          LBB28_25, $-846(%rip)
+	LONG $0xfffcb2e9; BYTE $0xff               // jmp          LBB30_25, $-846(%rip)
 
-LBB28_149:
+LBB30_149:
 	WORD $0x014c; BYTE $0xca                   // addq         %r9, %rdx
 	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_150:
+LBB30_150:
 	WORD $0x02c6; BYTE $0x30       // movb         $48, (%rdx)
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0x394c; BYTE $0xe2       // cmpq         %r12, %rdx
-	LONG $0xfff0820f; WORD $0xffff // jb           LBB28_150, $-16(%rip)
+	LONG $0xfff0820f; WORD $0xffff // jb           LBB30_150, $-16(%rip)
 
-LBB28_151:
+LBB30_151:
 	WORD $0x894c; BYTE $0xe0 // movq         %r12, %rax
 
-LBB28_152:
+LBB30_152:
 	WORD $0x2944; BYTE $0xe8 // subl         %r13d, %eax
 
-LBB28_153:
+LBB30_153:
 	LONG $0x10c48348 // addq         $16, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -7894,16 +9143,16 @@ LBB28_153:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB28_76:
+LBB30_76:
 	LONG $0xd0558b48                           // movq         $-48(%rbp), %rdx
 	LONG $0x121c8d49                           // leaq         (%r10,%rdx), %rbx
 	LONG $0xf2c38148; WORD $0x0000; BYTE $0x00 // addq         $242, %rbx
 	LONG $0xf8e48349                           // andq         $-8, %r12
 	WORD $0xf749; BYTE $0xdc                   // negq         %r12
 	WORD $0xd231                               // xorl         %edx, %edx
-	QUAD $0xfffff69b056f0f66                   // movdqa       $-2405(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff69b056f0f66                   // movdqa       $-2405(%rip), %xmm0  /* LCPI30_0(%rip) */
 
-LBB28_77:
+LBB30_77:
 	QUAD $0xffff1013847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-240(%rbx,%rdx)
 	QUAD $0xffff2013847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-224(%rbx,%rdx)
 	QUAD $0xffff3013847f0ff3; BYTE $0xff       // movdqu       %xmm0, $-208(%rbx,%rdx)
@@ -7922,92 +9171,92 @@ LBB28_77:
 	LONG $0x047f0ff3; BYTE $0x13               // movdqu       %xmm0, (%rbx,%rdx)
 	LONG $0x00c28148; WORD $0x0001; BYTE $0x00 // addq         $256, %rdx
 	LONG $0x08c48349                           // addq         $8, %r12
-	LONG $0xff7b850f; WORD $0xffff             // jne          LBB28_77, $-133(%rip)
+	LONG $0xff7b850f; WORD $0xffff             // jne          LBB30_77, $-133(%rip)
 
-LBB28_78:
+LBB30_78:
 	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
-	LONG $0x0034840f; WORD $0x0000 // je           LBB28_81, $52(%rip)
+	LONG $0x0034840f; WORD $0x0000 // je           LBB30_81, $52(%rip)
 	WORD $0x014c; BYTE $0xd2       // addq         %r10, %rdx
 	LONG $0xd0758b48               // movq         $-48(%rbp), %rsi
 	WORD $0x0148; BYTE $0xf2       // addq         %rsi, %rdx
 	LONG $0x12c28348               // addq         $18, %rdx
 	LONG $0x05e7c149               // shlq         $5, %r15
 	WORD $0xf631                   // xorl         %esi, %esi
-	QUAD $0xfffff5f1056f0f66       // movdqa       $-2575(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff5f1056f0f66       // movdqa       $-2575(%rip), %xmm0  /* LCPI30_0(%rip) */
 
-LBB28_80:
+LBB30_80:
 	LONG $0x447f0ff3; WORD $0xf032 // movdqu       %xmm0, $-16(%rdx,%rsi)
 	LONG $0x047f0ff3; BYTE $0x32   // movdqu       %xmm0, (%rdx,%rsi)
 	LONG $0x20c68348               // addq         $32, %rsi
 	WORD $0x3949; BYTE $0xf7       // cmpq         %rsi, %r15
-	LONG $0xffe8850f; WORD $0xffff // jne          LBB28_80, $-24(%rip)
+	LONG $0xffe8850f; WORD $0xffff // jne          LBB30_80, $-24(%rip)
 
-LBB28_81:
+LBB30_81:
 	WORD $0x8949; BYTE $0xfc       // movq         %rdi, %r12
 	WORD $0x0149; BYTE $0xcc       // addq         %rcx, %r12
 	WORD $0x3949; BYTE $0xcb       // cmpq         %rcx, %r11
-	LONG $0x001c840f; WORD $0x0000 // je           LBB28_84, $28(%rip)
+	LONG $0x001c840f; WORD $0x0000 // je           LBB30_84, $28(%rip)
 
-LBB28_82:
+LBB30_82:
 	WORD $0x0144; BYTE $0xc9     // addl         %r9d, %ecx
 	WORD $0xd9f7                 // negl         %ecx
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_83:
+LBB30_83:
 	LONG $0x2404c641; BYTE $0x30   // movb         $48, (%r12)
 	LONG $0x01c48349               // addq         $1, %r12
 	WORD $0xc183; BYTE $0xff       // addl         $-1, %ecx
-	LONG $0xffee850f; WORD $0xffff // jne          LBB28_83, $-18(%rip)
+	LONG $0xffee850f; WORD $0xffff // jne          LBB30_83, $-18(%rip)
 
-LBB28_84:
+LBB30_84:
 	LONG $0x043c8d4f                           // leaq         (%r12,%r8), %r15
 	LONG $0x0027103d; BYTE $0x00               // cmpl         $10000, %eax
-	LONG $0x0050820f; WORD $0x0000             // jb           LBB28_85, $80(%rip)
+	LONG $0x0050820f; WORD $0x0000             // jb           LBB30_85, $80(%rip)
 	WORD $0xc289                               // movl         %eax, %edx
 	LONG $0xb71759bb; BYTE $0xd1               // movl         $3518437209, %ebx
 	LONG $0xdaaf0f48                           // imulq        %rdx, %rbx
 	LONG $0x2debc148                           // shrq         $45, %rbx
 	LONG $0xd8f0d369; WORD $0xffff             // imull        $-10000, %ebx, %edx
 	WORD $0xc201                               // addl         %eax, %edx
-	LONG $0x004b840f; WORD $0x0000             // je           LBB28_87, $75(%rip)
+	LONG $0x004b840f; WORD $0x0000             // je           LBB30_87, $75(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
 	WORD $0xf06b; BYTE $0x64                   // imull        $100, %eax, %esi
 	WORD $0xf229                               // subl         %esi, %edx
-	LONG $0x49358d48; WORD $0x0035; BYTE $0x00 // leaq         $13641(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x19358d48; WORD $0x0039; BYTE $0x00 // leaq         $14617(%rip), %rsi  /* _Digits(%rip) */
 	LONG $0x5614b70f                           // movzwl       (%rsi,%rdx,2), %edx
 	LONG $0x57894166; BYTE $0xfe               // movw         %dx, $-2(%r15)
 	LONG $0x4604b70f                           // movzwl       (%rsi,%rax,2), %eax
 	LONG $0x47894166; BYTE $0xfc               // movw         %ax, $-4(%r15)
 	WORD $0x3145; BYTE $0xdb                   // xorl         %r11d, %r11d
-	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB28_89, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00               // jmp          LBB30_89, $30(%rip)
 
-LBB28_85:
+LBB30_85:
 	WORD $0x3145; BYTE $0xdb       // xorl         %r11d, %r11d
 	WORD $0x894c; BYTE $0xfa       // movq         %r15, %rdx
 	WORD $0xc389                   // movl         %eax, %ebx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0x001a830f; WORD $0x0000 // jae          LBB28_92, $26(%rip)
+	LONG $0x001a830f; WORD $0x0000 // jae          LBB30_92, $26(%rip)
 
-LBB28_91:
+LBB30_91:
 	WORD $0xd889                 // movl         %ebx, %eax
-	LONG $0x000055e9; BYTE $0x00 // jmp          LBB28_94, $85(%rip)
+	LONG $0x000055e9; BYTE $0x00 // jmp          LBB30_94, $85(%rip)
 
-LBB28_87:
+LBB30_87:
 	LONG $0x0004bb41; WORD $0x0000 // movl         $4, %r11d
 
-LBB28_89:
+LBB30_89:
 	LONG $0xfc578d49               // leaq         $-4(%r15), %rdx
 	WORD $0xfb83; BYTE $0x64       // cmpl         $100, %ebx
-	LONG $0xffe6820f; WORD $0xffff // jb           LBB28_91, $-26(%rip)
+	LONG $0xffe6820f; WORD $0xffff // jb           LBB30_91, $-26(%rip)
 
-LBB28_92:
+LBB30_92:
 	LONG $0xffc28348                           // addq         $-1, %rdx
-	LONG $0xf9358d48; WORD $0x0034; BYTE $0x00 // leaq         $13561(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0xc9358d48; WORD $0x0038; BYTE $0x00 // leaq         $14537(%rip), %rsi  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB28_93:
+LBB30_93:
 	WORD $0xd889                               // movl         %ebx, %eax
 	LONG $0x1fc06948; WORD $0xeb85; BYTE $0x51 // imulq        $1374389535, %rax, %rax
 	LONG $0x25e8c148                           // shrq         $37, %rax
@@ -8019,24 +9268,24 @@ LBB28_93:
 	LONG $0xfec28348                           // addq         $-2, %rdx
 	LONG $0x270ffb81; WORD $0x0000             // cmpl         $9999, %ebx
 	WORD $0xc389                               // movl         %eax, %ebx
-	LONG $0xffd2870f; WORD $0xffff             // ja           LBB28_93, $-46(%rip)
+	LONG $0xffd2870f; WORD $0xffff             // ja           LBB30_93, $-46(%rip)
 
-LBB28_94:
+LBB30_94:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
-	LONG $0x001a820f; WORD $0x0000             // jb           LBB28_96, $26(%rip)
+	LONG $0x001a820f; WORD $0x0000             // jb           LBB30_96, $26(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xb00d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13488(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x800d8d48; WORD $0x0038; BYTE $0x00 // leaq         $14464(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	WORD $0x894d; BYTE $0xe2                   // movq         %r12, %r10
 	LONG $0x04894166; BYTE $0x24               // movw         %ax, (%r12)
-	LONG $0x000009e9; BYTE $0x00               // jmp          LBB28_97, $9(%rip)
+	LONG $0x000009e9; BYTE $0x00               // jmp          LBB30_97, $9(%rip)
 
-LBB28_96:
+LBB30_96:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x894d; BYTE $0xe2 // movq         %r12, %r10
 	LONG $0x24048841         // movb         %al, (%r12)
 
-LBB28_97:
+LBB30_97:
 	WORD $0x294d; BYTE $0xdf     // subq         %r11, %r15
 	WORD $0x294d; BYTE $0xd8     // subq         %r11, %r8
 	LONG $0x01c08349             // addq         $1, %r8
@@ -8054,51 +9303,51 @@ LBB28_97:
 	WORD $0x8944; BYTE $0xe6     // movl         %r12d, %esi
 	LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_98:
+LBB30_98:
 	WORD $0xc180; BYTE $0x03       // addb         $3, %cl
 	WORD $0xc683; BYTE $0x01       // addl         $1, %esi
 	LONG $0x1f7c8041; WORD $0x30ff // cmpb         $48, $-1(%r15,%rbx)
 	LONG $0xff5b8d48               // leaq         $-1(%rbx), %rbx
-	LONG $0xffea840f; WORD $0xffff // je           LBB28_98, $-22(%rip)
+	LONG $0xffea840f; WORD $0xffff // je           LBB30_98, $-22(%rip)
 	LONG $0x1f048d49               // leaq         (%r15,%rbx), %rax
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0x8545; BYTE $0xc9       // testl        %r9d, %r9d
-	LONG $0x00458e0f; WORD $0x0000 // jle          LBB28_100, $69(%rip)
+	LONG $0x00458e0f; WORD $0x0000 // jle          LBB30_100, $69(%rip)
 	WORD $0x2945; BYTE $0xdd       // subl         %r11d, %r13d
 	LONG $0x2b3c8d42               // leal         (%rbx,%r13), %edi
 	WORD $0xc783; BYTE $0x01       // addl         $1, %edi
 	WORD $0x3941; BYTE $0xf9       // cmpl         %edi, %r9d
-	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB28_102, $59(%rip)
+	LONG $0x003b8d0f; WORD $0x0000 // jge          LBB30_102, $59(%rip)
 	WORD $0xc283; BYTE $0xff       // addl         $-1, %edx
 	WORD $0x6348; BYTE $0xc2       // movslq       %edx, %rax
 	LONG $0x18348d48               // leaq         (%rax,%rbx), %rsi
 	LONG $0x01c68348               // addq         $1, %rsi
 	WORD $0xf685                   // testl        %esi, %esi
 	LONG $0xd06d8b4c               // movq         $-48(%rbp), %r13
-	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB28_120, $245(%rip)
+	LONG $0x00f58e0f; WORD $0x0000 // jle          LBB30_120, $245(%rip)
 	WORD $0x8941; BYTE $0xf0       // movl         %esi, %r8d
 	LONG $0xff508d49               // leaq         $-1(%r8), %rdx
 	LONG $0x03fa8348               // cmpq         $3, %rdx
-	LONG $0x007b830f; WORD $0x0000 // jae          LBB28_121, $123(%rip)
+	LONG $0x007b830f; WORD $0x0000 // jae          LBB30_121, $123(%rip)
 	WORD $0xd231                   // xorl         %edx, %edx
-	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB28_117, $160(%rip)
+	LONG $0x0000a0e9; BYTE $0x00   // jmp          LBB30_117, $160(%rip)
 
-LBB28_100:
+LBB30_100:
 	LONG $0xd06d8b4c             // movq         $-48(%rbp), %r13
-	LONG $0xfffd3ee9; BYTE $0xff // jmp          LBB28_152, $-706(%rip)
+	LONG $0xfffd3ee9; BYTE $0xff // jmp          LBB30_152, $-706(%rip)
 
-LBB28_102:
+LBB30_102:
 	WORD $0x8945; BYTE $0xf6                   // movl         %r14d, %r14d
 	WORD $0x2949; BYTE $0xde                   // subq         %rbx, %r14
 	WORD $0x8545; BYTE $0xf6                   // testl        %r14d, %r14d
 	LONG $0xd06d8b4c                           // movq         $-48(%rbp), %r13
-	LONG $0xfd2b8e0f; WORD $0xffff             // jle          LBB28_152, $-725(%rip)
+	LONG $0xfd2b8e0f; WORD $0xffff             // jle          LBB30_152, $-725(%rip)
 	WORD $0x8945; BYTE $0xe3                   // movl         %r12d, %r11d
 	WORD $0x894c; BYTE $0xd9                   // movq         %r11, %rcx
 	WORD $0x2948; BYTE $0xd9                   // subq         %rbx, %rcx
 	WORD $0xd231                               // xorl         %edx, %edx
 	WORD $0xf983; BYTE $0x1f                   // cmpl         $31, %ecx
-	LONG $0x01e4820f; WORD $0x0000             // jb           LBB28_112, $484(%rip)
+	LONG $0x01e4820f; WORD $0x0000             // jb           LBB30_112, $484(%rip)
 	WORD $0x2949; BYTE $0xdb                   // subq         %rbx, %r11
 	WORD $0x8941; BYTE $0xc9                   // movl         %ecx, %r9d
 	LONG $0x01c18349                           // addq         $1, %r9
@@ -8114,28 +9363,28 @@ LBB28_102:
 	LONG $0x05e8c149                           // shrq         $5, %r8
 	LONG $0x01c08349                           // addq         $1, %r8
 	LONG $0xe0f98148; WORD $0x0000; BYTE $0x00 // cmpq         $224, %rcx
-	LONG $0x0085830f; WORD $0x0000             // jae          LBB28_106, $133(%rip)
+	LONG $0x0085830f; WORD $0x0000             // jae          LBB30_106, $133(%rip)
 	WORD $0xc931                               // xorl         %ecx, %ecx
-	LONG $0x000133e9; BYTE $0x00               // jmp          LBB28_108, $307(%rip)
+	LONG $0x000133e9; BYTE $0x00               // jmp          LBB30_108, $307(%rip)
 
-LBB28_121:
+LBB30_121:
 	WORD $0xe683; BYTE $0xfc // andl         $-4, %esi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xd231             // xorl         %edx, %edx
 	QUAD $0x9090909090909090 // .p2align 4, 0x90
 
-LBB28_122:
+LBB30_122:
 	LONG $0x173c8d49               // leaq         (%r15,%rdx), %rdi
 	LONG $0xfd3b448b               // movl         $-3(%rbx,%rdi), %eax
 	LONG $0xfe3b4489               // movl         %eax, $-2(%rbx,%rdi)
 	LONG $0xfcc28348               // addq         $-4, %rdx
 	WORD $0x3948; BYTE $0xd6       // cmpq         %rdx, %rsi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_122, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_122, $-25(%rip)
 	WORD $0xf748; BYTE $0xda       // negq         %rdx
 
-LBB28_117:
+LBB30_117:
 	LONG $0x03c0f641                     // testb        $3, %r8b
-	LONG $0x0033840f; WORD $0x0000       // je           LBB28_120, $51(%rip)
+	LONG $0x0033840f; WORD $0x0000       // je           LBB30_120, $51(%rip)
 	WORD $0xb60f; BYTE $0xf9             // movzbl       %cl, %edi
 	WORD $0xe783; BYTE $0x03             // andl         $3, %edi
 	WORD $0xf748; BYTE $0xdf             // negq         %rdi
@@ -8144,22 +9393,22 @@ LBB28_117:
 	WORD $0xd231                         // xorl         %edx, %edx
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB28_119:
+LBB30_119:
 	LONG $0x11348d48               // leaq         (%rcx,%rdx), %rsi
 	LONG $0x3304b60f               // movzbl       (%rbx,%rsi), %eax
 	LONG $0x01334488               // movb         %al, $1(%rbx,%rsi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0x3948; BYTE $0xd7       // cmpq         %rdx, %rdi
-	LONG $0xffe7850f; WORD $0xffff // jne          LBB28_119, $-25(%rip)
+	LONG $0xffe7850f; WORD $0xffff // jne          LBB30_119, $-25(%rip)
 
-LBB28_120:
+LBB30_120:
 	WORD $0x6349; BYTE $0xc1     // movslq       %r9d, %rax
 	LONG $0x0204c641; BYTE $0x2e // movb         $46, (%r10,%rax)
 	LONG $0x1f048d49             // leaq         (%r15,%rbx), %rax
 	LONG $0x02c08348             // addq         $2, %rax
-	LONG $0xfffc55e9; BYTE $0xff // jmp          LBB28_152, $-939(%rip)
+	LONG $0xfffc55e9; BYTE $0xff // jmp          LBB30_152, $-939(%rip)
 
-LBB28_106:
+LBB30_106:
 	WORD $0x8944; BYTE $0xde // movl         %r11d, %esi
 	LONG $0x01c68348         // addq         $1, %rsi
 	LONG $0xe0e68348         // andq         $-32, %rsi
@@ -8169,9 +9418,9 @@ LBB28_106:
 	LONG $0xf8e68348         // andq         $-8, %rsi
 	WORD $0xf748; BYTE $0xde // negq         %rsi
 	WORD $0xc931             // xorl         %ecx, %ecx
-	QUAD $0xfffff2fa056f0f66 // movdqa       $-3334(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff2fa056f0f66 // movdqa       $-3334(%rip), %xmm0  /* LCPI30_0(%rip) */
 
-LBB28_107:
+LBB30_107:
 	LONG $0x0f3c8d49                           // leaq         (%r15,%rcx), %rdi
 	LONG $0x447f0ff3; WORD $0x013b             // movdqu       %xmm0, $1(%rbx,%rdi)
 	LONG $0x447f0ff3; WORD $0x113b             // movdqu       %xmm0, $17(%rbx,%rdi)
@@ -8191,12 +9440,12 @@ LBB28_107:
 	QUAD $0x0000f13b847f0ff3; BYTE $0x00       // movdqu       %xmm0, $241(%rbx,%rdi)
 	LONG $0x00c18148; WORD $0x0001; BYTE $0x00 // addq         $256, %rcx
 	LONG $0x08c68348                           // addq         $8, %rsi
-	LONG $0xff73850f; WORD $0xffff             // jne          LBB28_107, $-141(%rip)
+	LONG $0xff73850f; WORD $0xffff             // jne          LBB30_107, $-141(%rip)
 
-LBB28_108:
+LBB30_108:
 	WORD $0x0148; BYTE $0xd8       // addq         %rbx, %rax
 	LONG $0x07c0f641               // testb        $7, %r8b
-	LONG $0x004d840f; WORD $0x0000 // je           LBB28_111, $77(%rip)
+	LONG $0x004d840f; WORD $0x0000 // je           LBB30_111, $77(%rip)
 	LONG $0x01c38041               // addb         $1, %r11b
 	LONG $0xe0e38041               // andb         $-32, %r11b
 	LONG $0xe0c38041               // addb         $-32, %r11b
@@ -8208,39 +9457,39 @@ LBB28_108:
 	WORD $0x014c; BYTE $0xf9       // addq         %r15, %rcx
 	LONG $0x11c18348               // addq         $17, %rcx
 	WORD $0xf631                   // xorl         %esi, %esi
-	QUAD $0xfffff22f056f0f66       // movdqa       $-3537(%rip), %xmm0  /* LCPI28_0(%rip) */
+	QUAD $0xfffff22f056f0f66       // movdqa       $-3537(%rip), %xmm0  /* LCPI30_0(%rip) */
 
-LBB28_110:
+LBB30_110:
 	LONG $0x313c8d48               // leaq         (%rcx,%rsi), %rdi
 	LONG $0x447f0ff3; WORD $0xf03b // movdqu       %xmm0, $-16(%rbx,%rdi)
 	LONG $0x047f0ff3; BYTE $0x3b   // movdqu       %xmm0, (%rbx,%rdi)
 	LONG $0x20c68348               // addq         $32, %rsi
 	WORD $0x3949; BYTE $0xf0       // cmpq         %rsi, %r8
-	LONG $0xffe4850f; WORD $0xffff // jne          LBB28_110, $-28(%rip)
+	LONG $0xffe4850f; WORD $0xffff // jne          LBB30_110, $-28(%rip)
 
-LBB28_111:
+LBB30_111:
 	WORD $0x3949; BYTE $0xd1               // cmpq         %rdx, %r9
-	LONG $0xfb3d840f; WORD $0xffff         // je           LBB28_152, $-1219(%rip)
+	LONG $0xfb3d840f; WORD $0xffff         // je           LBB30_152, $-1219(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
-LBB28_112:
+LBB30_112:
 	WORD $0x00c6; BYTE $0x30       // movb         $48, (%rax)
 	LONG $0x01c08348               // addq         $1, %rax
 	WORD $0xc283; BYTE $0x01       // addl         $1, %edx
 	WORD $0x3944; BYTE $0xf2       // cmpl         %r14d, %edx
-	LONG $0xffed8c0f; WORD $0xffff // jl           LBB28_112, $-19(%rip)
-	LONG $0xfffb1be9; BYTE $0xff   // jmp          LBB28_152, $-1253(%rip)
+	LONG $0xffed8c0f; WORD $0xffff // jl           LBB30_112, $-19(%rip)
+	LONG $0xfffb1be9; BYTE $0xff   // jmp          LBB30_152, $-1253(%rip)
 
-LBB28_1:
+LBB30_1:
 	WORD $0xc031                 // xorl         %eax, %eax
-	LONG $0xfffb17e9; BYTE $0xff // jmp          LBB28_153, $-1257(%rip)
+	LONG $0xfffb17e9; BYTE $0xff // jmp          LBB30_153, $-1257(%rip)
 
-LBB28_5:
+LBB30_5:
 	LONG $0xc84d894c                                   // movq         %r9, $-56(%rbp)
 	LONG $0xd07d8948                                   // movq         %rdi, $-48(%rbp)
 	LONG $0xff6bb841; WORD $0xffff                     // movl         $-149, %r8d
 	WORD $0x8941; BYTE $0xc3                           // movl         %eax, %r11d
-	LONG $0xfff268e9; BYTE $0xff                       // jmp          LBB28_6, $-3480(%rip)
+	LONG $0xfff268e9; BYTE $0xff                       // jmp          LBB30_6, $-3480(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 _format_significand:
@@ -8252,25 +9501,25 @@ _format_significand:
 	WORD $0x0149; BYTE $0xf0       // addq         %rsi, %r8
 	WORD $0x8948; BYTE $0xf8       // movq         %rdi, %rax
 	LONG $0x20e8c148               // shrq         $32, %rax
-	LONG $0x001c850f; WORD $0x0000 // jne          LBB29_2, $28(%rip)
+	LONG $0x001c850f; WORD $0x0000 // jne          LBB31_2, $28(%rip)
 	WORD $0x3145; BYTE $0xc9       // xorl         %r9d, %r9d
 	WORD $0x894d; BYTE $0xc6       // movq         %r8, %r14
 	WORD $0x8948; BYTE $0xfa       // movq         %rdi, %rdx
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0x00e3830f; WORD $0x0000 // jae          LBB29_8, $227(%rip)
+	LONG $0x00e3830f; WORD $0x0000 // jae          LBB31_8, $227(%rip)
 
-LBB29_7:
+LBB31_7:
 	WORD $0xd789                 // movl         %edx, %edi
-	LONG $0x000132e9; BYTE $0x00 // jmp          LBB29_10, $306(%rip)
+	LONG $0x000132e9; BYTE $0x00 // jmp          LBB31_10, $306(%rip)
 
-LBB29_2:
+LBB31_2:
 	QUAD $0x77118461cefdb948; WORD $0xabcc     // movabsq      $-6067343680855748867, %rcx
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	WORD $0xf748; BYTE $0xe1                   // mulq         %rcx
 	LONG $0x1aeac148                           // shrq         $26, %rdx
 	LONG $0x1f00ca69; WORD $0xfa0a             // imull        $-100000000, %edx, %ecx
 	WORD $0xf901                               // addl         %edi, %ecx
-	LONG $0x00a4840f; WORD $0x0000             // je           LBB29_3, $164(%rip)
+	LONG $0x00a4840f; WORD $0x0000             // je           LBB31_3, $164(%rip)
 	WORD $0xc889                               // movl         %ecx, %eax
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
 	LONG $0xc1af0f49                           // imulq        %r9, %rax
@@ -8296,7 +9545,7 @@ LBB29_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0xe30d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12515(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb30d8d48; WORD $0x0034; BYTE $0x00 // leaq         $13491(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -8308,21 +9557,21 @@ LBB29_2:
 	WORD $0x3145; BYTE $0xc9                   // xorl         %r9d, %r9d
 	LONG $0xf8708d4d                           // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000             // cmpl         $10000, %edx
-	LONG $0xff38820f; WORD $0xffff             // jb           LBB29_7, $-200(%rip)
-	LONG $0x000016e9; BYTE $0x00               // jmp          LBB29_8, $22(%rip)
+	LONG $0xff38820f; WORD $0xffff             // jb           LBB31_7, $-200(%rip)
+	LONG $0x000016e9; BYTE $0x00               // jmp          LBB31_8, $22(%rip)
 
-LBB29_3:
+LBB31_3:
 	LONG $0x0008b941; WORD $0x0000 // movl         $8, %r9d
 	LONG $0xf8708d4d               // leaq         $-8(%r8), %r14
 	LONG $0x2710fa81; WORD $0x0000 // cmpl         $10000, %edx
-	LONG $0xff1d820f; WORD $0xffff // jb           LBB29_7, $-227(%rip)
+	LONG $0xff1d820f; WORD $0xffff // jb           LBB31_7, $-227(%rip)
 
-LBB29_8:
+LBB31_8:
 	LONG $0x1759ba41; WORD $0xd1b7             // movl         $3518437209, %r10d
-	LONG $0x811d8d4c; WORD $0x0030; BYTE $0x00 // leaq         $12417(%rip), %r11  /* _Digits(%rip) */
+	LONG $0x511d8d4c; WORD $0x0034; BYTE $0x00 // leaq         $13393(%rip), %r11  /* _Digits(%rip) */
 	BYTE $0x90                                 // .p2align 4, 0x90
 
-LBB29_9:
+LBB31_9:
 	WORD $0xd789                               // movl         %edx, %edi
 	LONG $0xfaaf0f49                           // imulq        %r10, %rdi
 	LONG $0x2defc148                           // shrq         $45, %rdi
@@ -8339,22 +9588,22 @@ LBB29_9:
 	LONG $0xfcc68349                           // addq         $-4, %r14
 	LONG $0xe0fffa81; WORD $0x05f5             // cmpl         $99999999, %edx
 	WORD $0xfa89                               // movl         %edi, %edx
-	LONG $0xffb8870f; WORD $0xffff             // ja           LBB29_9, $-72(%rip)
+	LONG $0xffb8870f; WORD $0xffff             // ja           LBB31_9, $-72(%rip)
 
-LBB29_10:
+LBB31_10:
 	WORD $0xff83; BYTE $0x64       // cmpl         $100, %edi
-	LONG $0x0020830f; WORD $0x0000 // jae          LBB29_11, $32(%rip)
+	LONG $0x0020830f; WORD $0x0000 // jae          LBB31_11, $32(%rip)
 	WORD $0xff83; BYTE $0x0a       // cmpl         $10, %edi
-	LONG $0x004d820f; WORD $0x0000 // jb           LBB29_14, $77(%rip)
+	LONG $0x004d820f; WORD $0x0000 // jb           LBB31_14, $77(%rip)
 
-LBB29_13:
+LBB31_13:
 	WORD $0xf889                               // movl         %edi, %eax
-	LONG $0x1d0d8d48; WORD $0x0030; BYTE $0x00 // leaq         $12317(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xed0d8d48; WORD $0x0033; BYTE $0x00 // leaq         $13293(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x46894166; BYTE $0xfe               // movw         %ax, $-2(%r14)
-	LONG $0x00003de9; BYTE $0x00               // jmp          LBB29_15, $61(%rip)
+	LONG $0x00003de9; BYTE $0x00               // jmp          LBB31_15, $61(%rip)
 
-LBB29_11:
+LBB31_11:
 	WORD $0xb70f; BYTE $0xc7                   // movzwl       %di, %eax
 	WORD $0xe8c1; BYTE $0x02                   // shrl         $2, %eax
 	LONG $0x147bc069; WORD $0x0000             // imull        $5243, %eax, %eax
@@ -8362,19 +9611,19 @@ LBB29_11:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xcf29                               // subl         %ecx, %edi
 	WORD $0xb70f; BYTE $0xcf                   // movzwl       %di, %ecx
-	LONG $0xf1158d48; WORD $0x002f; BYTE $0x00 // leaq         $12273(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xc1158d48; WORD $0x0033; BYTE $0x00 // leaq         $13249(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4e894166; BYTE $0xfe               // movw         %cx, $-2(%r14)
 	LONG $0xfec68349                           // addq         $-2, %r14
 	WORD $0xc789                               // movl         %eax, %edi
 	WORD $0xff83; BYTE $0x0a                   // cmpl         $10, %edi
-	LONG $0xffb3830f; WORD $0xffff             // jae          LBB29_13, $-77(%rip)
+	LONG $0xffb3830f; WORD $0xffff             // jae          LBB31_13, $-77(%rip)
 
-LBB29_14:
+LBB31_14:
 	LONG $0x30c78040         // addb         $48, %dil
 	WORD $0x8840; BYTE $0x3e // movb         %dil, (%rsi)
 
-LBB29_15:
+LBB31_15:
 	WORD $0x294d; BYTE $0xc8                   // subq         %r9, %r8
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
 	BYTE $0x5b                                 // popq         %rbx
@@ -8391,45 +9640,45 @@ _left_shift:
 	BYTE $0x53                                 // pushq        %rbx
 	WORD $0xf189                               // movl         %esi, %ecx
 	LONG $0x68f16b4c                           // imulq        $104, %rcx, %r14
-	LONG $0x9a158d48; WORD $0x0089; BYTE $0x00 // leaq         $35226(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
+	LONG $0x6a158d48; WORD $0x008d; BYTE $0x00 // leaq         $36202(%rip), %rdx  /* _LSHIFT_TAB(%rip) */
 	LONG $0x16048b45                           // movl         (%r14,%rdx), %r8d
 	WORD $0x8b4c; BYTE $0x1f                   // movq         (%rdi), %r11
 	LONG $0x104f634c                           // movslq       $16(%rdi), %r9
 	WORD $0x8945; BYTE $0xca                   // movl         %r9d, %r10d
 	WORD $0x854d; BYTE $0xc9                   // testq        %r9, %r9
-	LONG $0x004c840f; WORD $0x0000             // je           LBB30_1, $76(%rip)
+	LONG $0x004c840f; WORD $0x0000             // je           LBB32_1, $76(%rip)
 	LONG $0x16348d49                           // leaq         (%r14,%rdx), %rsi
 	LONG $0x04c68348                           // addq         $4, %rsi
 	WORD $0xdb31                               // xorl         %ebx, %ebx
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
-LBB30_3:
+LBB32_3:
 	LONG $0x1e04b60f               // movzbl       (%rsi,%rbx), %eax
 	WORD $0xc084                   // testb        %al, %al
-	LONG $0x0041840f; WORD $0x0000 // je           LBB30_10, $65(%rip)
+	LONG $0x0041840f; WORD $0x0000 // je           LBB32_10, $65(%rip)
 	LONG $0x1b043841               // cmpb         %al, (%r11,%rbx)
-	LONG $0x01ba850f; WORD $0x0000 // jne          LBB30_5, $442(%rip)
+	LONG $0x01ba850f; WORD $0x0000 // jne          LBB32_5, $442(%rip)
 	LONG $0x01c38348               // addq         $1, %rbx
 	WORD $0x3949; BYTE $0xd9       // cmpq         %rbx, %r9
-	LONG $0xffdd850f; WORD $0xffff // jne          LBB30_3, $-35(%rip)
+	LONG $0xffdd850f; WORD $0xffff // jne          LBB32_3, $-35(%rip)
 	WORD $0x8944; BYTE $0xce       // movl         %r9d, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0015850f; WORD $0x0000 // jne          LBB30_9, $21(%rip)
-	LONG $0x000014e9; BYTE $0x00   // jmp          LBB30_10, $20(%rip)
+	LONG $0x0015850f; WORD $0x0000 // jne          LBB32_9, $21(%rip)
+	LONG $0x000014e9; BYTE $0x00   // jmp          LBB32_10, $20(%rip)
 
-LBB30_1:
+LBB32_1:
 	WORD $0xf631                   // xorl         %esi, %esi
 	WORD $0x014c; BYTE $0xf2       // addq         %r14, %rdx
 	LONG $0x04167c80; BYTE $0x00   // cmpb         $0, $4(%rsi,%rdx)
-	LONG $0x0004840f; WORD $0x0000 // je           LBB30_10, $4(%rip)
+	LONG $0x0004840f; WORD $0x0000 // je           LBB32_10, $4(%rip)
 
-LBB30_9:
+LBB32_9:
 	LONG $0xffc08341 // addl         $-1, %r8d
 
-LBB30_10:
+LBB32_10:
 	WORD $0x8545; BYTE $0xd2                                             // testl        %r10d, %r10d
-	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB30_25, $162(%rip)
+	LONG $0x00a28e0f; WORD $0x0000                                       // jle          LBB32_25, $162(%rip)
 	LONG $0x10048d43                                                     // leal         (%r8,%r10), %eax
 	WORD $0x634c; BYTE $0xf8                                             // movslq       %eax, %r15
 	LONG $0xffc18341                                                     // addl         $-1, %r9d
@@ -8438,7 +9687,7 @@ LBB30_10:
 	QUAD $0xcccccccccccdbe49; WORD $0xcccc                               // movabsq      $-3689348814741910323, %r14
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB30_12:
+LBB32_12:
 	WORD $0x8944; BYTE $0xc8       // movl         %r9d, %eax
 	LONG $0x34be0f49; BYTE $0x03   // movsbq       (%r11,%rax), %rsi
 	LONG $0xd0c68348               // addq         $-48, %rsi
@@ -8452,93 +9701,93 @@ LBB30_12:
 	WORD $0x8948; BYTE $0xf0       // movq         %rsi, %rax
 	WORD $0x2948; BYTE $0xd8       // subq         %rbx, %rax
 	LONG $0x087f394c               // cmpq         %r15, $8(%rdi)
-	LONG $0x000c860f; WORD $0x0000 // jbe          LBB30_18, $12(%rip)
+	LONG $0x000c860f; WORD $0x0000 // jbe          LBB32_18, $12(%rip)
 	WORD $0x3004                   // addb         $48, %al
 	LONG $0x3b048843               // movb         %al, (%r11,%r15)
-	LONG $0x000011e9; BYTE $0x00   // jmp          LBB30_20, $17(%rip)
+	LONG $0x000011e9; BYTE $0x00   // jmp          LBB32_20, $17(%rip)
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_18:
+LBB32_18:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x0007840f; WORD $0x0000             // je           LBB30_20, $7(%rip)
+	LONG $0x0007840f; WORD $0x0000             // je           LBB32_20, $7(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
 
-LBB30_20:
+LBB32_20:
 	LONG $0x02fa8349               // cmpq         $2, %r10
-	LONG $0x00148c0f; WORD $0x0000 // jl           LBB30_14, $20(%rip)
+	LONG $0x00148c0f; WORD $0x0000 // jl           LBB32_14, $20(%rip)
 	LONG $0xffc28349               // addq         $-1, %r10
 	WORD $0x8b4c; BYTE $0x1f       // movq         (%rdi), %r11
 	LONG $0xffc18341               // addl         $-1, %r9d
 	LONG $0xffc78349               // addq         $-1, %r15
-	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB30_12, $-110(%rip)
+	LONG $0xffff92e9; BYTE $0xff   // jmp          LBB32_12, $-110(%rip)
 
-LBB30_14:
+LBB32_14:
 	LONG $0x0afe8348               // cmpq         $10, %rsi
-	LONG $0x0071830f; WORD $0x0000 // jae          LBB30_15, $113(%rip)
+	LONG $0x0071830f; WORD $0x0000 // jae          LBB32_15, $113(%rip)
 
-LBB30_25:
+LBB32_25:
 	LONG $0x104f6348               // movslq       $16(%rdi), %rcx
 	WORD $0x6349; BYTE $0xc0       // movslq       %r8d, %rax
 	WORD $0x0148; BYTE $0xc8       // addq         %rcx, %rax
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0x084f8b48               // movq         $8(%rdi), %rcx
 	WORD $0x3948; BYTE $0xc1       // cmpq         %rax, %rcx
-	LONG $0x0005870f; WORD $0x0000 // ja           LBB30_27, $5(%rip)
+	LONG $0x0005870f; WORD $0x0000 // ja           LBB32_27, $5(%rip)
 	WORD $0x4f89; BYTE $0x10       // movl         %ecx, $16(%rdi)
 	WORD $0xc889                   // movl         %ecx, %eax
 
-LBB30_27:
+LBB32_27:
 	LONG $0x14470144               // addl         %r8d, $20(%rdi)
 	WORD $0xc085                   // testl        %eax, %eax
-	LONG $0x00328e0f; WORD $0x0000 // jle          LBB30_31, $50(%rip)
+	LONG $0x00328e0f; WORD $0x0000 // jle          LBB32_31, $50(%rip)
 	WORD $0x8b48; BYTE $0x0f       // movq         (%rdi), %rcx
 	WORD $0xc289                   // movl         %eax, %edx
 	LONG $0x01c28348               // addq         $1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	BYTE $0x90                     // .p2align 4, 0x90
 
-LBB30_29:
+LBB32_29:
 	WORD $0xc689                   // movl         %eax, %esi
 	LONG $0x30313c80               // cmpb         $48, (%rcx,%rsi)
-	LONG $0x0026850f; WORD $0x0000 // jne          LBB30_33, $38(%rip)
+	LONG $0x0026850f; WORD $0x0000 // jne          LBB32_33, $38(%rip)
 	WORD $0x4789; BYTE $0x10       // movl         %eax, $16(%rdi)
 	LONG $0xffc28348               // addq         $-1, %rdx
 	WORD $0xc083; BYTE $0xff       // addl         $-1, %eax
 	LONG $0x01fa8348               // cmpq         $1, %rdx
-	LONG $0xffe08f0f; WORD $0xffff // jg           LBB30_29, $-32(%rip)
-	LONG $0x000006e9; BYTE $0x00   // jmp          LBB30_32, $6(%rip)
+	LONG $0xffe08f0f; WORD $0xffff // jg           LBB32_29, $-32(%rip)
+	LONG $0x000006e9; BYTE $0x00   // jmp          LBB32_32, $6(%rip)
 
-LBB30_31:
-	LONG $0x0007850f; WORD $0x0000 // jne          LBB30_33, $7(%rip)
+LBB32_31:
+	LONG $0x0007850f; WORD $0x0000 // jne          LBB32_33, $7(%rip)
 
-LBB30_32:
+LBB32_32:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 
-LBB30_33:
+LBB32_33:
 	BYTE $0x5b   // popq         %rbx
 	WORD $0x5e41 // popq         %r14
 	WORD $0x5f41 // popq         %r15
 	BYTE $0x5d   // popq         %rbp
 	BYTE $0xc3   // retq
 
-LBB30_15:
+LBB32_15:
 	WORD $0x0145; BYTE $0xc1     // addl         %r8d, %r9d
 	WORD $0x6349; BYTE $0xf1     // movslq       %r9d, %rsi
 	LONG $0xffc68348             // addq         $-1, %rsi
-	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB30_16, $30(%rip)
+	LONG $0x00001ee9; BYTE $0x00 // jmp          LBB32_16, $30(%rip)
 	QUAD $0x9090909090909090     // .p2align 4, 0x90
 
-LBB30_17:
+LBB32_17:
 	WORD $0x3004             // addb         $48, %al
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	WORD $0x0488; BYTE $0x33 // movb         %al, (%rbx,%rsi)
 
-LBB30_24:
+LBB32_24:
 	LONG $0xffc68348               // addq         $-1, %rsi
 	LONG $0x09f98348               // cmpq         $9, %rcx
-	LONG $0xff62860f; WORD $0xffff // jbe          LBB30_25, $-158(%rip)
+	LONG $0xff62860f; WORD $0xffff // jbe          LBB32_25, $-158(%rip)
 
-LBB30_16:
+LBB32_16:
 	WORD $0x8948; BYTE $0xd1                   // movq         %rdx, %rcx
 	WORD $0x8948; BYTE $0xd0                   // movq         %rdx, %rax
 	WORD $0xf749; BYTE $0xe6                   // mulq         %r14
@@ -8548,15 +9797,15 @@ LBB30_16:
 	WORD $0x8948; BYTE $0xc8                   // movq         %rcx, %rax
 	WORD $0x2948; BYTE $0xd8                   // subq         %rbx, %rax
 	LONG $0x08773948                           // cmpq         %rsi, $8(%rdi)
-	LONG $0xffc5870f; WORD $0xffff             // ja           LBB30_17, $-59(%rip)
+	LONG $0xffc5870f; WORD $0xffff             // ja           LBB32_17, $-59(%rip)
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0xffc4840f; WORD $0xffff             // je           LBB30_24, $-60(%rip)
+	LONG $0xffc4840f; WORD $0xffff             // je           LBB32_24, $-60(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB30_24, $-72(%rip)
+	LONG $0xffffb8e9; BYTE $0xff               // jmp          LBB32_24, $-72(%rip)
 
-LBB30_5:
-	LONG $0xfe738c0f; WORD $0xffff // jl           LBB30_9, $-397(%rip)
-	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB30_10, $-398(%rip)
+LBB32_5:
+	LONG $0xfe738c0f; WORD $0xffff // jl           LBB32_9, $-397(%rip)
+	LONG $0xfffe72e9; BYTE $0xff   // jmp          LBB32_10, $-398(%rip)
 	LONG $0x90909090; BYTE $0x90   // .p2align 4, 0x90
 
 _right_shift:
@@ -8572,9 +9821,9 @@ _right_shift:
 	WORD $0xc031                   // xorl         %eax, %eax
 	LONG $0x90909090               // .p2align 4, 0x90
 
-LBB31_1:
+LBB33_1:
 	WORD $0x3949; BYTE $0xd3       // cmpq         %rdx, %r11
-	LONG $0x014f840f; WORD $0x0000 // je           LBB31_2, $335(%rip)
+	LONG $0x014f840f; WORD $0x0000 // je           LBB33_2, $335(%rip)
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	WORD $0x8b48; BYTE $0x37       // movq         (%rdi), %rsi
 	LONG $0x34be0f48; BYTE $0x16   // movsbq       (%rsi,%rdx), %rsi
@@ -8584,10 +9833,10 @@ LBB31_1:
 	WORD $0x8948; BYTE $0xc6       // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee       // shrq         %cl, %rsi
 	WORD $0x8548; BYTE $0xf6       // testq        %rsi, %rsi
-	LONG $0xffd0840f; WORD $0xffff // je           LBB31_1, $-48(%rip)
+	LONG $0xffd0840f; WORD $0xffff // je           LBB33_1, $-48(%rip)
 	WORD $0x8941; BYTE $0xd3       // movl         %edx, %r11d
 
-LBB31_7:
+LBB33_7:
 	WORD $0x578b; BYTE $0x14                                             // movl         $20(%rdi), %edx
 	WORD $0x2944; BYTE $0xda                                             // subl         %r11d, %edx
 	WORD $0xc283; BYTE $0x01                                             // addl         $1, %edx
@@ -8597,13 +9846,13 @@ LBB31_7:
 	WORD $0xf749; BYTE $0xd1                                             // notq         %r9
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	WORD $0x3945; BYTE $0xc3                                             // cmpl         %r8d, %r11d
-	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB31_10, $128(%rip)
+	LONG $0x00808d0f; WORD $0x0000                                       // jge          LBB33_10, $128(%rip)
 	WORD $0x634d; BYTE $0xc3                                             // movslq       %r11d, %r8
 	WORD $0x8b48; BYTE $0x37                                             // movq         (%rdi), %rsi
 	WORD $0x3145; BYTE $0xd2                                             // xorl         %r10d, %r10d
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_9:
+LBB33_9:
 	WORD $0x8948; BYTE $0xc2                               // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                               // shrq         %cl, %rdx
 	WORD $0x214c; BYTE $0xc8                               // andq         %r9, %rax
@@ -8619,95 +9868,389 @@ LBB31_9:
 	LONG $0xd0c08348                                       // addq         $-48, %rax
 	LONG $0x10576348                                       // movslq       $16(%rdi), %rdx
 	WORD $0x3948; BYTE $0xd3                               // cmpq         %rdx, %rbx
-	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB31_9, $-62(%rip)
-	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB31_10, $37(%rip)
+	LONG $0xffc28c0f; WORD $0xffff                         // jl           LBB33_9, $-62(%rip)
+	LONG $0x000025e9; BYTE $0x00                           // jmp          LBB33_10, $37(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_12:
+LBB33_12:
 	LONG $0x30c68040         // addb         $48, %sil
 	WORD $0x8b48; BYTE $0x1f // movq         (%rdi), %rbx
 	LONG $0x13348840         // movb         %sil, (%rbx,%rdx)
 	WORD $0xc283; BYTE $0x01 // addl         $1, %edx
 	WORD $0x8941; BYTE $0xd2 // movl         %edx, %r10d
 
-LBB31_15:
+LBB33_15:
 	WORD $0x0148; BYTE $0xc0 // addq         %rax, %rax
 	LONG $0x80048d48         // leaq         (%rax,%rax,4), %rax
 
-LBB31_10:
+LBB33_10:
 	WORD $0x8548; BYTE $0xc0                   // testq        %rax, %rax
-	LONG $0x002b840f; WORD $0x0000             // je           LBB31_16, $43(%rip)
+	LONG $0x002b840f; WORD $0x0000             // je           LBB33_16, $43(%rip)
 	WORD $0x8948; BYTE $0xc6                   // movq         %rax, %rsi
 	WORD $0xd348; BYTE $0xee                   // shrq         %cl, %rsi
 	WORD $0x214c; BYTE $0xc8                   // andq         %r9, %rax
 	WORD $0x6349; BYTE $0xd2                   // movslq       %r10d, %rdx
 	LONG $0x08573948                           // cmpq         %rdx, $8(%rdi)
-	LONG $0xffc9870f; WORD $0xffff             // ja           LBB31_12, $-55(%rip)
+	LONG $0xffc9870f; WORD $0xffff             // ja           LBB33_12, $-55(%rip)
 	WORD $0x8548; BYTE $0xf6                   // testq        %rsi, %rsi
-	LONG $0xffd1840f; WORD $0xffff             // je           LBB31_15, $-47(%rip)
+	LONG $0xffd1840f; WORD $0xffff             // je           LBB33_15, $-47(%rip)
 	LONG $0x011c47c7; WORD $0x0000; BYTE $0x00 // movl         $1, $28(%rdi)
-	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB31_15, $-59(%rip)
+	LONG $0xffffc5e9; BYTE $0xff               // jmp          LBB33_15, $-59(%rip)
 
-LBB31_16:
+LBB33_16:
 	LONG $0x10578944                     // movl         %r10d, $16(%rdi)
 	WORD $0x8545; BYTE $0xd2             // testl        %r10d, %r10d
-	LONG $0x00858e0f; WORD $0x0000       // jle          LBB31_20, $133(%rip)
+	LONG $0x00858e0f; WORD $0x0000       // jle          LBB33_20, $133(%rip)
 	WORD $0x8b48; BYTE $0x07             // movq         (%rdi), %rax
 	WORD $0x8944; BYTE $0xd1             // movl         %r10d, %ecx
 	LONG $0x01c18348                     // addq         $1, %rcx
 	LONG $0xffc28341                     // addl         $-1, %r10d
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
-LBB31_18:
+LBB33_18:
 	WORD $0x8944; BYTE $0xd2       // movl         %r10d, %edx
 	LONG $0x30103c80               // cmpb         $48, (%rax,%rdx)
-	LONG $0x0067850f; WORD $0x0000 // jne          LBB31_22, $103(%rip)
+	LONG $0x0067850f; WORD $0x0000 // jne          LBB33_22, $103(%rip)
 	LONG $0x10578944               // movl         %r10d, $16(%rdi)
 	LONG $0xffc18348               // addq         $-1, %rcx
 	LONG $0xffc28341               // addl         $-1, %r10d
 	LONG $0x01f98348               // cmpq         $1, %rcx
-	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB31_18, $-35(%rip)
-	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB31_21, $79(%rip)
+	LONG $0xffdd8f0f; WORD $0xffff // jg           LBB33_18, $-35(%rip)
+	LONG $0x00004fe9; BYTE $0x00   // jmp          LBB33_21, $79(%rip)
 
-LBB31_2:
+LBB33_2:
 	WORD $0x8548; BYTE $0xc0                                             // testq        %rax, %rax
-	LONG $0x0050840f; WORD $0x0000                                       // je           LBB31_23, $80(%rip)
+	LONG $0x0050840f; WORD $0x0000                                       // je           LBB33_23, $80(%rip)
 	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 	WORD $0x8948; BYTE $0xc2                                             // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea                                             // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2                                             // testq        %rdx, %rdx
-	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB31_7, $-332(%rip)
+	LONG $0xfeb4850f; WORD $0xffff                                       // jne          LBB33_7, $-332(%rip)
 
-LBB31_4:
+LBB33_4:
 	WORD $0x0148; BYTE $0xc0       // addq         %rax, %rax
 	LONG $0x80048d48               // leaq         (%rax,%rax,4), %rax
 	LONG $0x01c38341               // addl         $1, %r11d
 	WORD $0x8948; BYTE $0xc2       // movq         %rax, %rdx
 	WORD $0xd348; BYTE $0xea       // shrq         %cl, %rdx
 	WORD $0x8548; BYTE $0xd2       // testq        %rdx, %rdx
-	LONG $0xffe6840f; WORD $0xffff // je           LBB31_4, $-26(%rip)
-	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB31_7, $-363(%rip)
+	LONG $0xffe6840f; WORD $0xffff // je           LBB33_4, $-26(%rip)
+	LONG $0xfffe95e9; BYTE $0xff   // jmp          LBB33_7, $-363(%rip)
 
-LBB31_20:
-	LONG $0x0003840f; WORD $0x0000 // je           LBB31_21, $3(%rip)
+LBB33_20:
+	LONG $0x0003840f; WORD $0x0000 // je           LBB33_21, $3(%rip)
 
-LBB31_22:
+LBB33_22:
 	BYTE $0x5b // popq         %rbx
 	BYTE $0x5d // popq         %rbp
 	BYTE $0xc3 // retq
 
-LBB31_21:
+LBB33_21:
 	LONG $0x001447c7; WORD $0x0000; BYTE $0x00 // movl         $0, $20(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
 
-LBB31_23:
+LBB33_23:
 	LONG $0x001047c7; WORD $0x0000; BYTE $0x00 // movl         $0, $16(%rdi)
 	BYTE $0x5b                                 // popq         %rbx
 	BYTE $0x5d                                 // popq         %rbp
 	BYTE $0xc3                                 // retq
 	LONG $0x00000000; BYTE $0x00               // .p2align 4, 0x00
+
+LCPI34_0:
+	QUAD $0x2222222222222222; QUAD $0x2222222222222222 // .space 16, '""""""""""""""""'
+
+LCPI34_1:
+	QUAD $0x5c5c5c5c5c5c5c5c; QUAD $0x5c5c5c5c5c5c5c5c // .space 16, '\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+
+	// .p2align 4, 0x90
+_advance_string_default:
+	BYTE $0x55                                 // pushq        %rbp
+	WORD $0x8948; BYTE $0xe5                   // movq         %rsp, %rbp
+	WORD $0x5741                               // pushq        %r15
+	WORD $0x5641                               // pushq        %r14
+	WORD $0x5541                               // pushq        %r13
+	WORD $0x5441                               // pushq        %r12
+	BYTE $0x53                                 // pushq        %rbx
+	BYTE $0x50                                 // pushq        %rax
+	LONG $0x087f8b4c                           // movq         $8(%rdi), %r15
+	WORD $0x2949; BYTE $0xf7                   // subq         %rsi, %r15
+	LONG $0x0381840f; WORD $0x0000             // je           LBB34_17, $897(%rip)
+	WORD $0x8b4c; BYTE $0x0f                   // movq         (%rdi), %r9
+	LONG $0xff02c748; WORD $0xffff; BYTE $0xff // movq         $-1, (%rdx)
+	LONG $0x40ff8349                           // cmpq         $64, %r15
+	LONG $0x01f8820f; WORD $0x0000             // jb           LBB34_18, $504(%rip)
+	WORD $0x8948; BYTE $0xf7                   // movq         %rsi, %rdi
+	WORD $0xf748; BYTE $0xd7                   // notq         %rdi
+	QUAD $0xffffffffd045c748                   // movq         $-1, $-48(%rbp)
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	QUAD $0xffffff98056f0f66                   // movdqa       $-104(%rip), %xmm0  /* LCPI34_0(%rip) */
+	QUAD $0xffffffa00d6f0f66                   // movdqa       $-96(%rip), %xmm1  /* LCPI34_1(%rip) */
+
+	// .p2align 4, 0x90
+LBB34_3:
+	LONG $0x6f0f41f3; WORD $0x3114             // movdqu       (%r9,%rsi), %xmm2
+	LONG $0x6f0f41f3; WORD $0x315c; BYTE $0x10 // movdqu       $16(%r9,%rsi), %xmm3
+	LONG $0x6f0f41f3; WORD $0x3164; BYTE $0x20 // movdqu       $32(%r9,%rsi), %xmm4
+	LONG $0x6f0f41f3; WORD $0x316c; BYTE $0x30 // movdqu       $48(%r9,%rsi), %xmm5
+	LONG $0xf26f0f66                           // movdqa       %xmm2, %xmm6
+	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
+	LONG $0xd70f4466; BYTE $0xe6               // pmovmskb     %xmm6, %r12d
+	LONG $0xf36f0f66                           // movdqa       %xmm3, %xmm6
+	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
+	LONG $0xded70f66                           // pmovmskb     %xmm6, %ebx
+	LONG $0xf46f0f66                           // movdqa       %xmm4, %xmm6
+	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
+	LONG $0xc6d70f66                           // pmovmskb     %xmm6, %eax
+	LONG $0xf56f0f66                           // movdqa       %xmm5, %xmm6
+	LONG $0xf0740f66                           // pcmpeqb      %xmm0, %xmm6
+	LONG $0xd70f4466; BYTE $0xc6               // pmovmskb     %xmm6, %r8d
+	LONG $0xd1740f66                           // pcmpeqb      %xmm1, %xmm2
+	LONG $0xd70f4466; BYTE $0xea               // pmovmskb     %xmm2, %r13d
+	LONG $0xd9740f66                           // pcmpeqb      %xmm1, %xmm3
+	LONG $0xcbd70f66                           // pmovmskb     %xmm3, %ecx
+	LONG $0xe1740f66                           // pcmpeqb      %xmm1, %xmm4
+	LONG $0xd70f4466; BYTE $0xd4               // pmovmskb     %xmm4, %r10d
+	LONG $0xe9740f66                           // pcmpeqb      %xmm1, %xmm5
+	LONG $0xd70f4466; BYTE $0xdd               // pmovmskb     %xmm5, %r11d
+	LONG $0x30e0c149                           // shlq         $48, %r8
+	LONG $0x20e0c148                           // shlq         $32, %rax
+	WORD $0x094c; BYTE $0xc0                   // orq          %r8, %rax
+	LONG $0x10e3c148                           // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xc3                   // orq          %rax, %rbx
+	WORD $0x0949; BYTE $0xdc                   // orq          %rbx, %r12
+	LONG $0x30e3c149                           // shlq         $48, %r11
+	LONG $0x20e2c149                           // shlq         $32, %r10
+	WORD $0x094d; BYTE $0xda                   // orq          %r11, %r10
+	LONG $0x10e1c148                           // shlq         $16, %rcx
+	WORD $0x094c; BYTE $0xd1                   // orq          %r10, %rcx
+	WORD $0x0949; BYTE $0xcd                   // orq          %rcx, %r13
+	LONG $0x0030850f; WORD $0x0000             // jne          LBB34_7, $48(%rip)
+	WORD $0x854d; BYTE $0xf6                   // testq        %r14, %r14
+	LONG $0x0040850f; WORD $0x0000             // jne          LBB34_9, $64(%rip)
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	WORD $0x854d; BYTE $0xe4                   // testq        %r12, %r12
+	LONG $0x0086850f; WORD $0x0000             // jne          LBB34_10, $134(%rip)
+
+LBB34_6:
+	LONG $0xc0c78349               // addq         $-64, %r15
+	LONG $0xc0c78348               // addq         $-64, %rdi
+	LONG $0x40c68348               // addq         $64, %rsi
+	LONG $0x3fff8349               // cmpq         $63, %r15
+	LONG $0xff35870f; WORD $0xffff // ja           LBB34_3, $-203(%rip)
+	LONG $0x000081e9; BYTE $0x00   // jmp          LBB34_12, $129(%rip)
+
+LBB34_7:
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x000e850f; WORD $0x0000 // jne          LBB34_9, $14(%rip)
+	LONG $0xc5bc0f49               // bsfq         %r13, %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xd0458948               // movq         %rax, $-48(%rbp)
+	WORD $0x8948; BYTE $0x02       // movq         %rax, (%rdx)
+
+LBB34_9:
+	WORD $0x894c; BYTE $0xf0               // movq         %r14, %rax
+	WORD $0xf748; BYTE $0xd0               // notq         %rax
+	WORD $0x214c; BYTE $0xe8               // andq         %r13, %rax
+	LONG $0x00048d4c                       // leaq         (%rax,%rax), %r8
+	WORD $0x094d; BYTE $0xf0               // orq          %r14, %r8
+	WORD $0x894c; BYTE $0xc1               // movq         %r8, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x214c; BYTE $0xe9               // andq         %r13, %rcx
+	QUAD $0xaaaaaaaaaaaabb48; WORD $0xaaaa // movabsq      $-6148914691236517206, %rbx
+	WORD $0x2148; BYTE $0xd9               // andq         %rbx, %rcx
+	WORD $0x3145; BYTE $0xf6               // xorl         %r14d, %r14d
+	WORD $0x0148; BYTE $0xc1               // addq         %rax, %rcx
+	LONG $0xc6920f41                       // setb         %r14b
+	WORD $0x0148; BYTE $0xc9               // addq         %rcx, %rcx
+	QUAD $0x555555555555b848; WORD $0x5555 // movabsq      $6148914691236517205, %rax
+	WORD $0x3148; BYTE $0xc1               // xorq         %rax, %rcx
+	WORD $0x214c; BYTE $0xc1               // andq         %r8, %rcx
+	WORD $0xf748; BYTE $0xd1               // notq         %rcx
+	WORD $0x2149; BYTE $0xcc               // andq         %rcx, %r12
+	WORD $0x854d; BYTE $0xe4               // testq        %r12, %r12
+	LONG $0xff7a840f; WORD $0xffff         // je           LBB34_6, $-134(%rip)
+
+LBB34_10:
+	LONG $0xc4bc0f49         // bsfq         %r12, %rax
+	WORD $0x2948; BYTE $0xf8 // subq         %rdi, %rax
+
+LBB34_11:
+	LONG $0x08c48348 // addq         $8, %rsp
+	BYTE $0x5b       // popq         %rbx
+	WORD $0x5c41     // popq         %r12
+	WORD $0x5d41     // popq         %r13
+	WORD $0x5e41     // popq         %r14
+	WORD $0x5f41     // popq         %r15
+	BYTE $0x5d       // popq         %rbp
+	BYTE $0xc3       // retq
+
+LBB34_12:
+	WORD $0x014c; BYTE $0xce       // addq         %r9, %rsi
+	LONG $0x20ff8349               // cmpq         $32, %r15
+	LONG $0x00f6820f; WORD $0x0000 // jb           LBB34_23, $246(%rip)
+
+LBB34_13:
+	LONG $0x066f0ff3               // movdqu       (%rsi), %xmm0
+	LONG $0x4e6f0ff3; BYTE $0x10   // movdqu       $16(%rsi), %xmm1
+	QUAD $0xfffffe21156f0f66       // movdqa       $-479(%rip), %xmm2  /* LCPI34_0(%rip) */
+	QUAD $0xfffffe291d6f0f66       // movdqa       $-471(%rip), %xmm3  /* LCPI34_1(%rip) */
+	LONG $0xe06f0f66               // movdqa       %xmm0, %xmm4
+	LONG $0xe2740f66               // pcmpeqb      %xmm2, %xmm4
+	LONG $0xfcd70f66               // pmovmskb     %xmm4, %edi
+	LONG $0xd1740f66               // pcmpeqb      %xmm1, %xmm2
+	LONG $0xcad70f66               // pmovmskb     %xmm2, %ecx
+	LONG $0xc3740f66               // pcmpeqb      %xmm3, %xmm0
+	LONG $0xc0d70f66               // pmovmskb     %xmm0, %eax
+	LONG $0xcb740f66               // pcmpeqb      %xmm3, %xmm1
+	LONG $0xd9d70f66               // pmovmskb     %xmm1, %ebx
+	LONG $0x10e1c148               // shlq         $16, %rcx
+	WORD $0x0948; BYTE $0xcf       // orq          %rcx, %rdi
+	LONG $0x10e3c148               // shlq         $16, %rbx
+	WORD $0x0948; BYTE $0xd8       // orq          %rbx, %rax
+	LONG $0x0045850f; WORD $0x0000 // jne          LBB34_19, $69(%rip)
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x005b850f; WORD $0x0000 // jne          LBB34_21, $91(%rip)
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0x0088840f; WORD $0x0000 // je           LBB34_22, $136(%rip)
+
+LBB34_16:
+	LONG $0xc7bc0f48             // bsfq         %rdi, %rax
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x0148; BYTE $0xf0     // addq         %rsi, %rax
+	LONG $0x01c08348             // addq         $1, %rax
+	LONG $0xffff6be9; BYTE $0xff // jmp          LBB34_11, $-149(%rip)
+
+LBB34_18:
+	WORD $0x014c; BYTE $0xce       // addq         %r9, %rsi
+	QUAD $0xffffffffd045c748       // movq         $-1, $-48(%rbp)
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	LONG $0x20ff8349               // cmpq         $32, %r15
+	LONG $0xff6f830f; WORD $0xffff // jae          LBB34_13, $-145(%rip)
+	LONG $0x000060e9; BYTE $0x00   // jmp          LBB34_23, $96(%rip)
+
+LBB34_19:
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x0014850f; WORD $0x0000 // jne          LBB34_21, $20(%rip)
+	WORD $0x8948; BYTE $0xf1       // movq         %rsi, %rcx
+	WORD $0x294c; BYTE $0xc9       // subq         %r9, %rcx
+	LONG $0xd8bc0f48               // bsfq         %rax, %rbx
+	WORD $0x0148; BYTE $0xcb       // addq         %rcx, %rbx
+	LONG $0xd05d8948               // movq         %rbx, $-48(%rbp)
+	WORD $0x8948; BYTE $0x1a       // movq         %rbx, (%rdx)
+
+LBB34_21:
+	WORD $0x8944; BYTE $0xf1       // movl         %r14d, %ecx
+	WORD $0xd1f7                   // notl         %ecx
+	WORD $0xc121                   // andl         %eax, %ecx
+	LONG $0x4e048d45               // leal         (%r14,%rcx,2), %r8d
+	WORD $0x1c8d; BYTE $0x09       // leal         (%rcx,%rcx), %ebx
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xc321                   // andl         %eax, %ebx
+	LONG $0xaaaae381; WORD $0xaaaa // andl         $-1431655766, %ebx
+	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
+	WORD $0xcb01                   // addl         %ecx, %ebx
+	LONG $0xc6920f41               // setb         %r14b
+	WORD $0xdb01                   // addl         %ebx, %ebx
+	LONG $0x5555f381; WORD $0x5555 // xorl         $1431655765, %ebx
+	WORD $0x2144; BYTE $0xc3       // andl         %r8d, %ebx
+	WORD $0xd3f7                   // notl         %ebx
+	WORD $0xdf21                   // andl         %ebx, %edi
+	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
+	LONG $0xff78850f; WORD $0xffff // jne          LBB34_16, $-136(%rip)
+
+LBB34_22:
+	LONG $0x20c68348 // addq         $32, %rsi
+	LONG $0xe0c78349 // addq         $-32, %r15
+
+LBB34_23:
+	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
+	LONG $0x00b5850f; WORD $0x0000 // jne          LBB34_37, $181(%rip)
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x00a1840f; WORD $0x0000 // je           LBB34_36, $161(%rip)
+
+LBB34_25:
+	WORD $0x894c; BYTE $0xcf // movq         %r9, %rdi
+	WORD $0xf748; BYTE $0xd7 // notq         %rdi
+	LONG $0x01c78348         // addq         $1, %rdi
+
+LBB34_26:
+	WORD $0xc031 // xorl         %eax, %eax
+
+LBB34_27:
+	WORD $0x8948; BYTE $0xc3       // movq         %rax, %rbx
+	LONG $0x060cb60f               // movzbl       (%rsi,%rax), %ecx
+	WORD $0xf980; BYTE $0x22       // cmpb         $34, %cl
+	LONG $0x007e840f; WORD $0x0000 // je           LBB34_35, $126(%rip)
+	WORD $0xf980; BYTE $0x5c       // cmpb         $92, %cl
+	LONG $0x0012840f; WORD $0x0000 // je           LBB34_30, $18(%rip)
+	LONG $0x01438d48               // leaq         $1(%rbx), %rax
+	WORD $0x3949; BYTE $0xc7       // cmpq         %rax, %r15
+	LONG $0xffda850f; WORD $0xffff // jne          LBB34_27, $-38(%rip)
+	LONG $0x000053e9; BYTE $0x00   // jmp          LBB34_34, $83(%rip)
+
+LBB34_30:
+	LONG $0xff4f8d49                           // leaq         $-1(%r15), %rcx
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0x3948; BYTE $0xd9                   // cmpq         %rbx, %rcx
+	LONG $0xfe91840f; WORD $0xffff             // je           LBB34_11, $-367(%rip)
+	LONG $0xd07d8348; BYTE $0xff               // cmpq         $-1, $-48(%rbp)
+	LONG $0x000e850f; WORD $0x0000             // jne          LBB34_33, $14(%rip)
+	LONG $0x370c8d48                           // leaq         (%rdi,%rsi), %rcx
+	WORD $0x0148; BYTE $0xd9                   // addq         %rbx, %rcx
+	LONG $0xd04d8948                           // movq         %rcx, $-48(%rbp)
+	WORD $0x8948; BYTE $0x0a                   // movq         %rcx, (%rdx)
+
+LBB34_33:
+	WORD $0x0148; BYTE $0xde       // addq         %rbx, %rsi
+	LONG $0x02c68348               // addq         $2, %rsi
+	WORD $0x894c; BYTE $0xf9       // movq         %r15, %rcx
+	WORD $0x2948; BYTE $0xd9       // subq         %rbx, %rcx
+	LONG $0xfec18348               // addq         $-2, %rcx
+	LONG $0xfec78349               // addq         $-2, %r15
+	WORD $0x3949; BYTE $0xdf       // cmpq         %rbx, %r15
+	WORD $0x8949; BYTE $0xcf       // movq         %rcx, %r15
+	LONG $0xff85850f; WORD $0xffff // jne          LBB34_26, $-123(%rip)
+	LONG $0xfffe52e9; BYTE $0xff   // jmp          LBB34_11, $-430(%rip)
+
+LBB34_34:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	WORD $0xf980; BYTE $0x22                   // cmpb         $34, %cl
+	LONG $0xfe42850f; WORD $0xffff             // jne          LBB34_11, $-446(%rip)
+
+LBB34_35:
+	WORD $0x0148; BYTE $0xde // addq         %rbx, %rsi
+	LONG $0x01c68348         // addq         $1, %rsi
+
+LBB34_36:
+	WORD $0x294c; BYTE $0xce     // subq         %r9, %rsi
+	WORD $0x8948; BYTE $0xf0     // movq         %rsi, %rax
+	LONG $0xfffe30e9; BYTE $0xff // jmp          LBB34_11, $-464(%rip)
+
+LBB34_37:
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0x0031840f; WORD $0x0000 // je           LBB34_17, $49(%rip)
+	LONG $0xd07d8348; BYTE $0xff   // cmpq         $-1, $-48(%rbp)
+	LONG $0x0010850f; WORD $0x0000 // jne          LBB34_40, $16(%rip)
+	WORD $0x894c; BYTE $0xc8       // movq         %r9, %rax
+	WORD $0xf748; BYTE $0xd0       // notq         %rax
+	WORD $0x0148; BYTE $0xf0       // addq         %rsi, %rax
+	LONG $0xd0458948               // movq         %rax, $-48(%rbp)
+	WORD $0x8948; BYTE $0x02       // movq         %rax, (%rdx)
+
+LBB34_40:
+	LONG $0x01c68348               // addq         $1, %rsi
+	LONG $0xffc78349               // addq         $-1, %r15
+	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
+	LONG $0xff1f850f; WORD $0xffff // jne          LBB34_25, $-225(%rip)
+	LONG $0xffffbbe9; BYTE $0xff   // jmp          LBB34_36, $-69(%rip)
+
+LBB34_17:
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xfffdeae9; BYTE $0xff               // jmp          LBB34_11, $-534(%rip)
+	QUAD $0x0000000000000000                   // .p2align 4, 0x00
 
 _POW10_M128_TAB:
 	QUAD $0x1732c869cd60e453                           // .quad 1671618768450675795
@@ -10136,7 +11679,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_a03fbdd2: // _pow10_ceil_sig.g
+_LB_2c61c5d2: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -12791,7 +14334,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_a00a2ccc: // _pow10_ceil_sig_f32.g
+_LB_d387b277: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -12882,7 +14425,7 @@ _entry:
 _f32toa:
 	MOVQ  out+0(FP), DI
 	MOVSD val+8(FP), X0
-	CALL  ·__native_entry__+24640(SB) // _f32toa
+	CALL  ·__native_entry__+29152(SB) // _f32toa
 	MOVQ  AX, ret+16(FP)
 	RET
 
@@ -12904,6 +14447,27 @@ _f64toa:
 	MOVSD val+8(FP), X0
 	CALL  ·__native_entry__+464(SB) // _f64toa
 	MOVQ  AX, ret+16(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__get_by_path(SB), NOSPLIT | NOFRAME, $0 - 32
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -232(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_get_by_path:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	MOVQ path+16(FP), DX
+	CALL ·__native_entry__+27392(SB) // _get_by_path
+	MOVQ AX, ret+24(FP)
 	RET
 
 _stack_grow:
@@ -13010,7 +14574,7 @@ _skip_array:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+22928(SB) // _skip_array
+	CALL ·__native_entry__+20144(SB) // _skip_array
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -13030,7 +14594,7 @@ _entry:
 _skip_number:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
-	CALL ·__native_entry__+24432(SB) // _skip_number
+	CALL ·__native_entry__+23488(SB) // _skip_number
 	MOVQ AX, ret+16(FP)
 	RET
 
@@ -13052,7 +14616,7 @@ _skip_object:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+22976(SB) // _skip_object
+	CALL ·__native_entry__+22032(SB) // _skip_object
 	MOVQ AX, ret+32(FP)
 	RET
 
@@ -13074,8 +14638,28 @@ _skip_one:
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
 	MOVQ flags+24(FP), CX
-	CALL ·__native_entry__+21056(SB) // _skip_one
+	CALL ·__native_entry__+23632(SB) // _skip_one
 	MOVQ AX, ret+32(FP)
+	RET
+
+_stack_grow:
+	CALL runtime·morestack_noctxt<>(SB)
+	JMP  _entry
+
+TEXT ·__skip_one_fast(SB), NOSPLIT | NOFRAME, $0 - 24
+	NO_LOCAL_POINTERS
+
+_entry:
+	MOVQ (TLS), R14
+	LEAQ -144(SP), R12
+	CMPQ R12, 16(R14)
+	JBE  _stack_grow
+
+_skip_one_fast:
+	MOVQ s+0(FP), DI
+	MOVQ p+8(FP), SI
+	CALL ·__native_entry__+23840(SB) // _skip_one_fast
+	MOVQ AX, ret+16(FP)
 	RET
 
 _stack_grow:
@@ -13138,7 +14722,7 @@ _validate_one:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+24576(SB) // _validate_one
+	CALL ·__native_entry__+23664(SB) // _validate_one
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -13182,7 +14766,7 @@ _vnumber:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+18800(SB), AX // _vnumber
+	LEAQ ·__native_entry__+17888(SB), AX // _vnumber
 	JMP  AX
 
 _stack_grow:
@@ -13202,7 +14786,7 @@ _vsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+20352(SB), AX // _vsigned
+	LEAQ ·__native_entry__+19440(SB), AX // _vsigned
 	JMP  AX
 
 _stack_grow:
@@ -13243,7 +14827,7 @@ _vunsigned:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ v+16(FP), DX
-	LEAQ ·__native_entry__+20704(SB), AX // _vunsigned
+	LEAQ ·__native_entry__+19792(SB), AX // _vunsigned
 	JMP  AX
 
 _stack_grow:

--- a/internal/native/sse/native_amd64_test.go
+++ b/internal/native/sse/native_amd64_test.go
@@ -591,3 +591,59 @@ func TestNative_SkipNumber(t *testing.T) {
     assert.Equal(t, 9, p)
     assert.Equal(t, 0, q)
 }
+
+func TestNative_SkipOneFast(t *testing.T) {
+    p := 0
+    s := ` {"asdf": [null, true, false, 1, 2.0, -3]}, 1234.5`
+    q := __skip_one_fast(&s, &p)
+    assert.Equal(t, 42, p)
+    assert.Equal(t, 1, q)
+    p = 0
+    s = `1, 2.5, -3, "asdf\nqwer", true, false, null, {}, [],`
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 1, p)
+    assert.Equal(t, 0, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 6, p)
+    assert.Equal(t, 3, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 10, p)
+    assert.Equal(t, 8, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 24, p)
+    assert.Equal(t, 12, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 30, p)
+    assert.Equal(t, 26, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 37, p)
+    assert.Equal(t, 32, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 43, p)
+    assert.Equal(t, 39, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 47, p)
+    assert.Equal(t, 45, q)
+    p += 1
+    q = __skip_one_fast(&s, &p)
+    assert.Equal(t, 51, p)
+    assert.Equal(t, 49, q)
+}
+
+func TestNative_SkipOneFast_Error(t *testing.T) {
+    for _, s := range([]string{
+        "{{", "[{",  "{{}",
+        `"asdf`, `"\\\"`,
+    }) {
+        p := 0
+        q := __skip_one_fast(&s, &p)
+        assert.True(t, q < 0)
+    }
+}

--- a/internal/native/sse/native_export_amd64.go
+++ b/internal/native/sse/native_export_amd64.go
@@ -41,7 +41,9 @@ var (
 
 var (
     S_skip_one    = _subr__skip_one
+    S_skip_one_fast = _subr__skip_one_fast
     S_skip_array  = _subr__skip_array
     S_skip_object = _subr__skip_object
     S_skip_number = _subr__skip_number
+    S_get_by_path = _subr__get_by_path
 )

--- a/internal/native/sse/native_subr_amd64.go
+++ b/internal/native/sse/native_subr_amd64.go
@@ -9,29 +9,32 @@ package sse
 func __native_entry__() uintptr
 
 var (
-    _subr__f32toa       = __native_entry__() + 24640
-    _subr__f64toa       = __native_entry__() + 464
-    _subr__html_escape  = __native_entry__() + 10416
-    _subr__i64toa       = __native_entry__() + 4048
-    _subr__lspace       = __native_entry__() + 80
-    _subr__quote        = __native_entry__() + 5456
-    _subr__skip_array   = __native_entry__() + 22928
-    _subr__skip_number  = __native_entry__() + 24432
-    _subr__skip_object  = __native_entry__() + 22976
-    _subr__skip_one     = __native_entry__() + 21056
-    _subr__u64toa       = __native_entry__() + 4176
-    _subr__unquote      = __native_entry__() + 7232
-    _subr__validate_one = __native_entry__() + 24576
-    _subr__value        = __native_entry__() + 13680
-    _subr__vnumber      = __native_entry__() + 18800
-    _subr__vsigned      = __native_entry__() + 20352
-    _subr__vstring      = __native_entry__() + 15760
-    _subr__vunsigned    = __native_entry__() + 20704
+    _subr__f32toa        = __native_entry__() + 29152
+    _subr__f64toa        = __native_entry__() + 464
+    _subr__get_by_path   = __native_entry__() + 27392
+    _subr__html_escape   = __native_entry__() + 10416
+    _subr__i64toa        = __native_entry__() + 4048
+    _subr__lspace        = __native_entry__() + 80
+    _subr__quote         = __native_entry__() + 5456
+    _subr__skip_array    = __native_entry__() + 20144
+    _subr__skip_number   = __native_entry__() + 23488
+    _subr__skip_object   = __native_entry__() + 22032
+    _subr__skip_one      = __native_entry__() + 23632
+    _subr__skip_one_fast = __native_entry__() + 23840
+    _subr__u64toa        = __native_entry__() + 4176
+    _subr__unquote       = __native_entry__() + 7232
+    _subr__validate_one  = __native_entry__() + 23664
+    _subr__value         = __native_entry__() + 13680
+    _subr__vnumber       = __native_entry__() + 17888
+    _subr__vsigned       = __native_entry__() + 19440
+    _subr__vstring       = __native_entry__() + 15760
+    _subr__vunsigned     = __native_entry__() + 19792
 )
 
 const (
     _stack__f32toa = 64
     _stack__f64toa = 80
+    _stack__get_by_path = 232
     _stack__html_escape = 64
     _stack__i64toa = 16
     _stack__lspace = 8
@@ -40,6 +43,7 @@ const (
     _stack__skip_number = 72
     _stack__skip_object = 128
     _stack__skip_one = 128
+    _stack__skip_one_fast = 144
     _stack__u64toa = 8
     _stack__unquote = 72
     _stack__validate_one = 128
@@ -53,6 +57,7 @@ const (
 var (
     _ = _subr__f32toa
     _ = _subr__f64toa
+    _ = _subr__get_by_path
     _ = _subr__html_escape
     _ = _subr__i64toa
     _ = _subr__lspace
@@ -61,6 +66,7 @@ var (
     _ = _subr__skip_number
     _ = _subr__skip_object
     _ = _subr__skip_one
+    _ = _subr__skip_one_fast
     _ = _subr__u64toa
     _ = _subr__unquote
     _ = _subr__validate_one
@@ -74,6 +80,7 @@ var (
 const (
     _ = _stack__f32toa
     _ = _stack__f64toa
+    _ = _stack__get_by_path
     _ = _stack__html_escape
     _ = _stack__i64toa
     _ = _stack__lspace
@@ -82,6 +89,7 @@ const (
     _ = _stack__skip_number
     _ = _stack__skip_object
     _ = _stack__skip_one
+    _ = _stack__skip_one_fast
     _ = _stack__u64toa
     _ = _stack__unquote
     _ = _stack__validate_one

--- a/native/native.h
+++ b/native/native.h
@@ -36,10 +36,60 @@
 #define is_infinity(v)  ((as_uint64v(&v) << 1) == 0xFFE0000000000000)
 
 typedef struct {
-    char * buf;
+    void * buf;
     size_t len;
     size_t cap;
 } GoSlice;
+
+static const uint8_t GO_KIND_MASK = (1 << 5) - 1;
+typedef enum {
+	Invalid = 0,
+	Bool,
+	Int,
+	Int8,
+	Int16,
+	Int32,
+	Int64,
+	Uint,
+	Uint8,
+	Uint16,
+	Uint32,
+	Uint64,
+	Uintptr,
+	Float32,
+	Float64,
+	Complex64,
+	Complex128,
+	Array,
+	Chan,
+	Func,
+	Interface,
+	Map,
+	Pointer,
+	Slice,
+	String,
+	Struct,
+	UnsafePointer,
+} GoKind;
+
+typedef struct {
+    uint64_t size;
+    uint64_t ptr_data;
+    uint32_t hash;
+    uint8_t  flags;
+    uint8_t  align;
+    uint8_t  filed_align;
+    uint8_t  kind_flags;
+    uint64_t traits;
+    void*    gc_data;
+    int32_t  str;
+    int32_t  ptr_to_self;
+} GoType;
+
+typedef struct {
+    GoType * type;
+    void   * value;
+} GoIface;
 
 typedef struct {
     const char * buf;
@@ -98,4 +148,6 @@ ssize_t utf8_validate(const char *sp, ssize_t nb);
 long validate_string(const GoString *src, long *p);
 long validate_one(const GoString *src, long *p, StateMachine *m);
 
+long skip_one_fast(const GoString *src, long *p);
+long get_by_path(const GoString *src, long *p, const GoSlice *path);
 #endif


### PR DESCRIPTION
# Main Changes
use SIMD to accelerate the skip_object/array/number APIs in native code
Limits: not validate any more for performance, e.g. not validate the number format.

# Compare with master branch: 

## Common case, Performance x9

```
go: added golang.org/x/perf v0.0.0-20220920022801-e8d778a60d07
name             old time/op    new time/op    delta
GetOne_Sonic-12    12.8µs ± 4%     1.3µs ± 4%   -89.76%  (p=0.000 n=10+10)

name             old speed      new speed      delta
GetOne_Sonic-12  1.02GB/s ± 4%  9.93GB/s ± 4%  +876.39%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
GetOne_Sonic-12     24.0B ± 0%     24.0B ± 0%      ~     (all equal)

name             old allocs/op  new allocs/op  delta
GetOne_Sonic-12      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```

## Bench with lots of compare operators, Performance x2
```
go: added golang.org/x/perf v0.0.0-20220920022801-e8d778a60d07
name                         old time/op    new time/op    delta
GetWithManyCompare_Sonic-12    7.82µs ± 8%    3.70µs ±13%   -52.66%  (p=0.000 n=9+10)

name                         old speed      new speed      delta
GetWithManyCompare_Sonic-12   126MB/s ±15%   271MB/s ±14%  +115.32%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
GetWithManyCompare_Sonic-12     24.0B ± 0%     24.0B ± 0%      ~     (all equal)

name                         old allocs/op  new allocs/op  delta
GetWithManyCompare_Sonic-12      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```

# Compare with others
```
goos: darwin
goarch: amd64
pkg: github.com/bytedance/sonic/external_jsonlib_test/benchmark_test
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkGetByKeys_Sonic-12               994468              1159 ns/op        11248.84 MB/s         24 B/op          1 allocs/op
BenchmarkGetByKeys_JsonParser-12           64651             19126 ns/op         681.53 MB/s           0 B/op          0 allocs/op
```

# Fuzz tests
```
fuzz: elapsed: 19m5s, execs: 2931657 (2495/sec), new interesting: 47 (total: 3278)
fuzz: elapsed: 19m8s, execs: 2942448 (3644/sec), new interesting: 47 (total: 3278)
fuzz: elapsed: 19m11s, execs: 2950775 (2797/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m14s, execs: 2959739 (2988/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m17s, execs: 2969151 (2923/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m20s, execs: 2976046 (2480/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m23s, execs: 2987277 (3743/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m26s, execs: 2996019 (2725/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m29s, execs: 3002092 (2176/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m32s, execs: 3009235 (2317/sec), new interesting: 48 (total: 3279)
fuzz: elapsed: 19m35s, execs: 3031807 (7516/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m38s, execs: 3040127 (2797/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m41s, execs: 3048943 (2998/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m44s, execs: 3058271 (3018/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m47s, execs: 3066288 (2710/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m50s, execs: 3072181 (1997/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m53s, execs: 3079643 (2455/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m56s, execs: 3089230 (3240/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 19m59s, execs: 3097342 (2704/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 20m2s, execs: 3105458 (2704/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 20m5s, execs: 3108273 (934/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 20m8s, execs: 3113499 (1751/sec), new interesting: 49 (total: 3280)
fuzz: elapsed: 20m11s, execs: 3118179 (1560/sec), new interesting: 49 (total: 3280)
^Cfuzz: elapsed: 20m14s, execs: 3122095 (1389/sec), new interesting: 50 (total: 3281)
--- PASS: FuzzMain (1214.70s)
```
