### PR TITLE
try vtable quote

### DIFF
--- a/encoder/assembler_amd64_go117.go
+++ b/encoder/assembler_amd64_go117.go
@@ -651,7 +651,7 @@ func (self *_Assembler) go_panic() {
     self.Emit("MOVQ", _SP_p, _BX)
     self.call_go(_F_panic)
 }
-
+const  _VtableOff  = int64(unsafe.Offsetof(_Stack{}.vtb))
 func (self *_Assembler) encode_string(doubleQuote bool) {       
     self.Emit("MOVQ" , jit.Ptr(_SP_p, 8), _AX)  // MOVQ  8(SP.p), AX
     self.Emit("TESTQ", _AX, _AX)                // TESTQ AX, AX
@@ -698,7 +698,8 @@ func (self *_Assembler) encode_string(doubleQuote bool) {
     }
 
     /* call the native quoter */
-    self.call_c(_F_quote)                   // CALL  quote
+    self.Emit("MOVQ", jit.Ptr(_ST, _VtableOff), _AX)            // MOVQ _VtableOff(ST), _AX
+    self.call_c(_AX)                   // CALL  quote
     self.Emit("ADDQ" , _VAR_dn, _RL)        // ADDQ  dn, RL
 
     self.Emit("TESTQ", _AX, _AX)            // TESTQ AX, AX

--- a/encoder/assembler_test.go
+++ b/encoder/assembler_test.go
@@ -26,6 +26,7 @@ import (
     `testing`
     `unsafe`
 
+    `github.com/bytedance/sonic/internal/native`
     `github.com/bytedance/sonic/internal/rt`
     `github.com/davecgh/go-spew/spew`
     `github.com/stretchr/testify/assert`
@@ -97,6 +98,7 @@ func testOpCode(t *testing.T, v interface{}, ex string, err error, ins _Program)
     p := ins
     m := []byte(nil)
     s := new(_Stack)
+    s.vtb = int64(native.S_quote)
     a := newAssembler(p)
     f := a.Load()
     e := f(&m, rt.UnpackEface(v).Value, s, 0)
@@ -365,6 +367,7 @@ func TestAssembler_StringMoreSpace(t *testing.T) {
     p := _Program{newInsOp(_OP_str)}
     m := make([]byte, 0, 8)
     s := new(_Stack)
+    s.vtb = int64(native.S_quote)
     a := newAssembler(p)
     f := a.Load()
     v := "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a\u000b\u000c\u000d\u000e\u000f\u0010"

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -174,6 +174,14 @@ func Encode(val interface{}, opts Options) ([]byte, error) {
 func EncodeInto(buf *[]byte, val interface{}, opts Options) error {
     stk := newStack()
     efv := rt.UnpackEface(val)
+
+    // configure all options as virtual functions
+    if opts & EscapeHTML == 0 {
+        stk.vtb = int64(native.S_quote)
+    } else {
+        stk.vtb = int64(native.S_quote)
+    }
+
     err := encodeTypedPointer(buf, efv.Type, &efv.Value, stk, uint64(opts))
 
     /* return the stack into pool */

--- a/encoder/pools.go
+++ b/encoder/pools.go
@@ -25,6 +25,7 @@ import (
 
     `github.com/bytedance/sonic/internal/caching`
     `github.com/bytedance/sonic/option`
+    `github.com/bytedance/sonic/internal/native`
     `github.com/bytedance/sonic/internal/rt`
 )
 
@@ -50,8 +51,9 @@ type _State struct {
 }
 
 type _Stack struct {
-    sp uint64
-    sb [_MaxStack]_State
+    sp  uint64
+    sb  [_MaxStack]_State
+    vtb int64
 }
 
 type _Encoder func(
@@ -96,12 +98,14 @@ func newBytes() []byte {
     }
 }
 
-func newStack() *_Stack {
+func newStack() (r *_Stack) {
     if ret := stackPool.Get(); ret == nil {
-        return new(_Stack)
+        r = new(_Stack)
     } else {
-        return ret.(*_Stack)
+        r = ret.(*_Stack)
     }
+    r.vtb = int64(native.S_quote)
+    return 
 }
 
 func resetStack(p *_Stack) {


### PR DESCRIPTION
# performance test

```
go: upgraded github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06 => v0.0.0-20221115062448-fe3a3abad311
go: added github.com/google/safehtml v0.0.2
go: added golang.org/x/perf v0.0.0-20221222172245-91a04616dc65
go: added golang.org/x/text v0.3.6
name                                       old time/op    new time/op    delta
MarshalConcrete/TwitterStatus_Sonic-12        236µs ± 3%     234µs ± 1%   ~     (p=0.601 n=10+7)
MarshalConcrete/TwitterStatus_SonicStd-12     293µs ± 3%     291µs ± 1%   ~     (p=0.190 n=10+10)

name                                       old speed      new speed      delta
MarshalConcrete/TwitterStatus_Sonic-12     2.68GB/s ± 3%  2.69GB/s ± 1%   ~     (p=0.601 n=10+7)
MarshalConcrete/TwitterStatus_SonicStd-12  2.15GB/s ± 3%  2.17GB/s ± 1%   ~     (p=0.190 n=10+10)

name                                       old alloc/op   new alloc/op   delta
MarshalConcrete/TwitterStatus_Sonic-12        501kB ± 0%     501kB ± 0%   ~     (p=0.853 n=10+10)
MarshalConcrete/TwitterStatus_SonicStd-12     601kB ± 0%     600kB ± 0%   ~     (p=0.912 n=10+10)

name                                       old allocs/op  new allocs/op  delta
MarshalConcrete/TwitterStatus_Sonic-12         4.00 ± 0%      4.00 ± 0%   ~     (all equal)
MarshalConcrete/TwitterStatus_SonicStd-12      4.00 ± 0%      4.00 ± 0%   ~     (all equal)
git checkout -- .
git checkout chore/vtable

Switched to branch 'chore/vtable'

go: added golang.org/x/perf v0.0.0-20221222172245-91a04616dc65
go: added golang.org/x/text v0.3.6
name                                        old time/op    new time/op    delta
MarshalInterface/TwitterStatus_Sonic-12       1.11ms ± 2%    1.11ms ± 3%    ~     (p=0.497 n=9+10)
MarshalInterface/TwitterStatus_SonicStd-12    1.67ms ± 3%    1.65ms ± 1%  -1.55%  (p=0.004 n=10+9)

name                                        old speed      new speed      delta
MarshalInterface/TwitterStatus_Sonic-12      570MB/s ± 2%   567MB/s ± 3%    ~     (p=0.497 n=9+10)
MarshalInterface/TwitterStatus_SonicStd-12   378MB/s ± 3%   383MB/s ± 1%  +1.56%  (p=0.004 n=10+9)

name                                        old alloc/op   new alloc/op   delta
MarshalInterface/TwitterStatus_Sonic-12        468kB ± 0%     469kB ± 0%    ~     (p=0.436 n=10+10)
MarshalInterface/TwitterStatus_SonicStd-12     568kB ± 0%     568kB ± 0%    ~     (p=0.494 n=10+10)

name                                        old allocs/op  new allocs/op  delta
MarshalInterface/TwitterStatus_Sonic-12         4.00 ± 0%      4.00 ± 0%    ~     (all equal)
MarshalInterface/TwitterStatus_SonicStd-12      4.00 ± 0%      4.00 ± 0%    ~     (all equal)
git checkout -- .
git checkout chore/vtable
```