### PR TITLE
feat: add env option `SONIC_STOP_PROFILING` to stop profiling on demands

### DIFF
--- a/internal/rt/asm_amd64.s
+++ b/internal/rt/asm_amd64.s
@@ -22,6 +22,8 @@ _stack_grow:
 
 TEXT ·StopProf(SB), NOSPLIT, $0-0
     NO_LOCAL_POINTERS
+    CMPB github·com∕bytedance∕sonic∕internal∕rt·StopProfiling(SB), $0
+    JEQ  _ret_1
     MOVL $1, AX
     LEAQ github·com∕bytedance∕sonic∕internal∕rt·yieldCount(SB), CX
     LOCK
@@ -37,6 +39,8 @@ _ret_1:
 
 TEXT ·StartProf(SB), NOSPLIT, $0-0
     NO_LOCAL_POINTERS
+    CMPB github·com∕bytedance∕sonic∕internal∕rt·StopProfiling(SB), $0
+    JEQ  _ret_2
     MOVL $-1, AX
     LEAQ github·com∕bytedance∕sonic∕internal∕rt·yieldCount(SB), CX
     LOCK

--- a/internal/rt/gcwb.go
+++ b/internal/rt/gcwb.go
@@ -17,6 +17,7 @@
 package rt
 
 import (
+    `os`
     `sync/atomic`
     `unsafe`
 
@@ -74,6 +75,11 @@ func GcwbAddr() uintptr {
         return uintptr(fp) + off
     }
 }
+
+// StopProfiling is used to stop traceback introduced by SIGPROF while native code is running.
+// WARN: this option is only a workaround for traceback issue (https://github.com/bytedance/sonic/issues/310),
+// and will be dropped when the issue is fixed.
+var StopProfiling = os.Getenv("SONIC_STOP_PROFILING") != ""
 
 // WARN: must be aligned with runtime.Prof
 // type Prof struct {


### PR DESCRIPTION
## what this PR for?
- as #310 mentioned, go traceback while calling native functions may cause sonic crash. Therefore we commit PR #342 to prevent this ahead. However, it will make profiling results inaccurate, especially when sonic is heavily used.
- Thus, we add an environmental variant `SONIC_STOP_PROFILING` to control if `StopProf` feature should open, which only works when this variant is not empty