### PR TITLE
fix(ast): out-of-bound for single unclosed string

### DIFF
--- a/ast/search_test.go
+++ b/ast/search_test.go
@@ -127,9 +127,10 @@ type testGetByPath struct {
     ok    bool
 }
 
-func TestSearcher_GetByPathOk(t *testing.T) {
-    type Path = []interface{}
-    const Ok = true
+func TestSearcher_GetByPathSingle(t *testing.T) {
+    type Path   = []interface{}
+    const Ok    = true
+    const Error = false
     tests := []testGetByPath{
         {`true`, Path{}, true, Ok},
         {`false`, Path{}, false, Ok},
@@ -143,39 +144,28 @@ func TestSearcher_GetByPathOk(t *testing.T) {
         {`[1,2,3]`, Path{1}, 2.0, Ok},
         {`[1,2,3]`, Path{2}, 3.0, Ok},
         {`[1,2,3]`, Path{2}, 3.0, Ok},
-    }
-    for _, test := range tests {
-        t.Run(test.json, func(t *testing.T) {
-            s := NewSearcher(test.json)
-            node, err1 := s.GetByPath(test.path...)
-            v, err2 := node.Interface()
-            assert.Equal(t, test.value, v)
-            ok := err1 == nil && err2 == nil
-            assert.Equal(t, test.ok, ok)
-        })
-    }
-}
 
-func TestSearcher_GetByPathError(t *testing.T) {
-    type Path = []interface{}
-    const Error = false
-    tests := []testGetByPath{
-        {`tru`, Path{}, true, Error},
-        {`fal`, Path{}, false, Error},
+        {`tru`, Path{}, nil, Error},
+        {`fal`, Path{}, nil, Error},
         {`nul`, Path{}, nil, Error},
         {`{"a":1`, Path{}, nil, Error},
-        {`x12345.6789`, Path{}, 12345.6789, Error},
-        {`"abc`, Path{}, "abc", Error},
-        {`"a\"\\bc`, Path{}, "a\"\\bc", Error},
-        {`{"a":`, Path{"a"}, 1.0, Error},
-        {`[1,2,3]`, Path{4}, 1.0, Error},
-        {`[1,2,3]`, Path{"a"}, 3.0, Error},
+        {`x12345.6789`, Path{}, nil, Error},
+        {`"abc`, Path{}, nil, Error},
+        {`"a\"\\bc`, Path{}, nil, Error},
+        {`"a\"\`, Path{}, nil, Error},
+        {`{"a":`, Path{"a"}, nil, Error},
+        {`[1,2,3]`, Path{4}, nil, Error},
+        {`[1,2,3]`, Path{"a"}, nil, Error},
     }
     for _, test := range tests {
         t.Run(test.json, func(t *testing.T) {
             s := NewSearcher(test.json)
-            _, err := s.GetByPath(test.path...)
-            assert.Equal(t, test.ok, err == nil)
+            node, err1  := s.GetByPath(test.path...)
+            assert.Equal(t, test.ok, err1 == nil)
+
+            value, err2 := node.Interface()
+            assert.Equal(t, test.value, value)
+            assert.Equal(t, test.ok, err2 == nil)
         })
     }
 }

--- a/fuzz/ast_fuzz_test.go
+++ b/fuzz/ast_fuzz_test.go
@@ -26,6 +26,11 @@ import (
 	`github.com/davecgh/go-spew/spew`
 )
 
+// data is random, check whether is panic
+func fuzzAst(t *testing.T, data []byte) {
+	sonic.Get(data)
+}
+
 func fuzzASTGetFromObject(t *testing.T, data []byte, m map[string]interface{}) {
 	for k, expv := range(m) {
 		msg := fmt.Sprintf("Data:\n%s\nKey:\n%s\n", spew.Sdump(&data), spew.Sdump(&k))

--- a/fuzz/fuzz_test.go
+++ b/fuzz/fuzz_test.go
@@ -53,6 +53,8 @@ var target = sonic.ConfigStd
 func fuzzMain(t *testing.T, data []byte) {
     fuzzValidate(t, data)
     fuzzHtmlEscape(t, data)
+    // fuzz ast get api, should not panic here.
+    fuzzAst(t, data)
     // Only fuzz the validate json here.
     if !json.Valid(data) {
         return
@@ -211,7 +213,7 @@ func enableSyncGC() {
 
 func TestMain(m *testing.M) {
     // Avoid OOM
-    setMemLimit(8 * GB)
+    setMemLimit(12 * GB)
     enableSyncGC()
     time.Sleep(time.Millisecond)
     m.Run()

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -11410,7 +11410,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_395d350a: // _pow10_ceil_sig.g
+_LB_25169fe2: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14065,7 +14065,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_37fc1daa: // _pow10_ceil_sig_f32.g
+_LB_06ddba4e: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -6709,20 +6709,20 @@ LBB28_18:
 	LONG $0xffffcce9; BYTE $0xff               // jmp          LBB28_16, $-52(%rip)
 
 LBB28_19:
-	WORD $0x8b4d; BYTE $0x07             // movq         (%r15), %r8
-	LONG $0x084f8b4d                     // movq         $8(%r15), %r9
-	LONG $0x101c8d4d                     // leaq         (%r8,%rdx), %r11
-	WORD $0x2949; BYTE $0xd1             // subq         %rdx, %r9
-	LONG $0x20f98349                     // cmpq         $32, %r9
-	LONG $0x07e8820f; WORD $0x0000       // jb           LBB28_27, $2024(%rip)
-	LONG $0xffffba41; WORD $0xffff       // movl         $4294967295, %r10d
-	WORD $0x3145; BYTE $0xe4             // xorl         %r12d, %r12d
-	QUAD $0xfffffe3b056ff9c5             // vmovdqa      $-453(%rip), %xmm0  /* LCPI28_3(%rip) */
-	QUAD $0xfffffe430d6ff9c5             // vmovdqa      $-445(%rip), %xmm1  /* LCPI28_4(%rip) */
-	WORD $0xd231                         // xorl         %edx, %edx
-	WORD $0x3145; BYTE $0xff             // xorl         %r15d, %r15d
-	LONG $0x00002be9; BYTE $0x00         // jmp          LBB28_21, $43(%rip)
-	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
+	WORD $0x8b4d; BYTE $0x07       // movq         (%r15), %r8
+	LONG $0x084f8b4d               // movq         $8(%r15), %r9
+	LONG $0x101c8d4d               // leaq         (%r8,%rdx), %r11
+	WORD $0x2949; BYTE $0xd1       // subq         %rdx, %r9
+	LONG $0x20f98349               // cmpq         $32, %r9
+	LONG $0x07e88c0f; WORD $0x0000 // jl           LBB28_27, $2024(%rip)
+	LONG $0x0020bc41; WORD $0x0000 // movl         $32, %r12d
+	LONG $0xffffba41; WORD $0xffff // movl         $4294967295, %r10d
+	WORD $0xd231                   // xorl         %edx, %edx
+	QUAD $0xfffffe36056ff9c5       // vmovdqa      $-458(%rip), %xmm0  /* LCPI28_3(%rip) */
+	QUAD $0xfffffe3e0d6ff9c5       // vmovdqa      $-450(%rip), %xmm1  /* LCPI28_4(%rip) */
+	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
+	LONG $0x000028e9; BYTE $0x00   // jmp          LBB28_21, $40(%rip)
+	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
 LBB28_23:
 	WORD $0x3145; BYTE $0xff       // xorl         %r15d, %r15d
@@ -6733,8 +6733,8 @@ LBB28_24:
 	LONG $0x20c28348               // addq         $32, %rdx
 	LONG $0x214c8d4b; BYTE $0xe0   // leaq         $-32(%r9,%r12), %rcx
 	LONG $0xe0c48349               // addq         $-32, %r12
-	LONG $0x1ff98348               // cmpq         $31, %rcx
-	LONG $0x078b860f; WORD $0x0000 // jbe          LBB28_25, $1931(%rip)
+	LONG $0x3ff98348               // cmpq         $63, %rcx
+	LONG $0x078b8e0f; WORD $0x0000 // jle          LBB28_25, $1931(%rip)
 
 LBB28_21:
 	LONG $0x6f7ac1c4; WORD $0x1314             // vmovdqu      (%r11,%rdx), %xmm2
@@ -7291,11 +7291,11 @@ LBB28_25:
 	WORD $0x854d; BYTE $0xff       // testq        %r15, %r15
 	LONG $0x0020850f; WORD $0x0000 // jne          LBB28_82, $32(%rip)
 	WORD $0x0149; BYTE $0xd3       // addq         %rdx, %r11
-	WORD $0x014d; BYTE $0xe1       // addq         %r12, %r9
+	WORD $0x2949; BYTE $0xd1       // subq         %rdx, %r9
 
 LBB28_27:
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0052850f; WORD $0x0000 // jne          LBB28_86, $82(%rip)
+	LONG $0x00528f0f; WORD $0x0000 // jg           LBB28_86, $82(%rip)
 	LONG $0xfff7bee9; BYTE $0xff   // jmp          LBB28_16, $-2114(%rip)
 
 LBB28_81:
@@ -7310,7 +7310,7 @@ LBB28_82:
 	WORD $0xf748; BYTE $0xd2       // notq         %rdx
 	WORD $0x0149; BYTE $0xd1       // addq         %rdx, %r9
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_86, $36(%rip)
+	LONG $0x00248f0f; WORD $0x0000 // jg           LBB28_86, $36(%rip)
 	LONG $0xfff790e9; BYTE $0xff   // jmp          LBB28_16, $-2160(%rip)
 
 LBB28_84:
@@ -7319,7 +7319,7 @@ LBB28_84:
 	WORD $0x0149; BYTE $0xc3                   // addq         %rax, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
-	LONG $0xf771840f; WORD $0xffff             // je           LBB28_16, $-2191(%rip)
+	LONG $0xf7718e0f; WORD $0xffff             // jle          LBB28_16, $-2191(%rip)
 
 LBB28_86:
 	LONG $0x03b60f41                           // movzbl       (%r11), %eax
@@ -7332,7 +7332,7 @@ LBB28_86:
 	WORD $0x0149; BYTE $0xc3                   // addq         %rax, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
-	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_86, $-51(%rip)
+	LONG $0xffcd8f0f; WORD $0xffff             // jg           LBB28_86, $-51(%rip)
 	LONG $0xfff739e9; BYTE $0xff               // jmp          LBB28_16, $-2247(%rip)
 	BYTE $0x90                                 // .p2align 2, 0x90
 
@@ -11410,7 +11410,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_ba9a92e3: // _pow10_ceil_sig.g
+_LB_395d350a: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14065,7 +14065,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_ae3e0b42: // _pow10_ceil_sig_f32.g
+_LB_37fc1daa: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -12886,7 +12886,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_2f2edd29: // _pow10_ceil_sig.g
+_LB_e4586741: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -15541,7 +15541,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_241d96ec: // _pow10_ceil_sig_f32.g
+_LB_665783d0: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -7682,22 +7682,22 @@ LBB28_23:
 	LONG $0xffffcce9; BYTE $0xff               // jmp          LBB28_21, $-52(%rip)
 
 LBB28_24:
-	WORD $0x8b49; BYTE $0x0f                                             // movq         (%r15), %rcx
-	LONG $0x085f8b4d                                                     // movq         $8(%r15), %r11
-	LONG $0x244c8948; BYTE $0x18                                         // movq         %rcx, $24(%rsp)
-	LONG $0x113c8d4c                                                     // leaq         (%rcx,%rdx), %r15
-	WORD $0x2949; BYTE $0xd3                                             // subq         %rdx, %r11
-	LONG $0x20fb8349                                                     // cmpq         $32, %r11
-	LONG $0x06b0820f; WORD $0x0000                                       // jb           LBB28_33, $1712(%rip)
-	LONG $0xffffb941; WORD $0xffff                                       // movl         $4294967295, %r9d
-	WORD $0xdb31                                                         // xorl         %ebx, %ebx
-	QUAD $0xfffffd67056ffdc5                                             // vmovdqa      $-665(%rip), %ymm0  /* LCPI28_6(%rip) */
-	QUAD $0xfffffd7f0d6ffdc5                                             // vmovdqa      $-641(%rip), %ymm1  /* LCPI28_7(%rip) */
-	LONG $0xab918d45; WORD $0xaaaa; BYTE $0xaa                           // leal         $-1431655765(%r9), %r10d
-	WORD $0xd231                                                         // xorl         %edx, %edx
-	WORD $0xff31                                                         // xorl         %edi, %edi
-	LONG $0x000064e9; BYTE $0x00                                         // jmp          LBB28_26, $100(%rip)
-	QUAD $0x9090909090909090; LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+	WORD $0x8b49; BYTE $0x0f                   // movq         (%r15), %rcx
+	LONG $0x085f8b4d                           // movq         $8(%r15), %r11
+	LONG $0x244c8948; BYTE $0x18               // movq         %rcx, $24(%rsp)
+	LONG $0x113c8d4c                           // leaq         (%rcx,%rdx), %r15
+	WORD $0x2949; BYTE $0xd3                   // subq         %rdx, %r11
+	LONG $0x20fb8349                           // cmpq         $32, %r11
+	LONG $0x06b08c0f; WORD $0x0000             // jl           LBB28_33, $1712(%rip)
+	LONG $0x000020bb; BYTE $0x00               // movl         $32, %ebx
+	LONG $0xffffb941; WORD $0xffff             // movl         $4294967295, %r9d
+	WORD $0xd231                               // xorl         %edx, %edx
+	QUAD $0xfffffd62056ffdc5                   // vmovdqa      $-670(%rip), %ymm0  /* LCPI28_6(%rip) */
+	QUAD $0xfffffd7a0d6ffdc5                   // vmovdqa      $-646(%rip), %ymm1  /* LCPI28_7(%rip) */
+	LONG $0xab918d45; WORD $0xaaaa; BYTE $0xaa // leal         $-1431655765(%r9), %r10d
+	WORD $0xff31                               // xorl         %edi, %edi
+	LONG $0x000061e9; BYTE $0x00               // jmp          LBB28_26, $97(%rip)
+	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
 LBB28_29:
 	WORD $0xfe89                   // movl         %edi, %esi
@@ -7724,8 +7724,8 @@ LBB28_30:
 	LONG $0x20c28348               // addq         $32, %rdx
 	LONG $0x1b4c8d49; BYTE $0xe0   // leaq         $-32(%r11,%rbx), %rcx
 	LONG $0xe0c38348               // addq         $-32, %rbx
-	LONG $0x1ff98348               // cmpq         $31, %rcx
-	LONG $0x0615860f; WORD $0x0000 // jbe          LBB28_31, $1557(%rip)
+	LONG $0x3ff98348               // cmpq         $63, %rcx
+	LONG $0x06158e0f; WORD $0x0000 // jle          LBB28_31, $1557(%rip)
 
 LBB28_26:
 	LONG $0x6f7ec1c4; WORD $0x1714 // vmovdqu      (%r15,%rdx), %ymm2
@@ -8176,11 +8176,11 @@ LBB28_31:
 	WORD $0x8548; BYTE $0xff       // testq        %rdi, %rdi
 	LONG $0x0028850f; WORD $0x0000 // jne          LBB28_89, $40(%rip)
 	WORD $0x0149; BYTE $0xd7       // addq         %rdx, %r15
-	WORD $0x0149; BYTE $0xdb       // addq         %rbx, %r11
+	WORD $0x2949; BYTE $0xd3       // subq         %rdx, %r11
 
 LBB28_33:
 	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x005a850f; WORD $0x0000 // jne          LBB28_93, $90(%rip)
+	LONG $0x005a8f0f; WORD $0x0000 // jg           LBB28_93, $90(%rip)
 	LONG $0xfff8f1e9; BYTE $0xff   // jmp          LBB28_21, $-1807(%rip)
 
 LBB28_87:
@@ -8199,7 +8199,7 @@ LBB28_89:
 	WORD $0xf748; BYTE $0xd2       // notq         %rdx
 	WORD $0x0149; BYTE $0xd3       // addq         %rdx, %r11
 	WORD $0x854d; BYTE $0xdb       // testq        %r11, %r11
-	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_93, $36(%rip)
+	LONG $0x00248f0f; WORD $0x0000 // jg           LBB28_93, $36(%rip)
 	LONG $0xfff8bbe9; BYTE $0xff   // jmp          LBB28_21, $-1861(%rip)
 
 LBB28_91:
@@ -8208,7 +8208,7 @@ LBB28_91:
 	WORD $0x0149; BYTE $0xc7                   // addq         %rax, %r15
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xd3                   // addq         %rdx, %r11
-	LONG $0xf89c840f; WORD $0xffff             // je           LBB28_21, $-1892(%rip)
+	LONG $0xf89c8e0f; WORD $0xffff             // jle          LBB28_21, $-1892(%rip)
 
 LBB28_93:
 	LONG $0x07b60f41                           // movzbl       (%r15), %eax
@@ -8221,7 +8221,7 @@ LBB28_93:
 	WORD $0x0149; BYTE $0xc7                   // addq         %rax, %r15
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xd3                   // addq         %rdx, %r11
-	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_93, $-51(%rip)
+	LONG $0xffcd8f0f; WORD $0xffff             // jg           LBB28_93, $-51(%rip)
 	LONG $0xfff864e9; BYTE $0xff               // jmp          LBB28_21, $-1948(%rip)
 
 	// .p2align 2, 0x90
@@ -12886,7 +12886,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_d6605758: // _pow10_ceil_sig.g
+_LB_2f2edd29: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -15541,7 +15541,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_4a64d01e: // _pow10_ceil_sig_f32.g
+_LB_241d96ec: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/internal/native/sse/native_amd64.s
+++ b/internal/native/sse/native_amd64.s
@@ -11556,7 +11556,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_2f95a749: // _pow10_ceil_sig.g
+_LB_d943ffab: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14211,7 +14211,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_1ce9cabf: // _pow10_ceil_sig_f32.g
+_LB_1191cfee: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/internal/native/sse/native_amd64.s
+++ b/internal/native/sse/native_amd64.s
@@ -6760,20 +6760,20 @@ LBB28_18:
 	LONG $0xffffcee9; BYTE $0xff               // jmp          LBB28_16, $-50(%rip)
 
 LBB28_19:
-	WORD $0x8b4d; BYTE $0x06               // movq         (%r14), %r8
-	LONG $0x084e8b4d                       // movq         $8(%r14), %r9
-	LONG $0x101c8d4d                       // leaq         (%r8,%rdx), %r11
-	WORD $0x2949; BYTE $0xd1               // subq         %rdx, %r9
-	LONG $0x20f98349                       // cmpq         $32, %r9
-	LONG $0x098c820f; WORD $0x0000         // jb           LBB28_27, $2444(%rip)
-	LONG $0xffffba41; WORD $0xffff         // movl         $4294967295, %r10d
-	WORD $0x3145; BYTE $0xff               // xorl         %r15d, %r15d
-	QUAD $0xfffffe3c056f0f66               // movdqa       $-452(%rip), %xmm0  /* LCPI28_3(%rip) */
-	QUAD $0xfffffe440d6f0f66               // movdqa       $-444(%rip), %xmm1  /* LCPI28_4(%rip) */
-	WORD $0xd231                           // xorl         %edx, %edx
-	WORD $0x3145; BYTE $0xf6               // xorl         %r14d, %r14d
-	LONG $0x00002ce9; BYTE $0x00           // jmp          LBB28_21, $44(%rip)
-	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+	WORD $0x8b4d; BYTE $0x06                   // movq         (%r14), %r8
+	LONG $0x084e8b4d                           // movq         $8(%r14), %r9
+	LONG $0x101c8d4d                           // leaq         (%r8,%rdx), %r11
+	WORD $0x2949; BYTE $0xd1                   // subq         %rdx, %r9
+	LONG $0x20f98349                           // cmpq         $32, %r9
+	LONG $0x098c8c0f; WORD $0x0000             // jl           LBB28_27, $2444(%rip)
+	LONG $0x0020bf41; WORD $0x0000             // movl         $32, %r15d
+	LONG $0xffffba41; WORD $0xffff             // movl         $4294967295, %r10d
+	WORD $0xd231                               // xorl         %edx, %edx
+	QUAD $0xfffffe37056f0f66                   // movdqa       $-457(%rip), %xmm0  /* LCPI28_3(%rip) */
+	QUAD $0xfffffe3f0d6f0f66                   // movdqa       $-449(%rip), %xmm1  /* LCPI28_4(%rip) */
+	WORD $0x3145; BYTE $0xf6                   // xorl         %r14d, %r14d
+	LONG $0x000029e9; BYTE $0x00               // jmp          LBB28_21, $41(%rip)
+	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 LBB28_23:
 	WORD $0x3145; BYTE $0xf6       // xorl         %r14d, %r14d
@@ -6784,8 +6784,8 @@ LBB28_24:
 	LONG $0x20c28348               // addq         $32, %rdx
 	LONG $0x394c8d4b; BYTE $0xe0   // leaq         $-32(%r9,%r15), %rcx
 	LONG $0xe0c78349               // addq         $-32, %r15
-	LONG $0x1ff98348               // cmpq         $31, %rcx
-	LONG $0x092e860f; WORD $0x0000 // jbe          LBB28_25, $2350(%rip)
+	LONG $0x3ff98348               // cmpq         $63, %rcx
+	LONG $0x092e8e0f; WORD $0x0000 // jle          LBB28_25, $2350(%rip)
 
 LBB28_21:
 	LONG $0x6f0f41f3; WORD $0x1314             // movdqu       (%r11,%rdx), %xmm2
@@ -7437,11 +7437,11 @@ LBB28_25:
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
 	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_84, $36(%rip)
 	WORD $0x0149; BYTE $0xd3       // addq         %rdx, %r11
-	WORD $0x014d; BYTE $0xf9       // addq         %r15, %r9
+	WORD $0x2949; BYTE $0xd1       // subq         %rdx, %r9
 
 LBB28_27:
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0056850f; WORD $0x0000 // jne          LBB28_88, $86(%rip)
+	LONG $0x00568f0f; WORD $0x0000 // jg           LBB28_88, $86(%rip)
 	LONG $0xfff61ce9; BYTE $0xff   // jmp          LBB28_16, $-2532(%rip)
 
 LBB28_83:
@@ -7457,7 +7457,7 @@ LBB28_84:
 	WORD $0xf748; BYTE $0xd2       // notq         %rdx
 	WORD $0x0149; BYTE $0xd1       // addq         %rdx, %r9
 	WORD $0x854d; BYTE $0xc9       // testq        %r9, %r9
-	LONG $0x0024850f; WORD $0x0000 // jne          LBB28_88, $36(%rip)
+	LONG $0x00248f0f; WORD $0x0000 // jg           LBB28_88, $36(%rip)
 	LONG $0xfff5eae9; BYTE $0xff   // jmp          LBB28_16, $-2582(%rip)
 
 LBB28_86:
@@ -7466,7 +7466,7 @@ LBB28_86:
 	WORD $0x0149; BYTE $0xc3                   // addq         %rax, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
-	LONG $0xf5cb840f; WORD $0xffff             // je           LBB28_16, $-2613(%rip)
+	LONG $0xf5cb8e0f; WORD $0xffff             // jle          LBB28_16, $-2613(%rip)
 
 LBB28_88:
 	LONG $0x03b60f41                           // movzbl       (%r11), %eax
@@ -7479,7 +7479,7 @@ LBB28_88:
 	WORD $0x0149; BYTE $0xc3                   // addq         %rax, %r11
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x0149; BYTE $0xc9                   // addq         %rcx, %r9
-	LONG $0xffcd850f; WORD $0xffff             // jne          LBB28_88, $-51(%rip)
+	LONG $0xffcd8f0f; WORD $0xffff             // jg           LBB28_88, $-51(%rip)
 	LONG $0xfff593e9; BYTE $0xff               // jmp          LBB28_16, $-2669(%rip)
 	WORD $0x9090                               // .p2align 2, 0x90
 
@@ -11556,7 +11556,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_1eff03ac: // _pow10_ceil_sig.g
+_LB_2f95a749: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14211,7 +14211,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_43ccba7c: // _pow10_ceil_sig_f32.g
+_LB_1ce9cabf: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433

--- a/native/scanning.c
+++ b/native/scanning.c
@@ -1634,7 +1634,7 @@ static always_inline long skip_array_fast(const GoString *src, long *p) {
 
 static always_inline long skip_string_fast(const GoString *src, long *p) {
     const char* s = src->buf + *p;
-    size_t nb = src->len - *p;
+    long nb = src->len - *p;
     long vi = *p - 1;
     uint64_t prev_bs = 0, escaped;
 


### PR DESCRIPTION
1. fixed out-of-bound for single unclosed string.
2. enhanced the ast fuzz test. we got from the random data directly,  and did not find any panics.

```
fuzz: elapsed: 1h11m38s, execs: 4174743 (102/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m41s, execs: 4174991 (83/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m44s, execs: 4175047 (19/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m47s, execs: 4177154 (702/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m50s, execs: 4177154 (0/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m53s, execs: 4178579 (475/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m56s, execs: 4180035 (485/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h11m59s, execs: 4181583 (516/sec), new interesting: 60 (total: 3216)
fuzz: elapsed: 1h12m2s, execs: 4183057 (491/sec), new interesting: 61 (total: 3217)
fuzz: elapsed: 1h12m5s, execs: 4187475 (1473/sec), new interesting: 61 (total: 3217)
fuzz: elapsed: 1h12m8s, execs: 4187888 (138/sec), new interesting: 61 (total: 3217)
fuzz: elapsed: 1h12m11s, execs: 4188476 (196/sec), new interesting: 61 (total: 3217)
fuzz: elapsed: 1h12m14s, execs: 4190240 (588/sec), new interesting: 61 (total: 3217)
```