### PR TITLE
fix: export not found error in ast get

### DIFF
--- a/ast/api_amd64.go
+++ b/ast/api_amd64.go
@@ -116,6 +116,10 @@ func (self *Searcher) GetByPath(path ...interface{}) (Node, error) {
     self.parser.p = 0
     start, err = self.parser.getByPath(path...)
     if err != 0 {
+        // for compatibility with old version
+        if err == types.ERR_NOT_FOUND {
+            return Node{}, ErrNotExist
+        }
         return Node{}, self.parser.syntaxError(err)
     }
 

--- a/ast/search_test.go
+++ b/ast/search_test.go
@@ -84,6 +84,26 @@ func TestExportError(t *testing.T) {
     if err.Error() != `"Syntax error at index 1: invalid char\n\n\t{:\"b\"]\n\t.^....\n"` {
         t.Fatal(err)
     }
+
+    data = `{"a":null}`
+    p = NewSearcher(data)
+    _, err = p.GetByPath("b")
+    if err == nil {
+        t.Fatal()
+    }
+    if err != ErrNotExist {
+        t.Fatal(err)
+    }
+
+    data = `[1,2,3]`
+    p = NewSearcher(data)
+    _, err = p.GetByPath(4)
+    if err == nil {
+        t.Fatal()
+    }
+    if err != ErrNotExist {
+        t.Fatal(err)
+    }
 }
 
 func TestSearcher_GetByPath(t *testing.T) {

--- a/internal/native/avx/native_amd64.s
+++ b/internal/native/avx/native_amd64.s
@@ -196,7 +196,7 @@ LBB1_6:
 	LONG $0x000124b8; BYTE $0x00               // movl         $292, %eax
 	WORD $0x2944; BYTE $0xc8                   // subl         %r9d, %eax
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0xba158d48; WORD $0x00af; BYTE $0x00 // leaq         $44986(%rip), %rdx  /* _pow10_ceil_sig.g(%rip) */
+	LONG $0xda158d48; WORD $0x00af; BYTE $0x00 // leaq         $45018(%rip), %rdx  /* _pow10_ceil_sig.g(%rip) */
 	LONG $0x101c8b4c                           // movq         (%rax,%rdx), %r11
 	LONG $0x106c8b4c; BYTE $0x08               // movq         $8(%rax,%rdx), %r13
 	WORD $0xc1fe                               // incb         %cl
@@ -378,7 +378,7 @@ LBB1_51:
 	LONG $0x009d820f; WORD $0x0000             // jb           LBB1_64, $157(%rip)
 	LONG $0x01678d4d                           // leaq         $1(%r15), %r12
 	WORD $0x894c; BYTE $0xe6                   // movq         %r12, %rsi
-	LONG $0x00774fe8; BYTE $0x00               // callq        _format_significand, $30543(%rip)
+	LONG $0x00776fe8; BYTE $0x00               // callq        _format_significand, $30575(%rip)
 	WORD $0x8948; BYTE $0xc3                   // movq         %rax, %rbx
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
@@ -413,7 +413,7 @@ LBB1_60:
 	WORD $0x0c8d; BYTE $0x12                   // leal         (%rdx,%rdx), %ecx
 	WORD $0x0c8d; BYTE $0x89                   // leal         (%rcx,%rcx,4), %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
-	LONG $0x940d8d48; WORD $0x00ab; BYTE $0x00 // leaq         $43924(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xb40d8d48; WORD $0x00ab; BYTE $0x00 // leaq         $43956(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x510cb70f                           // movzwl       (%rcx,%rdx,2), %ecx
 	LONG $0x024b8966                           // movw         %cx, $2(%rbx)
 	WORD $0x300c                               // orb          $48, %al
@@ -495,7 +495,7 @@ LBB1_61:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
 	LONG $0x00878c0f; WORD $0x0000             // jl           LBB1_63, $135(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0x4a0d8d48; WORD $0x00aa; BYTE $0x00 // leaq         $43594(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x6a0d8d48; WORD $0x00aa; BYTE $0x00 // leaq         $43626(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x02438966                           // movw         %ax, $2(%rbx)
 	LONG $0x04c38348                           // addq         $4, %rbx
@@ -689,7 +689,7 @@ LBB1_77:
 LBB1_78:
 	WORD $0x894c; BYTE $0xfe       // movq         %r15, %rsi
 	WORD $0xf8c5; BYTE $0x77       // vzeroupper
-	LONG $0x007246e8; BYTE $0x00   // callq        _format_significand, $29254(%rip)
+	LONG $0x007266e8; BYTE $0x00   // callq        _format_significand, $29286(%rip)
 	LONG $0x90909090; WORD $0x9090 // .p2align 4, 0x90
 
 LBB1_79:
@@ -916,7 +916,7 @@ LBB2_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0xf00d8d48; WORD $0x00a3; BYTE $0x00 // leaq         $41968(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x100d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42000(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -932,7 +932,7 @@ LBB2_2:
 
 LBB2_5:
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
-	LONG $0xa9158d4c; WORD $0x00a3; BYTE $0x00 // leaq         $41897(%rip), %r10  /* _Digits(%rip) */
+	LONG $0xc9158d4c; WORD $0x00a3; BYTE $0x00 // leaq         $41929(%rip), %r10  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
 LBB2_6:
@@ -964,7 +964,7 @@ LBB2_7:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xca                   // movzwl       %dx, %ecx
-	LONG $0x31158d48; WORD $0x00a3; BYTE $0x00 // leaq         $41777(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x51158d48; WORD $0x00a3; BYTE $0x00 // leaq         $41809(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4b894166; BYTE $0xfe               // movw         %cx, $-2(%r11)
 	LONG $0xfec38349                           // addq         $-2, %r11
@@ -974,7 +974,7 @@ LBB2_9:
 	WORD $0xfa83; BYTE $0x0a                   // cmpl         $10, %edx
 	LONG $0x0018820f; WORD $0x0000             // jb           LBB2_11, $24(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x100d8d48; WORD $0x00a3; BYTE $0x00 // leaq         $41744(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x300d8d48; WORD $0x00a3; BYTE $0x00 // leaq         $41776(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x43894166; BYTE $0xfe               // movw         %ax, $-2(%r11)
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
@@ -1050,7 +1050,7 @@ _u64toa:
 	WORD $0x0148; BYTE $0xc0                   // addq         %rax, %rax
 	LONG $0x03e8fe81; WORD $0x0000             // cmpl         $1000, %esi
 	LONG $0x0016820f; WORD $0x0000             // jb           LBB4_3, $22(%rip)
-	LONG $0x3c0d8d48; WORD $0x00a2; BYTE $0x00 // leaq         $41532(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x5c0d8d48; WORD $0x00a2; BYTE $0x00 // leaq         $41564(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x0c8a; BYTE $0x0a                   // movb         (%rdx,%rcx), %cl
 	WORD $0x0f88                               // movb         %cl, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1064,14 +1064,14 @@ LBB4_3:
 LBB4_4:
 	WORD $0xb70f; BYTE $0xd2                   // movzwl       %dx, %edx
 	LONG $0x01ca8348                           // orq          $1, %rdx
-	LONG $0x14358d48; WORD $0x00a2; BYTE $0x00 // leaq         $41492(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x34358d48; WORD $0x00a2; BYTE $0x00 // leaq         $41524(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x32                   // movb         (%rdx,%rsi), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
 	WORD $0x1488; BYTE $0x37                   // movb         %dl, (%rdi,%rsi)
 
 LBB4_6:
-	LONG $0x03158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41475(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x23158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41507(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x10                   // movb         (%rax,%rdx), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
@@ -1080,7 +1080,7 @@ LBB4_6:
 LBB4_7:
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0xeb158d48; WORD $0x00a1; BYTE $0x00 // leaq         $41451(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x0b158d48; WORD $0x00a2; BYTE $0x00 // leaq         $41483(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x10                   // movb         (%rax,%rdx), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xc1ff                               // incl         %ecx
@@ -1127,7 +1127,7 @@ LBB4_8:
 	WORD $0x014d; BYTE $0xdb                   // addq         %r11, %r11
 	LONG $0x9680fe81; WORD $0x0098             // cmpl         $10000000, %esi
 	LONG $0x0017820f; WORD $0x0000             // jb           LBB4_11, $23(%rip)
-	LONG $0x49058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41289(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x69058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41321(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x02048a41                           // movb         (%r10,%rax), %al
 	WORD $0x0788                               // movb         %al, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1141,14 +1141,14 @@ LBB4_11:
 LBB4_12:
 	WORD $0x8944; BYTE $0xd0                   // movl         %r10d, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x1d358d48; WORD $0x00a1; BYTE $0x00 // leaq         $41245(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x3d358d48; WORD $0x00a1; BYTE $0x00 // leaq         $41277(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
 	WORD $0x0488; BYTE $0x37                   // movb         %al, (%rdi,%rsi)
 
 LBB4_14:
-	LONG $0x0c058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41228(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x2c058d48; WORD $0x00a1; BYTE $0x00 // leaq         $41260(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x01048a41                           // movb         (%r9,%rax), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
@@ -1157,7 +1157,7 @@ LBB4_14:
 LBB4_15:
 	LONG $0xc1b70f41                           // movzwl       %r9w, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0xf2358d48; WORD $0x00a0; BYTE $0x00 // leaq         $41202(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x12358d48; WORD $0x00a1; BYTE $0x00 // leaq         $41234(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0x0488; BYTE $0x17                   // movb         %al, (%rdi,%rdx)
@@ -1239,7 +1239,7 @@ LBB4_16:
 	LONG $0x000010b9; BYTE $0x00               // movl         $16, %ecx
 	WORD $0xc129                               // subl         %eax, %ecx
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0xf8158d48; WORD $0x00c6; BYTE $0x00 // leaq         $50936(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x18158d48; WORD $0x00c7; BYTE $0x00 // leaq         $50968(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x0071e2c4; WORD $0x1004             // vpshufb      (%rax,%rdx), %xmm1, %xmm0
 	LONG $0x077ffac5                           // vmovdqu      %xmm0, (%rdi)
 	WORD $0xc889                               // movl         %ecx, %eax
@@ -1265,7 +1265,7 @@ LBB4_20:
 	WORD $0xfa83; BYTE $0x63                   // cmpl         $99, %edx
 	LONG $0x001f870f; WORD $0x0000             // ja           LBB4_22, $31(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x3b0d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40763(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x5b0d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40795(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x41                   // movb         (%rcx,%rax,2), %dl
 	LONG $0x0141448a                           // movb         $1(%rcx,%rax,2), %al
 	WORD $0x1788                               // movb         %dl, (%rdi)
@@ -1290,7 +1290,7 @@ LBB4_22:
 	WORD $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xe60d8d48; WORD $0x009e; BYTE $0x00 // leaq         $40678(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x060d8d48; WORD $0x009f; BYTE $0x00 // leaq         $40710(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x41                   // movb         (%rcx,%rax,2), %dl
 	LONG $0x0141448a                           // movb         $1(%rcx,%rax,2), %al
 	WORD $0x5788; BYTE $0x01                   // movb         %dl, $1(%rdi)
@@ -1302,7 +1302,7 @@ LBB4_24:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0xc0058d4c; WORD $0x009e; BYTE $0x00 // leaq         $40640(%rip), %r8  /* _Digits(%rip) */
+	LONG $0xe0058d4c; WORD $0x009e; BYTE $0x00 // leaq         $40672(%rip), %r8  /* _Digits(%rip) */
 	LONG $0x400c8a41                           // movb         (%r8,%rax,2), %cl
 	LONG $0x40448a41; BYTE $0x01               // movb         $1(%r8,%rax,2), %al
 	WORD $0x0f88                               // movb         %cl, (%rdi)
@@ -1392,8 +1392,8 @@ _quote:
 	WORD $0x8948; BYTE $0xf0                   // movq         %rsi, %rax
 	WORD $0x8b4c; BYTE $0x31                   // movq         (%rcx), %r14
 	LONG $0x01c0f641                           // testb        $1, %r8b
-	LONG $0x4b0d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50507(%rip), %rcx  /* __SingleQuoteTab(%rip) */
-	LONG $0x44058d4c; WORD $0x00d5; BYTE $0x00 // leaq         $54596(%rip), %r8  /* __DoubleQuoteTab(%rip) */
+	LONG $0x6b0d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50539(%rip), %rcx  /* __SingleQuoteTab(%rip) */
+	LONG $0x64058d4c; WORD $0x00d5; BYTE $0x00 // leaq         $54628(%rip), %r8  /* __DoubleQuoteTab(%rip) */
 	LONG $0xc1440f4c                           // cmoveq       %rcx, %r8
 	QUAD $0x00000000f50c8d48                   // leaq         (,%rsi,8), %rcx
 	WORD $0x3949; BYTE $0xce                   // cmpq         %rcx, %r14
@@ -1494,7 +1494,7 @@ LBB5_15:
 	LONG $0x34b60f41; BYTE $0x24               // movzbl       (%r12), %esi
 	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
 	LONG $0x04e2c148                           // shlq         $4, %rdx
-	LONG $0xad1d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50093(%rip), %rbx  /* __SingleQuoteTab(%rip) */
+	LONG $0xcd1d8d48; WORD $0x00c3; BYTE $0x00 // leaq         $50125(%rip), %rbx  /* __SingleQuoteTab(%rip) */
 	LONG $0x1a3c8348; BYTE $0x00               // cmpq         $0, (%rdx,%rbx)
 	LONG $0x0082850f; WORD $0x0000             // jne          LBB5_21, $130(%rip)
 	LONG $0xff518d48                           // leaq         $-1(%rcx), %rdx
@@ -1711,7 +1711,7 @@ LBB5_74:
 	LONG $0x00024de9; BYTE $0x00 // jmp          LBB5_76, $589(%rip)
 
 LBB5_51:
-	LONG $0xf60d8d4c; WORD $0x00e0; BYTE $0x00 // leaq         $57590(%rip), %r9  /* __EscTab(%rip) */
+	LONG $0x160d8d4c; WORD $0x00e1; BYTE $0x00 // leaq         $57622(%rip), %r9  /* __EscTab(%rip) */
 	QUAD $0xfffffb4e056ff9c5                   // vmovdqa      $-1202(%rip), %xmm0  /* LCPI5_0(%rip) */
 	QUAD $0xfffffb560d6ff9c5                   // vmovdqa      $-1194(%rip), %xmm1  /* LCPI5_1(%rip) */
 	QUAD $0xfffffb5e156ff9c5                   // vmovdqa      $-1186(%rip), %xmm2  /* LCPI5_2(%rip) */
@@ -1935,7 +1935,7 @@ _unquote:
 	LONG $0xb845894c                           // movq         %r8, $-72(%rbp)
 	WORD $0x8945; BYTE $0xc2                   // movl         %r8d, %r10d
 	LONG $0x01e28341                           // andl         $1, %r10d
-	LONG $0x3a058d4c; WORD $0x00df; BYTE $0x00 // leaq         $57146(%rip), %r8  /* __UnquoteTab(%rip) */
+	LONG $0x5a058d4c; WORD $0x00df; BYTE $0x00 // leaq         $57178(%rip), %r8  /* __UnquoteTab(%rip) */
 	QUAD $0xffffffb2056ff9c5                   // vmovdqa      $-78(%rip), %xmm0  /* LCPI6_0(%rip) */
 	WORD $0x8949; BYTE $0xf9                   // movq         %rdi, %r9
 	WORD $0x8949; BYTE $0xf5                   // movq         %rsi, %r13
@@ -2625,7 +2625,7 @@ _html_escape:
 	QUAD $0xffffff910d6ff9c5                   // vmovdqa      $-111(%rip), %xmm1  /* LCPI7_1(%rip) */
 	QUAD $0xffffff99156ff9c5                   // vmovdqa      $-103(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD $0xffffffa11d6ff9c5                   // vmovdqa      $-95(%rip), %xmm3  /* LCPI7_3(%rip) */
-	LONG $0xda1d8d4c; WORD $0x00d6; BYTE $0x00 // leaq         $55002(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0xfa1d8d4c; WORD $0x00d6; BYTE $0x00 // leaq         $55034(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x8949; BYTE $0xff                   // movq         %rdi, %r15
 	LONG $0xd0558b4c                           // movq         $-48(%rbp), %r10
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
@@ -3009,7 +3009,7 @@ LBB8_5:
 	WORD $0xd348; BYTE $0xe7                   // shlq         %cl, %rdi
 	WORD $0xc389                               // movl         %eax, %ebx
 	LONG $0x04e3c148                           // shlq         $4, %rbx
-	LONG $0x71358d4c; WORD $0x005c; BYTE $0x00 // leaq         $23665(%rip), %r14  /* _POW10_M128_TAB(%rip) */
+	LONG $0x91358d4c; WORD $0x005c; BYTE $0x00 // leaq         $23697(%rip), %r14  /* _POW10_M128_TAB(%rip) */
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	LONG $0x3364f74a; BYTE $0x08               // mulq         $8(%rbx,%r14)
 	WORD $0x8949; BYTE $0xc7                   // movq         %rax, %r15
@@ -3136,7 +3136,7 @@ LBB9_5:
 	LONG $0xd05d8948                           // movq         %rbx, $-48(%rbp)
 	LONG $0x005a8e0f; WORD $0x0000             // jle          LBB9_12, $90(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0x58358d4c; WORD $0x0086; BYTE $0x00 // leaq         $34392(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x78358d4c; WORD $0x0086; BYTE $0x00 // leaq         $34424(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_8, $45(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
@@ -3149,7 +3149,7 @@ LBB9_10:
 LBB9_11:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x005575e8; BYTE $0x00 // callq        _right_shift, $21877(%rip)
+	LONG $0x005595e8; BYTE $0x00 // callq        _right_shift, $21909(%rip)
 
 LBB9_7:
 	WORD $0x0141; BYTE $0xdc       // addl         %ebx, %r12d
@@ -3166,7 +3166,7 @@ LBB9_8:
 	LONG $0xffffd3e9; BYTE $0xff   // jmp          LBB9_7, $-45(%rip)
 
 LBB9_12:
-	LONG $0x01358d4c; WORD $0x0086; BYTE $0x00 // leaq         $34305(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x21358d4c; WORD $0x0086; BYTE $0x00 // leaq         $34337(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_14, $45(%rip)
 
 LBB9_18:
@@ -3178,7 +3178,7 @@ LBB9_18:
 LBB9_20:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x005326e8; BYTE $0x00 // callq        _left_shift, $21286(%rip)
+	LONG $0x005346e8; BYTE $0x00 // callq        _left_shift, $21318(%rip)
 	LONG $0x14478b41             // movl         $20(%r15), %eax
 
 LBB9_13:
@@ -3221,7 +3221,7 @@ LBB9_21:
 LBB9_25:
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x00003cbe; BYTE $0x00   // movl         $60, %esi
-	LONG $0x005483e8; BYTE $0x00   // callq        _right_shift, $21635(%rip)
+	LONG $0x0054a3e8; BYTE $0x00   // callq        _right_shift, $21667(%rip)
 	LONG $0x3cc48341               // addl         $60, %r12d
 	LONG $0x88fc8341               // cmpl         $-120, %r12d
 	LONG $0xffe58c0f; WORD $0xffff // jl           LBB9_25, $-27(%rip)
@@ -3247,7 +3247,7 @@ LBB9_31:
 	WORD $0xf741; BYTE $0xdc       // negl         %r12d
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	WORD $0x8944; BYTE $0xe6       // movl         %r12d, %esi
-	LONG $0x005430e8; BYTE $0x00   // callq        _right_shift, $21552(%rip)
+	LONG $0x005450e8; BYTE $0x00   // callq        _right_shift, $21584(%rip)
 	LONG $0xfc02be41; WORD $0xffff // movl         $-1022, %r14d
 
 LBB9_32:
@@ -3255,7 +3255,7 @@ LBB9_32:
 	LONG $0x000d840f; WORD $0x0000 // je           LBB9_34, $13(%rip)
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x000035be; BYTE $0x00   // movl         $53, %esi
-	LONG $0x005222e8; BYTE $0x00   // callq        _left_shift, $21026(%rip)
+	LONG $0x005242e8; BYTE $0x00   // callq        _left_shift, $21058(%rip)
 
 LBB9_34:
 	LONG $0x14478b41                           // movl         $20(%r15), %eax
@@ -4306,7 +4306,7 @@ LCPI14_2:
 _advance_string:
 	WORD $0xc1f6; BYTE $0x20       // testb        $32, %cl
 	LONG $0x0005850f; WORD $0x0000 // jne          LBB14_2, $5(%rip)
-	LONG $0x004852e9; BYTE $0x00   // jmp          _advance_string_default, $18514(%rip)
+	LONG $0x004872e9; BYTE $0x00   // jmp          _advance_string_default, $18546(%rip)
 
 LBB14_2:
 	BYTE $0x55                                               // pushq        %rbp
@@ -5011,7 +5011,7 @@ LBB15_62:
 	WORD $0xfe83; BYTE $0x17                   // cmpl         $23, %esi
 	LONG $0x00a48c0f; WORD $0x0000             // jl           LBB15_73, $164(%rip)
 	WORD $0x468d; BYTE $0xea                   // leal         $-22(%rsi), %eax
-	LONG $0xc00d8d48; WORD $0x00e0; BYTE $0x00 // leaq         $57536(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0xe00d8d48; WORD $0x00e0; BYTE $0x00 // leaq         $57568(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc8               // vmovsd       %xmm0, $-56(%rbp)
 	LONG $0x000016b8; BYTE $0x00               // movl         $22, %eax
@@ -5033,7 +5033,7 @@ LBB15_70:
 	WORD $0xfe83; BYTE $0xea                   // cmpl         $-22, %esi
 	LONG $0x0094820f; WORD $0x0000             // jb           LBB15_77, $148(%rip)
 	WORD $0xdef7                               // negl         %esi
-	LONG $0x77058d48; WORD $0x00e0; BYTE $0x00 // leaq         $57463(%rip), %rax  /* _P10_TAB(%rip) */
+	LONG $0x97058d48; WORD $0x00e0; BYTE $0x00 // leaq         $57495(%rip), %rax  /* _P10_TAB(%rip) */
 	LONG $0x045efbc5; BYTE $0xf0               // vdivsd       (%rax,%rsi,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc8               // vmovsd       %xmm0, $-56(%rbp)
 	LONG $0x0000dee9; BYTE $0x00               // jmp          LBB15_81, $222(%rip)
@@ -5064,7 +5064,7 @@ LBB15_74:
 	LONG $0xc82ef9c5                           // vucomisd     %xmm0, %xmm1
 	LONG $0x0018870f; WORD $0x0000             // ja           LBB15_77, $24(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0xfb0d8d48; WORD $0x00df; BYTE $0x00 // leaq         $57339(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x1b0d8d48; WORD $0x00e0; BYTE $0x00 // leaq         $57371(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x0459fbc5; BYTE $0xc1               // vmulsd       (%rcx,%rax,8), %xmm0, %xmm0
 	LONG $0x4511fbc5; BYTE $0xc8               // vmovsd       %xmm0, $-56(%rbp)
 	LONG $0x000062e9; BYTE $0x00               // jmp          LBB15_81, $98(%rip)
@@ -7503,7 +7503,7 @@ LBB29_2:
 	WORD $0x7b3c                           // cmpb         $123, %al
 	LONG $0xc865894c                       // movq         %r12, $-56(%rbp)
 	LONG $0xc06d894c                       // movq         %r13, $-64(%rbp)
-	LONG $0x05fb850f; WORD $0x0000         // jne          LBB29_80, $1531(%rip)
+	LONG $0x060a850f; WORD $0x0000         // jne          LBB29_81, $1546(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
 LBB29_4:
@@ -7512,7 +7512,7 @@ LBB29_4:
 	WORD $0x894c; BYTE $0xfa       // movq         %r15, %rdx
 	LONG $0xffd28fe8; BYTE $0xff   // callq        _advance_ns, $-11633(%rip)
 	WORD $0x223c                   // cmpb         $34, %al
-	LONG $0x05d8850f; WORD $0x0000 // jne          LBB29_80, $1496(%rip)
+	LONG $0x05e7850f; WORD $0x0000 // jne          LBB29_81, $1511(%rip)
 	LONG $0x08458b49               // movq         $8(%r13), %rax
 	WORD $0x894c; BYTE $0xfb       // movq         %r15, %rbx
 	WORD $0x8b4c; BYTE $0x28       // movq         (%rax), %r13
@@ -7522,9 +7522,9 @@ LBB29_4:
 	WORD $0x8b4c; BYTE $0x23       // movq         (%rbx), %r12
 	WORD $0x894c; BYTE $0xe6       // movq         %r12, %rsi
 	LONG $0xb8558d48               // leaq         $-72(%rbp), %rdx
-	LONG $0x001defe8; BYTE $0x00   // callq        _advance_string_default, $7663(%rip)
+	LONG $0x001e0fe8; BYTE $0x00   // callq        _advance_string_default, $7695(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x05c0880f; WORD $0x0000 // js           LBB29_82, $1472(%rip)
+	LONG $0x05cf880f; WORD $0x0000 // js           LBB29_83, $1487(%rip)
 	WORD $0x8949; BYTE $0xd8       // movq         %rbx, %r8
 	WORD $0x8948; BYTE $0x03       // movq         %rax, (%rbx)
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
@@ -7609,7 +7609,7 @@ LBB29_25:
 	WORD $0x394c; BYTE $0xe0                   // cmpq         %r12, %rax
 	WORD $0x8949; BYTE $0xc7                   // movq         %rax, %r15
 	LONG $0x03d6860f; WORD $0x0000             // jbe          LBB29_71, $982(%rip)
-	LONG $0xa7358d4c; WORD $0x0094; BYTE $0x00 // leaq         $38055(%rip), %r14  /* __UnquoteTab(%rip) */
+	LONG $0xc7358d4c; WORD $0x0094; BYTE $0x00 // leaq         $38087(%rip), %r14  /* __UnquoteTab(%rip) */
 	LONG $0xd05d8d48                           // leaq         $-48(%rbp), %rbx
 
 LBB29_28:
@@ -7620,13 +7620,13 @@ LBB29_28:
 	WORD $0x294c; BYTE $0xe1                   // subq         %r12, %rcx
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x8548; BYTE $0xc9                   // testq        %rcx, %rcx
-	LONG $0x04948e0f; WORD $0x0000             // jle          LBB29_86, $1172(%rip)
+	LONG $0x04a38e0f; WORD $0x0000             // jle          LBB29_87, $1187(%rip)
 	LONG $0x54b60f41; WORD $0x0124             // movzbl       $1(%r12), %edx
 	LONG $0x321c8a46                           // movb         (%rdx,%r14), %r11b
 	LONG $0xfffb8041                           // cmpb         $-1, %r11b
 	LONG $0x003e840f; WORD $0x0000             // je           LBB29_35, $62(%rip)
 	WORD $0x8445; BYTE $0xdb                   // testb        %r11b, %r11b
-	LONG $0x0465840f; WORD $0x0000             // je           LBB29_84, $1125(%rip)
+	LONG $0x0474840f; WORD $0x0000             // je           LBB29_85, $1140(%rip)
 	LONG $0xd05d8844                           // movb         %r11b, $-48(%rbp)
 	LONG $0x02c48349                           // addq         $2, %r12
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -7644,18 +7644,18 @@ LBB29_33:
 
 LBB29_35:
 	LONG $0x03f98348                           // cmpq         $3, %rcx
-	LONG $0x04358e0f; WORD $0x0000             // jle          LBB29_85, $1077(%rip)
+	LONG $0x04448e0f; WORD $0x0000             // jle          LBB29_86, $1092(%rip)
 	LONG $0x24448b41; BYTE $0x02               // movl         $2(%r12), %eax
 	WORD $0xc289                               // movl         %eax, %edx
 	WORD $0xd2f7                               // notl         %edx
 	LONG $0xcfd0b08d; WORD $0xcfcf             // leal         $-808464432(%rax), %esi
 	LONG $0x8080e281; WORD $0x8080             // andl         $-2139062144, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x03f9850f; WORD $0x0000             // jne          LBB29_83, $1017(%rip)
+	LONG $0x0408850f; WORD $0x0000             // jne          LBB29_84, $1032(%rip)
 	LONG $0x1919b08d; WORD $0x1919             // leal         $421075225(%rax), %esi
 	WORD $0xc609                               // orl          %eax, %esi
 	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
-	LONG $0x03e5850f; WORD $0x0000             // jne          LBB29_83, $997(%rip)
+	LONG $0x03f4850f; WORD $0x0000             // jne          LBB29_84, $1012(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
 	LONG $0xc0c0b941; WORD $0xc0c0             // movl         $-1061109568, %r9d
@@ -7663,13 +7663,13 @@ LBB29_35:
 	LONG $0x469e8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r11d
 	WORD $0x2141; BYTE $0xd1                   // andl         %edx, %r9d
 	WORD $0x8545; BYTE $0xd9                   // testl        %r11d, %r9d
-	LONG $0x03c1850f; WORD $0x0000             // jne          LBB29_83, $961(%rip)
+	LONG $0x03d0850f; WORD $0x0000             // jne          LBB29_84, $976(%rip)
 	LONG $0xe0e0b941; WORD $0xe0e0             // movl         $-522133280, %r9d
 	WORD $0x2941; BYTE $0xf1                   // subl         %esi, %r9d
 	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
 	WORD $0x2144; BYTE $0xca                   // andl         %r9d, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x03a7850f; WORD $0x0000             // jne          LBB29_83, $935(%rip)
+	LONG $0x03b6850f; WORD $0x0000             // jne          LBB29_84, $950(%rip)
 	WORD $0xc80f                               // bswapl       %eax
 	WORD $0xc289                               // movl         %eax, %edx
 	WORD $0xeac1; BYTE $0x04                   // shrl         $4, %edx
@@ -7755,13 +7755,13 @@ LBB29_59:
 
 LBB29_60:
 	LONG $0x06f98348                           // cmpq         $6, %rcx
-	LONG $0x02bb8c0f; WORD $0x0000             // jl           LBB29_88, $699(%rip)
+	LONG $0x02ca8c0f; WORD $0x0000             // jl           LBB29_89, $714(%rip)
 	LONG $0x00dbff3d; BYTE $0x00               // cmpl         $56319, %eax
-	LONG $0x02b0870f; WORD $0x0000             // ja           LBB29_88, $688(%rip)
+	LONG $0x02bf870f; WORD $0x0000             // ja           LBB29_89, $703(%rip)
 	LONG $0x5c398041                           // cmpb         $92, (%r9)
-	LONG $0x02a6850f; WORD $0x0000             // jne          LBB29_88, $678(%rip)
+	LONG $0x02b5850f; WORD $0x0000             // jne          LBB29_89, $693(%rip)
 	LONG $0x247c8041; WORD $0x7507             // cmpb         $117, $7(%r12)
-	LONG $0x029a850f; WORD $0x0000             // jne          LBB29_88, $666(%rip)
+	LONG $0x02a9850f; WORD $0x0000             // jne          LBB29_89, $681(%rip)
 	LONG $0x244c8d4d; BYTE $0x08               // leaq         $8(%r12), %r9
 	LONG $0x244c8b41; BYTE $0x08               // movl         $8(%r12), %ecx
 	WORD $0xca89                               // movl         %ecx, %edx
@@ -7769,11 +7769,11 @@ LBB29_60:
 	LONG $0xcfd0b18d; WORD $0xcfcf             // leal         $-808464432(%rcx), %esi
 	LONG $0x8080e281; WORD $0x8080             // andl         $-2139062144, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x026c850f; WORD $0x0000             // jne          LBB29_87, $620(%rip)
+	LONG $0x027b850f; WORD $0x0000             // jne          LBB29_88, $635(%rip)
 	LONG $0x1919b18d; WORD $0x1919             // leal         $421075225(%rcx), %esi
 	WORD $0xce09                               // orl          %ecx, %esi
 	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
-	LONG $0x0258850f; WORD $0x0000             // jne          LBB29_87, $600(%rip)
+	LONG $0x0267850f; WORD $0x0000             // jne          LBB29_88, $615(%rip)
 	WORD $0xce89                               // movl         %ecx, %esi
 	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
 	LONG $0xc0c0bb41; WORD $0xc0c0             // movl         $-1061109568, %r11d
@@ -7781,13 +7781,13 @@ LBB29_60:
 	LONG $0x46b68d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r14d
 	WORD $0x2141; BYTE $0xd3                   // andl         %edx, %r11d
 	WORD $0x8545; BYTE $0xf3                   // testl        %r14d, %r11d
-	LONG $0x0234850f; WORD $0x0000             // jne          LBB29_87, $564(%rip)
+	LONG $0x0243850f; WORD $0x0000             // jne          LBB29_88, $579(%rip)
 	LONG $0xe0e0bb41; WORD $0xe0e0             // movl         $-522133280, %r11d
 	WORD $0x2941; BYTE $0xf3                   // subl         %esi, %r11d
 	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
 	WORD $0x2144; BYTE $0xda                   // andl         %r11d, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x021a850f; WORD $0x0000             // jne          LBB29_87, $538(%rip)
+	LONG $0x0229850f; WORD $0x0000             // jne          LBB29_88, $553(%rip)
 	WORD $0xc90f                               // bswapl       %ecx
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xeac1; BYTE $0x04                   // shrl         $4, %edx
@@ -7802,7 +7802,7 @@ LBB29_60:
 	WORD $0xd189                               // movl         %edx, %ecx
 	LONG $0x0000e181; WORD $0x00fc             // andl         $16515072, %ecx
 	LONG $0x0000f981; WORD $0x00dc             // cmpl         $14417920, %ecx
-	LONG $0x01f1850f; WORD $0x0000             // jne          LBB29_88, $497(%rip)
+	LONG $0x0200850f; WORD $0x0000             // jne          LBB29_89, $512(%rip)
 	WORD $0xd189                               // movl         %edx, %ecx
 	WORD $0xe9c1; BYTE $0x08                   // shrl         $8, %ecx
 	LONG $0xff00e181; WORD $0x0000             // andl         $65280, %ecx
@@ -7829,7 +7829,7 @@ LBB29_60:
 	WORD $0x4588; BYTE $0xd3                   // movb         %al, $-45(%rbp)
 	LONG $0x0cc48349                           // addq         $12, %r12
 	LONG $0x000004b9; BYTE $0x00               // movl         $4, %ecx
-	LONG $0x6b358d4c; WORD $0x0091; BYTE $0x00 // leaq         $37227(%rip), %r14  /* __UnquoteTab(%rip) */
+	LONG $0x8b358d4c; WORD $0x0091; BYTE $0x00 // leaq         $37259(%rip), %r14  /* __UnquoteTab(%rip) */
 	LONG $0xd05d8d48                           // leaq         $-48(%rbp), %rbx
 	LONG $0x0d4c8d4c; BYTE $0xd0               // leaq         $-48(%rbp,%rcx), %r9
 	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
@@ -7861,7 +7861,7 @@ LBB29_22:
 	WORD $0x894c; BYTE $0xc2       // movq         %r8, %rdx
 	LONG $0xffcd85e8; BYTE $0xff   // callq        _advance_ns, $-12923(%rip)
 	WORD $0x3a3c                   // cmpb         $58, %al
-	LONG $0x00ce850f; WORD $0x0000 // jne          LBB29_80, $206(%rip)
+	LONG $0x00dd850f; WORD $0x0000 // jne          LBB29_81, $221(%rip)
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
 	LONG $0x00a4850f; WORD $0x0000 // jne          LBB29_78, $164(%rip)
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
@@ -7889,9 +7889,9 @@ LBB29_71:
 
 LBB29_73:
 	WORD $0x5b3c                   // cmpb         $91, %al
-	LONG $0x0079850f; WORD $0x0000 // jne          LBB29_80, $121(%rip)
+	LONG $0x0088850f; WORD $0x0000 // jne          LBB29_81, $136(%rip)
 	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
-	LONG $0x0070850f; WORD $0x0000 // jne          LBB29_80, $112(%rip)
+	LONG $0x007f850f; WORD $0x0000 // jne          LBB29_81, $127(%rip)
 	LONG $0x08458b49               // movq         $8(%r13), %rax
 	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
 	WORD $0xff48; BYTE $0xc3       // incq         %rbx
@@ -7923,13 +7923,18 @@ LBB29_79:
 	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
 	WORD $0x894c; BYTE $0xfe     // movq         %r15, %rsi
 	LONG $0xffedd4e8; BYTE $0xff // callq        _skip_one_fast, $-4652(%rip)
-	LONG $0x00000ae9; BYTE $0x00 // jmp          LBB29_81, $10(%rip)
+	LONG $0x000019e9; BYTE $0x00 // jmp          LBB29_82, $25(%rip)
 
 LBB29_80:
 	WORD $0xff49; BYTE $0x0f                   // decq         (%r15)
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xdfc0c748; WORD $0xffff; BYTE $0xff // movq         $-33, %rax
+	LONG $0x00000ae9; BYTE $0x00               // jmp          LBB29_82, $10(%rip)
 
 LBB29_81:
+	WORD $0xff49; BYTE $0x0f                   // decq         (%r15)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_82:
 	LONG $0x28c48348 // addq         $40, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -7939,42 +7944,42 @@ LBB29_81:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB29_82:
+LBB29_83:
 	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
 	LONG $0x08408b48                           // movq         $8(%rax), %rax
 	WORD $0x8948; BYTE $0x03                   // movq         %rax, (%rbx)
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_81, $-38(%rip)
-
-LBB29_83:
-	LONG $0x02c48349                           // addq         $2, %r12
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_86, $18(%rip)
+	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_82, $-38(%rip)
 
 LBB29_84:
-	WORD $0xff49; BYTE $0xc4                   // incq         %r12
-	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
-	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_86, $3(%rip)
+	LONG $0x02c48349                           // addq         $2, %r12
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_87, $18(%rip)
 
 LBB29_85:
-	WORD $0xff49; BYTE $0xc4 // incq         %r12
+	WORD $0xff49; BYTE $0xc4                   // incq         %r12
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_87, $3(%rip)
 
 LBB29_86:
-	WORD $0x2949; BYTE $0xfc     // subq         %rdi, %r12
-	WORD $0x894d; BYTE $0x20     // movq         %r12, (%r8)
-	LONG $0xffffade9; BYTE $0xff // jmp          LBB29_81, $-83(%rip)
+	WORD $0xff49; BYTE $0xc4 // incq         %r12
 
 LBB29_87:
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_89, $7(%rip)
+	WORD $0x2949; BYTE $0xfc     // subq         %rdi, %r12
+	WORD $0x894d; BYTE $0x20     // movq         %r12, (%r8)
+	LONG $0xffffade9; BYTE $0xff // jmp          LBB29_82, $-83(%rip)
 
 LBB29_88:
-	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_90, $7(%rip)
 
 LBB29_89:
-	WORD $0x894d; BYTE $0xcc                   // movq         %r9, %r12
-	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_86, $-38(%rip)
-	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+
+LBB29_90:
+	WORD $0x894d; BYTE $0xcc     // movq         %r9, %r12
+	LONG $0xffffdae9; BYTE $0xff // jmp          LBB29_87, $-38(%rip)
+	QUAD $0x9090909090909090     // .p2align 4, 0x90
 
 _validate_utf8:
 	BYTE $0x55                                             // pushq        %rbp
@@ -8330,12 +8335,12 @@ LBB31_28:
 	LONG $0xff1f820f; WORD $0xffff // jb           LBB31_17, $-225(%rip)
 
 LBB31_30:
-	WORD $0xc031                           // xorl         %eax, %eax
-	LONG $0x08c48348                       // addq         $8, %rsp
-	BYTE $0x5b                             // popq         %rbx
-	BYTE $0x5d                             // popq         %rbp
-	BYTE $0xc3                             // retq
-	QUAD $0x0000000000000000; WORD $0x0000 // .p2align 5, 0x00
+	WORD $0xc031                                                                               // xorl         %eax, %eax
+	LONG $0x08c48348                                                                           // addq         $8, %rsp
+	BYTE $0x5b                                                                                 // popq         %rbx
+	BYTE $0x5d                                                                                 // popq         %rbp
+	BYTE $0xc3                                                                                 // retq
+	QUAD $0x0000000000000000; QUAD $0x0000000000000000; QUAD $0x0000000000000000; WORD $0x0000 // .p2align 5, 0x00
 
 LCPI32_0:
 	QUAD $0x3030303030303030; QUAD $0x3030303030303030 // .space 16, '0000000000000000'
@@ -11410,7 +11415,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_25169fe2: // _pow10_ceil_sig.g
+_LB_3887b4d9: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14065,7 +14070,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_06ddba4e: // _pow10_ceil_sig_f32.g
+_LB_bc74c56d: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -14156,7 +14161,7 @@ _entry:
 _f32toa:
 	MOVQ  out+0(FP), DI
 	MOVSD val+8(FP), X0
-	CALL  ·__native_entry__+28576(SB) // _f32toa
+	CALL  ·__native_entry__+28608(SB) // _f32toa
 	MOVQ  AX, ret+16(FP)
 	RET
 
@@ -14474,7 +14479,7 @@ _validate_utf8:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+27328(SB) // _validate_utf8
+	CALL ·__native_entry__+27344(SB) // _validate_utf8
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -14493,7 +14498,7 @@ _entry:
 
 _validate_utf8_fast:
 	MOVQ s+0(FP), DI
-	CALL ·__native_entry__+28000(SB) // _validate_utf8_fast
+	CALL ·__native_entry__+28016(SB) // _validate_utf8_fast
 	MOVQ AX, ret+8(FP)
 	RET
 

--- a/internal/native/avx/native_subr_amd64.go
+++ b/internal/native/avx/native_subr_amd64.go
@@ -9,7 +9,7 @@ package avx
 func __native_entry__() uintptr
 
 var (
-    _subr__f32toa             = __native_entry__() + 28576
+    _subr__f32toa             = __native_entry__() + 28608
     _subr__f64toa             = __native_entry__() + 448
     _subr__get_by_path        = __native_entry__() + 25568
     _subr__html_escape        = __native_entry__() + 9296
@@ -24,8 +24,8 @@ var (
     _subr__u64toa             = __native_entry__() + 3856
     _subr__unquote            = __native_entry__() + 6928
     _subr__validate_one       = __native_entry__() + 22368
-    _subr__validate_utf8      = __native_entry__() + 27328
-    _subr__validate_utf8_fast = __native_entry__() + 28000
+    _subr__validate_utf8      = __native_entry__() + 27344
+    _subr__validate_utf8_fast = __native_entry__() + 28016
     _subr__value              = __native_entry__() + 12480
     _subr__vnumber            = __native_entry__() + 16256
     _subr__vsigned            = __native_entry__() + 17872

--- a/internal/native/avx2/native_amd64.s
+++ b/internal/native/avx2/native_amd64.s
@@ -8390,7 +8390,7 @@ LBB29_2:
 	LONG $0x05a1850f; WORD $0x0000 // jne          LBB29_81, $1441(%rip)
 	WORD $0x7b3c                   // cmpb         $123, %al
 	LONG $0xc87d894c               // movq         %r15, $-56(%rbp)
-	LONG $0x0606850f; WORD $0x0000 // jne          LBB29_88, $1542(%rip)
+	LONG $0x0615850f; WORD $0x0000 // jne          LBB29_89, $1557(%rip)
 	LONG $0x90909090; BYTE $0x90   // .p2align 4, 0x90
 
 LBB29_4:
@@ -8398,7 +8398,7 @@ LBB29_4:
 	WORD $0x894c; BYTE $0xf6       // movq         %r14, %rsi
 	LONG $0xffd085e8; BYTE $0xff   // callq        _advance_ns, $-12155(%rip)
 	WORD $0x223c                   // cmpb         $34, %al
-	LONG $0x05ee850f; WORD $0x0000 // jne          LBB29_88, $1518(%rip)
+	LONG $0x05fd850f; WORD $0x0000 // jne          LBB29_89, $1533(%rip)
 	LONG $0x08478b49               // movq         $8(%r15), %rax
 	WORD $0x8b4c; BYTE $0x28       // movq         (%rax), %r13
 	LONG $0x08788b4c               // movq         $8(%rax), %r15
@@ -8409,7 +8409,7 @@ LBB29_4:
 	LONG $0xc0558d48               // leaq         $-64(%rbp), %rdx
 	LONG $0x002738e8; BYTE $0x00   // callq        _advance_string_default, $10040(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x05d9880f; WORD $0x0000 // js           LBB29_90, $1497(%rip)
+	LONG $0x05e8880f; WORD $0x0000 // js           LBB29_91, $1512(%rip)
 	WORD $0x8949; BYTE $0x06       // movq         %rax, (%r14)
 	LONG $0xc04d8b48               // movq         $-64(%rbp), %rcx
 	LONG $0xfff98348               // cmpq         $-1, %rcx
@@ -8541,13 +8541,13 @@ LBB29_34:
 	WORD $0x2948; BYTE $0xda                   // subq         %rbx, %rdx
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x8548; BYTE $0xd2                   // testq        %rdx, %rdx
-	LONG $0x04448e0f; WORD $0x0000             // jle          LBB29_94, $1092(%rip)
+	LONG $0x04538e0f; WORD $0x0000             // jle          LBB29_95, $1107(%rip)
 	LONG $0x014bb60f                           // movzbl       $1(%rbx), %ecx
 	LONG $0x390c8a42                           // movb         (%rcx,%r15), %cl
 	WORD $0xf980; BYTE $0xff                   // cmpb         $-1, %cl
 	LONG $0x003c840f; WORD $0x0000             // je           LBB29_41, $60(%rip)
 	WORD $0xc984                               // testb        %cl, %cl
-	LONG $0x0419840f; WORD $0x0000             // je           LBB29_92, $1049(%rip)
+	LONG $0x0428840f; WORD $0x0000             // je           LBB29_93, $1064(%rip)
 	WORD $0x4d88; BYTE $0xd0                   // movb         %cl, $-48(%rbp)
 	LONG $0x02c38348                           // addq         $2, %rbx
 	LONG $0x000001ba; BYTE $0x00               // movl         $1, %edx
@@ -8565,18 +8565,18 @@ LBB29_39:
 
 LBB29_41:
 	LONG $0x03fa8348                           // cmpq         $3, %rdx
-	LONG $0x03ea8e0f; WORD $0x0000             // jle          LBB29_93, $1002(%rip)
+	LONG $0x03f98e0f; WORD $0x0000             // jle          LBB29_94, $1017(%rip)
 	WORD $0x438b; BYTE $0x02                   // movl         $2(%rbx), %eax
 	WORD $0xc189                               // movl         %eax, %ecx
 	WORD $0xd1f7                               // notl         %ecx
 	LONG $0xcfd0b88d; WORD $0xcfcf             // leal         $-808464432(%rax), %edi
 	LONG $0x8080e181; WORD $0x8080             // andl         $-2139062144, %ecx
 	WORD $0xf985                               // testl        %edi, %ecx
-	LONG $0x03b0850f; WORD $0x0000             // jne          LBB29_91, $944(%rip)
+	LONG $0x03bf850f; WORD $0x0000             // jne          LBB29_92, $959(%rip)
 	LONG $0x1919b88d; WORD $0x1919             // leal         $421075225(%rax), %edi
 	WORD $0xc709                               // orl          %eax, %edi
 	LONG $0x8080c7f7; WORD $0x8080             // testl        $-2139062144, %edi
-	LONG $0x039c850f; WORD $0x0000             // jne          LBB29_91, $924(%rip)
+	LONG $0x03ab850f; WORD $0x0000             // jne          LBB29_92, $939(%rip)
 	WORD $0xc789                               // movl         %eax, %edi
 	LONG $0x7f7fe781; WORD $0x7f7f             // andl         $2139062143, %edi
 	LONG $0xc0c0c0be; BYTE $0xc0               // movl         $-1061109568, %esi
@@ -8584,13 +8584,13 @@ LBB29_41:
 	LONG $0x468f8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rdi), %r9d
 	WORD $0xce21                               // andl         %ecx, %esi
 	WORD $0x8544; BYTE $0xce                   // testl        %r9d, %esi
-	LONG $0x037b850f; WORD $0x0000             // jne          LBB29_91, $891(%rip)
+	LONG $0x038a850f; WORD $0x0000             // jne          LBB29_92, $906(%rip)
 	LONG $0xe0e0e0be; BYTE $0xe0               // movl         $-522133280, %esi
 	WORD $0xfe29                               // subl         %edi, %esi
 	LONG $0x3939c781; WORD $0x3939             // addl         $960051513, %edi
 	WORD $0xf121                               // andl         %esi, %ecx
 	WORD $0xf985                               // testl        %edi, %ecx
-	LONG $0x0364850f; WORD $0x0000             // jne          LBB29_91, $868(%rip)
+	LONG $0x0373850f; WORD $0x0000             // jne          LBB29_92, $883(%rip)
 	WORD $0xc80f                               // bswapl       %eax
 	WORD $0xc189                               // movl         %eax, %ecx
 	WORD $0xe9c1; BYTE $0x04                   // shrl         $4, %ecx
@@ -8677,13 +8677,13 @@ LBB29_65:
 
 LBB29_66:
 	LONG $0x06fa8348                           // cmpq         $6, %rdx
-	LONG $0x02848c0f; WORD $0x0000             // jl           LBB29_96, $644(%rip)
+	LONG $0x02938c0f; WORD $0x0000             // jl           LBB29_97, $659(%rip)
 	LONG $0x00dbff3d; BYTE $0x00               // cmpl         $56319, %eax
-	LONG $0x0279870f; WORD $0x0000             // ja           LBB29_96, $633(%rip)
+	LONG $0x0288870f; WORD $0x0000             // ja           LBB29_97, $648(%rip)
 	LONG $0x5c398041                           // cmpb         $92, (%r9)
-	LONG $0x026f850f; WORD $0x0000             // jne          LBB29_96, $623(%rip)
+	LONG $0x027e850f; WORD $0x0000             // jne          LBB29_97, $638(%rip)
 	LONG $0x75077b80                           // cmpb         $117, $7(%rbx)
-	LONG $0x0265850f; WORD $0x0000             // jne          LBB29_96, $613(%rip)
+	LONG $0x0274850f; WORD $0x0000             // jne          LBB29_97, $628(%rip)
 	LONG $0x084b8d4c                           // leaq         $8(%rbx), %r9
 	WORD $0x538b; BYTE $0x08                   // movl         $8(%rbx), %edx
 	WORD $0xd189                               // movl         %edx, %ecx
@@ -8691,11 +8691,11 @@ LBB29_66:
 	LONG $0xcfd0b28d; WORD $0xcfcf             // leal         $-808464432(%rdx), %esi
 	LONG $0x8080e181; WORD $0x8080             // andl         $-2139062144, %ecx
 	WORD $0xf185                               // testl        %esi, %ecx
-	LONG $0x023a850f; WORD $0x0000             // jne          LBB29_95, $570(%rip)
+	LONG $0x0249850f; WORD $0x0000             // jne          LBB29_96, $585(%rip)
 	LONG $0x1919b28d; WORD $0x1919             // leal         $421075225(%rdx), %esi
 	WORD $0xd609                               // orl          %edx, %esi
 	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
-	LONG $0x0226850f; WORD $0x0000             // jne          LBB29_95, $550(%rip)
+	LONG $0x0235850f; WORD $0x0000             // jne          LBB29_96, $565(%rip)
 	WORD $0xd789                               // movl         %edx, %edi
 	LONG $0x7f7fe781; WORD $0x7f7f             // andl         $2139062143, %edi
 	LONG $0xc0c0c0be; BYTE $0xc0               // movl         $-1061109568, %esi
@@ -8703,13 +8703,13 @@ LBB29_66:
 	LONG $0x46bf8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rdi), %r15d
 	WORD $0xce21                               // andl         %ecx, %esi
 	WORD $0x8544; BYTE $0xfe                   // testl        %r15d, %esi
-	LONG $0x0205850f; WORD $0x0000             // jne          LBB29_95, $517(%rip)
+	LONG $0x0214850f; WORD $0x0000             // jne          LBB29_96, $532(%rip)
 	LONG $0xe0e0e0be; BYTE $0xe0               // movl         $-522133280, %esi
 	WORD $0xfe29                               // subl         %edi, %esi
 	LONG $0x3939c781; WORD $0x3939             // addl         $960051513, %edi
 	WORD $0xf121                               // andl         %esi, %ecx
 	WORD $0xf985                               // testl        %edi, %ecx
-	LONG $0x01ee850f; WORD $0x0000             // jne          LBB29_95, $494(%rip)
+	LONG $0x01fd850f; WORD $0x0000             // jne          LBB29_96, $509(%rip)
 	WORD $0xca0f                               // bswapl       %edx
 	WORD $0xd189                               // movl         %edx, %ecx
 	WORD $0xe9c1; BYTE $0x04                   // shrl         $4, %ecx
@@ -8724,7 +8724,7 @@ LBB29_66:
 	WORD $0xca89                               // movl         %ecx, %edx
 	LONG $0x0000e281; WORD $0x00fc             // andl         $16515072, %edx
 	LONG $0x0000fa81; WORD $0x00dc             // cmpl         $14417920, %edx
-	LONG $0x01c5850f; WORD $0x0000             // jne          LBB29_96, $453(%rip)
+	LONG $0x01d4850f; WORD $0x0000             // jne          LBB29_97, $468(%rip)
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xeac1; BYTE $0x08                   // shrl         $8, %edx
 	LONG $0xff00e281; WORD $0x0000             // andl         $65280, %edx
@@ -8788,7 +8788,7 @@ LBB29_77:
 	WORD $0xf8c5; BYTE $0x77       // vzeroupper
 	LONG $0xffcb3ce8; BYTE $0xff   // callq        _advance_ns, $-13508(%rip)
 	WORD $0x3a3c                   // cmpb         $58, %al
-	LONG $0x00a5850f; WORD $0x0000 // jne          LBB29_88, $165(%rip)
+	LONG $0x00b4850f; WORD $0x0000 // jne          LBB29_89, $180(%rip)
 	WORD $0x8548; BYTE $0xdb       // testq        %rbx, %rbx
 	LONG $0x007b850f; WORD $0x0000 // jne          LBB29_86, $123(%rip)
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
@@ -8804,9 +8804,9 @@ LBB29_77:
 
 LBB29_81:
 	WORD $0x5b3c                   // cmpb         $91, %al
-	LONG $0x0069850f; WORD $0x0000 // jne          LBB29_88, $105(%rip)
+	LONG $0x0078850f; WORD $0x0000 // jne          LBB29_89, $120(%rip)
 	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
-	LONG $0x0060850f; WORD $0x0000 // jne          LBB29_88, $96(%rip)
+	LONG $0x006f850f; WORD $0x0000 // jne          LBB29_89, $111(%rip)
 	LONG $0x08478b49               // movq         $8(%r15), %rax
 	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
 	WORD $0xff48; BYTE $0xc3       // incq         %rbx
@@ -8837,13 +8837,18 @@ LBB29_87:
 	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
 	WORD $0x894c; BYTE $0xf6     // movq         %r14, %rsi
 	LONG $0xffeea4e8; BYTE $0xff // callq        _skip_one_fast, $-4444(%rip)
-	LONG $0x00000ae9; BYTE $0x00 // jmp          LBB29_89, $10(%rip)
+	LONG $0x000019e9; BYTE $0x00 // jmp          LBB29_90, $25(%rip)
 
 LBB29_88:
 	WORD $0xff49; BYTE $0x0e                   // decq         (%r14)
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xdfc0c748; WORD $0xffff; BYTE $0xff // movq         $-33, %rax
+	LONG $0x00000ae9; BYTE $0x00               // jmp          LBB29_90, $10(%rip)
 
 LBB29_89:
+	WORD $0xff49; BYTE $0x0e                   // decq         (%r14)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_90:
 	LONG $0x28c48348 // addq         $40, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -8853,41 +8858,41 @@ LBB29_89:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB29_90:
+LBB29_91:
 	LONG $0x24448b49; BYTE $0x08               // movq         $8(%r12), %rax
 	WORD $0x8949; BYTE $0x06                   // movq         %rax, (%r14)
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB29_89, $-35(%rip)
-
-LBB29_91:
-	LONG $0x02c38348                           // addq         $2, %rbx
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_94, $18(%rip)
+	LONG $0xffffdde9; BYTE $0xff               // jmp          LBB29_90, $-35(%rip)
 
 LBB29_92:
-	WORD $0xff48; BYTE $0xc3                   // incq         %rbx
-	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
-	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_94, $3(%rip)
+	LONG $0x02c38348                           // addq         $2, %rbx
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_95, $18(%rip)
 
 LBB29_93:
-	WORD $0xff48; BYTE $0xc3 // incq         %rbx
+	WORD $0xff48; BYTE $0xc3                   // incq         %rbx
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_95, $3(%rip)
 
 LBB29_94:
-	WORD $0x294c; BYTE $0xc3     // subq         %r8, %rbx
-	WORD $0x8949; BYTE $0x1e     // movq         %rbx, (%r14)
-	LONG $0xffffb0e9; BYTE $0xff // jmp          LBB29_89, $-80(%rip)
+	WORD $0xff48; BYTE $0xc3 // incq         %rbx
 
 LBB29_95:
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_97, $7(%rip)
+	WORD $0x294c; BYTE $0xc3     // subq         %r8, %rbx
+	WORD $0x8949; BYTE $0x1e     // movq         %rbx, (%r14)
+	LONG $0xffffb0e9; BYTE $0xff // jmp          LBB29_90, $-80(%rip)
 
 LBB29_96:
-	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_98, $7(%rip)
 
 LBB29_97:
-	WORD $0x894c; BYTE $0xcb               // movq         %r9, %rbx
-	LONG $0xffffdae9; BYTE $0xff           // jmp          LBB29_94, $-38(%rip)
-	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+
+LBB29_98:
+	WORD $0x894c; BYTE $0xcb                           // movq         %r9, %rbx
+	LONG $0xffffdae9; BYTE $0xff                       // jmp          LBB29_95, $-38(%rip)
+	QUAD $0x9090909090909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
 
 _validate_utf8:
 	BYTE $0x55                                             // pushq        %rbp
@@ -9084,10 +9089,10 @@ LBB30_32:
 	LONG $0xffffe4e9; BYTE $0xff               // jmp          LBB30_37, $-28(%rip)
 
 LBB30_17:
-	WORD $0x8948; BYTE $0x3e                                                           // movq         %rdi, (%rsi)
-	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff                                         // movq         $-1, %rax
-	LONG $0xffffd5e9; BYTE $0xff                                                       // jmp          LBB30_37, $-43(%rip)
-	QUAD $0x0000000000000000; QUAD $0x0000000000000000; LONG $0x00000000; WORD $0x0000 // .p2align 5, 0x00
+	WORD $0x8948; BYTE $0x3e                   // movq         %rdi, (%rsi)
+	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
+	LONG $0xffffd5e9; BYTE $0xff               // jmp          LBB30_37, $-43(%rip)
+	LONG $0x00000000; WORD $0x0000             // .p2align 5, 0x00
 
 LCPI31_0:
 	QUAD $0x0f0f0f0f0f0f0f0f; QUAD $0x0f0f0f0f0f0f0f0f // .space 16, '\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f'
@@ -12886,7 +12891,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_e4586741: // _pow10_ceil_sig.g
+_LB_5f525b1b: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -15541,7 +15546,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_665783d0: // _pow10_ceil_sig_f32.g
+_LB_6cbaa151: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -15950,7 +15955,7 @@ _validate_utf8:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+30992(SB) // _validate_utf8
+	CALL ·__native_entry__+31008(SB) // _validate_utf8
 	MOVQ AX, ret+24(FP)
 	RET
 

--- a/internal/native/avx2/native_subr_amd64.go
+++ b/internal/native/avx2/native_subr_amd64.go
@@ -24,7 +24,7 @@ var (
     _subr__u64toa             = __native_entry__() + 4144
     _subr__unquote            = __native_entry__() + 8336
     _subr__validate_one       = __native_entry__() + 26064
-    _subr__validate_utf8      = __native_entry__() + 30992
+    _subr__validate_utf8      = __native_entry__() + 31008
     _subr__validate_utf8_fast = __native_entry__() + 31952
     _subr__value              = __native_entry__() + 15472
     _subr__vnumber            = __native_entry__() + 19280

--- a/internal/native/sse/native_amd64.s
+++ b/internal/native/sse/native_amd64.s
@@ -198,7 +198,7 @@ LBB1_6:
 	LONG $0x000124b8; BYTE $0x00               // movl         $292, %eax
 	WORD $0x2944; BYTE $0xc8                   // subl         %r9d, %eax
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0xfa158d48; WORD $0x00b1; BYTE $0x00 // leaq         $45562(%rip), %rdx  /* _pow10_ceil_sig.g(%rip) */
+	LONG $0x0a158d48; WORD $0x00b2; BYTE $0x00 // leaq         $45578(%rip), %rdx  /* _pow10_ceil_sig.g(%rip) */
 	LONG $0x101c8b4c                           // movq         (%rax,%rdx), %r11
 	LONG $0x106c8b4c; BYTE $0x08               // movq         $8(%rax,%rdx), %r13
 	WORD $0xc1fe                               // incb         %cl
@@ -380,7 +380,7 @@ LBB1_51:
 	LONG $0x009d820f; WORD $0x0000             // jb           LBB1_64, $157(%rip)
 	LONG $0x01678d4d                           // leaq         $1(%r15), %r12
 	WORD $0x894c; BYTE $0xe6                   // movq         %r12, %rsi
-	LONG $0x00796fe8; BYTE $0x00               // callq        _format_significand, $31087(%rip)
+	LONG $0x00797fe8; BYTE $0x00               // callq        _format_significand, $31103(%rip)
 	WORD $0x8948; BYTE $0xc3                   // movq         %rax, %rbx
 	QUAD $0x9090909090909090; LONG $0x90909090 // .p2align 4, 0x90
 
@@ -415,7 +415,7 @@ LBB1_60:
 	WORD $0x0c8d; BYTE $0x12                   // leal         (%rdx,%rdx), %ecx
 	WORD $0x0c8d; BYTE $0x89                   // leal         (%rcx,%rcx,4), %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
-	LONG $0xd40d8d48; WORD $0x00ad; BYTE $0x00 // leaq         $44500(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0xe40d8d48; WORD $0x00ad; BYTE $0x00 // leaq         $44516(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x510cb70f                           // movzwl       (%rcx,%rdx,2), %ecx
 	LONG $0x024b8966                           // movw         %cx, $2(%rbx)
 	WORD $0x300c                               // orb          $48, %al
@@ -497,7 +497,7 @@ LBB1_61:
 	WORD $0xf883; BYTE $0x0a                   // cmpl         $10, %eax
 	LONG $0x00878c0f; WORD $0x0000             // jl           LBB1_63, $135(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0x8d0d8d48; WORD $0x00ac; BYTE $0x00 // leaq         $44173(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x9d0d8d48; WORD $0x00ac; BYTE $0x00 // leaq         $44189(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x02438966                           // movw         %ax, $2(%rbx)
 	LONG $0x04c38348                           // addq         $4, %rbx
@@ -686,7 +686,7 @@ LBB1_77:
 
 LBB1_78:
 	WORD $0x894c; BYTE $0xfe             // movq         %r15, %rsi
-	LONG $0x007479e8; BYTE $0x00         // callq        _format_significand, $29817(%rip)
+	LONG $0x007489e8; BYTE $0x00         // callq        _format_significand, $29833(%rip)
 	QUAD $0x9090909090909090; BYTE $0x90 // .p2align 4, 0x90
 
 LBB1_79:
@@ -910,7 +910,7 @@ LBB2_2:
 	WORD $0xcf6b; BYTE $0x64                   // imull        $100, %edi, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	LONG $0xd8b70f44                           // movzwl       %ax, %r11d
-	LONG $0x500d8d48; WORD $0x00a6; BYTE $0x00 // leaq         $42576(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x600d8d48; WORD $0x00a6; BYTE $0x00 // leaq         $42592(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x04b70f42; BYTE $0x51               // movzwl       (%rcx,%r10,2), %eax
 	LONG $0x40894166; BYTE $0xfe               // movw         %ax, $-2(%r8)
 	LONG $0x04b70f42; BYTE $0x49               // movzwl       (%rcx,%r9,2), %eax
@@ -926,7 +926,7 @@ LBB2_2:
 
 LBB2_5:
 	LONG $0x1759b941; WORD $0xd1b7             // movl         $3518437209, %r9d
-	LONG $0x09158d4c; WORD $0x00a6; BYTE $0x00 // leaq         $42505(%rip), %r10  /* _Digits(%rip) */
+	LONG $0x19158d4c; WORD $0x00a6; BYTE $0x00 // leaq         $42521(%rip), %r10  /* _Digits(%rip) */
 	QUAD $0x9090909090909090; BYTE $0x90       // .p2align 4, 0x90
 
 LBB2_6:
@@ -958,7 +958,7 @@ LBB2_7:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xca                   // movzwl       %dx, %ecx
-	LONG $0x91158d48; WORD $0x00a5; BYTE $0x00 // leaq         $42385(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0xa1158d48; WORD $0x00a5; BYTE $0x00 // leaq         $42401(%rip), %rdx  /* _Digits(%rip) */
 	LONG $0x4a0cb70f                           // movzwl       (%rdx,%rcx,2), %ecx
 	LONG $0x4b894166; BYTE $0xfe               // movw         %cx, $-2(%r11)
 	LONG $0xfec38349                           // addq         $-2, %r11
@@ -968,7 +968,7 @@ LBB2_9:
 	WORD $0xfa83; BYTE $0x0a                   // cmpl         $10, %edx
 	LONG $0x0018820f; WORD $0x0000             // jb           LBB2_11, $24(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x700d8d48; WORD $0x00a5; BYTE $0x00 // leaq         $42352(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x800d8d48; WORD $0x00a5; BYTE $0x00 // leaq         $42368(%rip), %rcx  /* _Digits(%rip) */
 	LONG $0x4104b70f                           // movzwl       (%rcx,%rax,2), %eax
 	LONG $0x43894166; BYTE $0xfe               // movw         %ax, $-2(%r11)
 	WORD $0x894c; BYTE $0xc0                   // movq         %r8, %rax
@@ -1057,7 +1057,7 @@ _u64toa:
 	WORD $0x0148; BYTE $0xc0                   // addq         %rax, %rax
 	LONG $0x03e8fe81; WORD $0x0000             // cmpl         $1000, %esi
 	LONG $0x0016820f; WORD $0x0000             // jb           LBB4_3, $22(%rip)
-	LONG $0x8c0d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42124(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x9c0d8d48; WORD $0x00a4; BYTE $0x00 // leaq         $42140(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x0c8a; BYTE $0x0a                   // movb         (%rdx,%rcx), %cl
 	WORD $0x0f88                               // movb         %cl, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1071,14 +1071,14 @@ LBB4_3:
 LBB4_4:
 	WORD $0xb70f; BYTE $0xd2                   // movzwl       %dx, %edx
 	LONG $0x01ca8348                           // orq          $1, %rdx
-	LONG $0x64358d48; WORD $0x00a4; BYTE $0x00 // leaq         $42084(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x74358d48; WORD $0x00a4; BYTE $0x00 // leaq         $42100(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x32                   // movb         (%rdx,%rsi), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
 	WORD $0x1488; BYTE $0x37                   // movb         %dl, (%rdi,%rsi)
 
 LBB4_6:
-	LONG $0x53158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42067(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x63158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42083(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x10                   // movb         (%rax,%rdx), %dl
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
@@ -1087,7 +1087,7 @@ LBB4_6:
 LBB4_7:
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x3b158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42043(%rip), %rdx  /* _Digits(%rip) */
+	LONG $0x4b158d48; WORD $0x00a4; BYTE $0x00 // leaq         $42059(%rip), %rdx  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x10                   // movb         (%rax,%rdx), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xc1ff                               // incl         %ecx
@@ -1134,7 +1134,7 @@ LBB4_8:
 	WORD $0x014d; BYTE $0xdb                   // addq         %r11, %r11
 	LONG $0x9680fe81; WORD $0x0098             // cmpl         $10000000, %esi
 	LONG $0x0017820f; WORD $0x0000             // jb           LBB4_11, $23(%rip)
-	LONG $0x99058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41881(%rip), %rax  /* _Digits(%rip) */
+	LONG $0xa9058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41897(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x02048a41                           // movb         (%r10,%rax), %al
 	WORD $0x0788                               // movb         %al, (%rdi)
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -1148,14 +1148,14 @@ LBB4_11:
 LBB4_12:
 	WORD $0x8944; BYTE $0xd0                   // movl         %r10d, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x6d358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41837(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x7d358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41853(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
 	WORD $0x0488; BYTE $0x37                   // movb         %al, (%rdi,%rsi)
 
 LBB4_14:
-	LONG $0x5c058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41820(%rip), %rax  /* _Digits(%rip) */
+	LONG $0x6c058d48; WORD $0x00a3; BYTE $0x00 // leaq         $41836(%rip), %rax  /* _Digits(%rip) */
 	LONG $0x01048a41                           // movb         (%r9,%rax), %al
 	WORD $0xce89                               // movl         %ecx, %esi
 	WORD $0xc1ff                               // incl         %ecx
@@ -1164,7 +1164,7 @@ LBB4_14:
 LBB4_15:
 	LONG $0xc1b70f41                           // movzwl       %r9w, %eax
 	LONG $0x01c88348                           // orq          $1, %rax
-	LONG $0x42358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41794(%rip), %rsi  /* _Digits(%rip) */
+	LONG $0x52358d48; WORD $0x00a3; BYTE $0x00 // leaq         $41810(%rip), %rsi  /* _Digits(%rip) */
 	WORD $0x048a; BYTE $0x30                   // movb         (%rax,%rsi), %al
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0x0488; BYTE $0x17                   // movb         %al, (%rdi,%rdx)
@@ -1250,7 +1250,7 @@ LBB4_16:
 	LONG $0x000010b9; BYTE $0x00               // movl         $16, %ecx
 	WORD $0xc129                               // subl         %eax, %ecx
 	LONG $0x04e0c148                           // shlq         $4, %rax
-	LONG $0x38158d48; WORD $0x00c9; BYTE $0x00 // leaq         $51512(%rip), %rdx  /* _VecShiftShuffles(%rip) */
+	LONG $0x48158d48; WORD $0x00c9; BYTE $0x00 // leaq         $51528(%rip), %rdx  /* _VecShiftShuffles(%rip) */
 	LONG $0x00380f66; WORD $0x100c             // pshufb       (%rax,%rdx), %xmm1
 	LONG $0x0f7f0ff3                           // movdqu       %xmm1, (%rdi)
 	WORD $0xc889                               // movl         %ecx, %eax
@@ -1276,7 +1276,7 @@ LBB4_20:
 	WORD $0xfa83; BYTE $0x63                   // cmpl         $99, %edx
 	LONG $0x001f870f; WORD $0x0000             // ja           LBB4_22, $31(%rip)
 	WORD $0xd089                               // movl         %edx, %eax
-	LONG $0x7b0d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41339(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x8b0d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41355(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x41                   // movb         (%rcx,%rax,2), %dl
 	LONG $0x0141448a                           // movb         $1(%rcx,%rax,2), %al
 	WORD $0x1788                               // movb         %dl, (%rdi)
@@ -1301,7 +1301,7 @@ LBB4_22:
 	WORD $0xc96b; BYTE $0x64                   // imull        $100, %ecx, %ecx
 	WORD $0xc829                               // subl         %ecx, %eax
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0x260d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41254(%rip), %rcx  /* _Digits(%rip) */
+	LONG $0x360d8d48; WORD $0x00a1; BYTE $0x00 // leaq         $41270(%rip), %rcx  /* _Digits(%rip) */
 	WORD $0x148a; BYTE $0x41                   // movb         (%rcx,%rax,2), %dl
 	LONG $0x0141448a                           // movb         $1(%rcx,%rax,2), %al
 	WORD $0x5788; BYTE $0x01                   // movb         %dl, $1(%rdi)
@@ -1313,7 +1313,7 @@ LBB4_24:
 	WORD $0xc86b; BYTE $0x64                   // imull        $100, %eax, %ecx
 	WORD $0xca29                               // subl         %ecx, %edx
 	WORD $0xb70f; BYTE $0xc0                   // movzwl       %ax, %eax
-	LONG $0x00058d4c; WORD $0x00a1; BYTE $0x00 // leaq         $41216(%rip), %r8  /* _Digits(%rip) */
+	LONG $0x10058d4c; WORD $0x00a1; BYTE $0x00 // leaq         $41232(%rip), %r8  /* _Digits(%rip) */
 	LONG $0x400c8a41                           // movb         (%r8,%rax,2), %cl
 	LONG $0x40448a41; BYTE $0x01               // movb         $1(%r8,%rax,2), %al
 	WORD $0x0f88                               // movb         %cl, (%rdi)
@@ -1406,8 +1406,8 @@ _quote:
 	WORD $0x8948; BYTE $0xf0                   // movq         %rsi, %rax
 	WORD $0x8b4c; BYTE $0x19                   // movq         (%rcx), %r11
 	LONG $0x01c0f641                           // testb        $1, %r8b
-	LONG $0x780d8d48; WORD $0x00c7; BYTE $0x00 // leaq         $51064(%rip), %rcx  /* __SingleQuoteTab(%rip) */
-	LONG $0x71058d4c; WORD $0x00d7; BYTE $0x00 // leaq         $55153(%rip), %r8  /* __DoubleQuoteTab(%rip) */
+	LONG $0x880d8d48; WORD $0x00c7; BYTE $0x00 // leaq         $51080(%rip), %rcx  /* __SingleQuoteTab(%rip) */
+	LONG $0x81058d4c; WORD $0x00d7; BYTE $0x00 // leaq         $55169(%rip), %r8  /* __DoubleQuoteTab(%rip) */
 	LONG $0xc1440f4c                           // cmoveq       %rcx, %r8
 	QUAD $0x00000000f50c8d48                   // leaq         (,%rsi,8), %rcx
 	WORD $0x3949; BYTE $0xcb                   // cmpq         %rcx, %r11
@@ -1514,7 +1514,7 @@ LBB5_15:
 	LONG $0x34b60f41; BYTE $0x24               // movzbl       (%r12), %esi
 	WORD $0x8948; BYTE $0xf2                   // movq         %rsi, %rdx
 	LONG $0x04e2c148                           // shlq         $4, %rdx
-	LONG $0xbd1d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50621(%rip), %rbx  /* __SingleQuoteTab(%rip) */
+	LONG $0xcd1d8d48; WORD $0x00c5; BYTE $0x00 // leaq         $50637(%rip), %rbx  /* __SingleQuoteTab(%rip) */
 	LONG $0x1a3c8348; BYTE $0x00               // cmpq         $0, (%rdx,%rbx)
 	LONG $0x0082850f; WORD $0x0000             // jne          LBB5_21, $130(%rip)
 	LONG $0xff518d48                           // leaq         $-1(%rcx), %rdx
@@ -1731,7 +1731,7 @@ LBB5_74:
 	LONG $0x00025de9; BYTE $0x00 // jmp          LBB5_76, $605(%rip)
 
 LBB5_51:
-	LONG $0x060d8d4c; WORD $0x00e3; BYTE $0x00 // leaq         $58118(%rip), %r9  /* __EscTab(%rip) */
+	LONG $0x160d8d4c; WORD $0x00e3; BYTE $0x00 // leaq         $58134(%rip), %r9  /* __EscTab(%rip) */
 	QUAD $0xfffffb2e056f0f66                   // movdqa       $-1234(%rip), %xmm0  /* LCPI5_0(%rip) */
 	QUAD $0xfffffb360d6f0f66                   // movdqa       $-1226(%rip), %xmm1  /* LCPI5_1(%rip) */
 	QUAD $0xfffffb3e156f0f66                   // movdqa       $-1218(%rip), %xmm2  /* LCPI5_2(%rip) */
@@ -1958,7 +1958,7 @@ _unquote:
 	LONG $0xb845894c                           // movq         %r8, $-72(%rbp)
 	WORD $0x8945; BYTE $0xc2                   // movl         %r8d, %r10d
 	LONG $0x01e28341                           // andl         $1, %r10d
-	LONG $0x3a058d4c; WORD $0x00e1; BYTE $0x00 // leaq         $57658(%rip), %r8  /* __UnquoteTab(%rip) */
+	LONG $0x4a058d4c; WORD $0x00e1; BYTE $0x00 // leaq         $57674(%rip), %r8  /* __UnquoteTab(%rip) */
 	QUAD $0xffffffb2056f0f66                   // movdqa       $-78(%rip), %xmm0  /* LCPI6_0(%rip) */
 	WORD $0x8949; BYTE $0xf9                   // movq         %rdi, %r9
 	WORD $0x8949; BYTE $0xf5                   // movq         %rsi, %r13
@@ -2648,7 +2648,7 @@ _html_escape:
 	QUAD $0xffffff910d6f0f66                   // movdqa       $-111(%rip), %xmm1  /* LCPI7_1(%rip) */
 	QUAD $0xffffff99156f0f66                   // movdqa       $-103(%rip), %xmm2  /* LCPI7_2(%rip) */
 	QUAD $0xffffffa11d6f0f66                   // movdqa       $-95(%rip), %xmm3  /* LCPI7_3(%rip) */
-	LONG $0xda1d8d4c; WORD $0x00d8; BYTE $0x00 // leaq         $55514(%rip), %r11  /* __HtmlQuoteTab(%rip) */
+	LONG $0xea1d8d4c; WORD $0x00d8; BYTE $0x00 // leaq         $55530(%rip), %r11  /* __HtmlQuoteTab(%rip) */
 	WORD $0x8949; BYTE $0xff                   // movq         %rdi, %r15
 	LONG $0xd0558b4c                           // movq         $-48(%rbp), %r10
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
@@ -3036,7 +3036,7 @@ LBB8_5:
 	WORD $0xd348; BYTE $0xe7                   // shlq         %cl, %rdi
 	WORD $0xc389                               // movl         %eax, %ebx
 	LONG $0x04e3c148                           // shlq         $4, %rbx
-	LONG $0x61358d4c; WORD $0x005e; BYTE $0x00 // leaq         $24161(%rip), %r14  /* _POW10_M128_TAB(%rip) */
+	LONG $0x71358d4c; WORD $0x005e; BYTE $0x00 // leaq         $24177(%rip), %r14  /* _POW10_M128_TAB(%rip) */
 	WORD $0x8948; BYTE $0xf8                   // movq         %rdi, %rax
 	LONG $0x3364f74a; BYTE $0x08               // mulq         $8(%rbx,%r14)
 	WORD $0x8949; BYTE $0xc7                   // movq         %rax, %r15
@@ -3163,7 +3163,7 @@ LBB9_5:
 	LONG $0xd05d8948                           // movq         %rbx, $-48(%rbp)
 	LONG $0x005a8e0f; WORD $0x0000             // jle          LBB9_12, $90(%rip)
 	WORD $0x3145; BYTE $0xe4                   // xorl         %r12d, %r12d
-	LONG $0x48358d4c; WORD $0x0088; BYTE $0x00 // leaq         $34888(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x58358d4c; WORD $0x0088; BYTE $0x00 // leaq         $34904(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_8, $45(%rip)
 	WORD $0x9090; BYTE $0x90                   // .p2align 4, 0x90
 
@@ -3176,7 +3176,7 @@ LBB9_10:
 LBB9_11:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x005745e8; BYTE $0x00 // callq        _right_shift, $22341(%rip)
+	LONG $0x005755e8; BYTE $0x00 // callq        _right_shift, $22357(%rip)
 
 LBB9_7:
 	WORD $0x0141; BYTE $0xdc       // addl         %ebx, %r12d
@@ -3193,7 +3193,7 @@ LBB9_8:
 	LONG $0xffffd3e9; BYTE $0xff   // jmp          LBB9_7, $-45(%rip)
 
 LBB9_12:
-	LONG $0xf1358d4c; WORD $0x0087; BYTE $0x00 // leaq         $34801(%rip), %r14  /* _POW_TAB(%rip) */
+	LONG $0x01358d4c; WORD $0x0088; BYTE $0x00 // leaq         $34817(%rip), %r14  /* _POW_TAB(%rip) */
 	LONG $0x00002de9; BYTE $0x00               // jmp          LBB9_14, $45(%rip)
 
 LBB9_18:
@@ -3205,7 +3205,7 @@ LBB9_18:
 LBB9_20:
 	WORD $0x894c; BYTE $0xff     // movq         %r15, %rdi
 	WORD $0xde89                 // movl         %ebx, %esi
-	LONG $0x0054f6e8; BYTE $0x00 // callq        _left_shift, $21750(%rip)
+	LONG $0x005506e8; BYTE $0x00 // callq        _left_shift, $21766(%rip)
 	LONG $0x14478b41             // movl         $20(%r15), %eax
 
 LBB9_13:
@@ -3248,7 +3248,7 @@ LBB9_21:
 LBB9_25:
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x00003cbe; BYTE $0x00   // movl         $60, %esi
-	LONG $0x005653e8; BYTE $0x00   // callq        _right_shift, $22099(%rip)
+	LONG $0x005663e8; BYTE $0x00   // callq        _right_shift, $22115(%rip)
 	LONG $0x3cc48341               // addl         $60, %r12d
 	LONG $0x88fc8341               // cmpl         $-120, %r12d
 	LONG $0xffe58c0f; WORD $0xffff // jl           LBB9_25, $-27(%rip)
@@ -3274,7 +3274,7 @@ LBB9_31:
 	WORD $0xf741; BYTE $0xdc       // negl         %r12d
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	WORD $0x8944; BYTE $0xe6       // movl         %r12d, %esi
-	LONG $0x005600e8; BYTE $0x00   // callq        _right_shift, $22016(%rip)
+	LONG $0x005610e8; BYTE $0x00   // callq        _right_shift, $22032(%rip)
 	LONG $0xfc02be41; WORD $0xffff // movl         $-1022, %r14d
 
 LBB9_32:
@@ -3282,7 +3282,7 @@ LBB9_32:
 	LONG $0x000d840f; WORD $0x0000 // je           LBB9_34, $13(%rip)
 	WORD $0x894c; BYTE $0xff       // movq         %r15, %rdi
 	LONG $0x000035be; BYTE $0x00   // movl         $53, %esi
-	LONG $0x0053f2e8; BYTE $0x00   // callq        _left_shift, $21490(%rip)
+	LONG $0x005402e8; BYTE $0x00   // callq        _left_shift, $21506(%rip)
 
 LBB9_34:
 	LONG $0x14478b41                           // movl         $20(%r15), %eax
@@ -4336,7 +4336,7 @@ LCPI14_2:
 _advance_string:
 	WORD $0xc1f6; BYTE $0x20       // testb        $32, %cl
 	LONG $0x0005850f; WORD $0x0000 // jne          LBB14_2, $5(%rip)
-	LONG $0x004a12e9; BYTE $0x00   // jmp          _advance_string_default, $18962(%rip)
+	LONG $0x004a22e9; BYTE $0x00   // jmp          _advance_string_default, $18978(%rip)
 
 LBB14_2:
 	BYTE $0x55                                             // pushq        %rbp
@@ -5057,7 +5057,7 @@ LBB15_62:
 	WORD $0xfe83; BYTE $0x17                   // cmpl         $23, %esi
 	LONG $0x00a68c0f; WORD $0x0000             // jl           LBB15_73, $166(%rip)
 	WORD $0x468d; BYTE $0xea                   // leal         $-22(%rsi), %eax
-	LONG $0x4e0d8d48; WORD $0x00e2; BYTE $0x00 // leaq         $57934(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x5e0d8d48; WORD $0x00e2; BYTE $0x00 // leaq         $57950(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x04590ff2; BYTE $0xc1               // mulsd        (%rcx,%rax,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc8               // movsd        %xmm0, $-56(%rbp)
 	LONG $0x000016b8; BYTE $0x00               // movl         $22, %eax
@@ -5079,7 +5079,7 @@ LBB15_70:
 	WORD $0xfe83; BYTE $0xea                   // cmpl         $-22, %esi
 	LONG $0x0096820f; WORD $0x0000             // jb           LBB15_77, $150(%rip)
 	WORD $0xdef7                               // negl         %esi
-	LONG $0x05058d48; WORD $0x00e2; BYTE $0x00 // leaq         $57861(%rip), %rax  /* _P10_TAB(%rip) */
+	LONG $0x15058d48; WORD $0x00e2; BYTE $0x00 // leaq         $57877(%rip), %rax  /* _P10_TAB(%rip) */
 	LONG $0x045e0ff2; BYTE $0xf0               // divsd        (%rax,%rsi,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc8               // movsd        %xmm0, $-56(%rbp)
 	LONG $0x0000e0e9; BYTE $0x00               // jmp          LBB15_81, $224(%rip)
@@ -5111,7 +5111,7 @@ LBB15_74:
 	LONG $0xc82e0f66                           // ucomisd      %xmm0, %xmm1
 	LONG $0x0018870f; WORD $0x0000             // ja           LBB15_77, $24(%rip)
 	WORD $0xc089                               // movl         %eax, %eax
-	LONG $0x870d8d48; WORD $0x00e1; BYTE $0x00 // leaq         $57735(%rip), %rcx  /* _P10_TAB(%rip) */
+	LONG $0x970d8d48; WORD $0x00e1; BYTE $0x00 // leaq         $57751(%rip), %rcx  /* _P10_TAB(%rip) */
 	LONG $0x04590ff2; BYTE $0xc1               // mulsd        (%rcx,%rax,8), %xmm0
 	LONG $0x45110ff2; BYTE $0xc8               // movsd        %xmm0, $-56(%rbp)
 	LONG $0x000062e9; BYTE $0x00               // jmp          LBB15_81, $98(%rip)
@@ -7650,7 +7650,7 @@ LBB29_2:
 	WORD $0x7b3c                           // cmpb         $123, %al
 	LONG $0xc865894c                       // movq         %r12, $-56(%rbp)
 	LONG $0xc06d894c                       // movq         %r13, $-64(%rbp)
-	LONG $0x05fb850f; WORD $0x0000         // jne          LBB29_80, $1531(%rip)
+	LONG $0x060a850f; WORD $0x0000         // jne          LBB29_81, $1546(%rip)
 	QUAD $0x9090909090909090; WORD $0x9090 // .p2align 4, 0x90
 
 LBB29_4:
@@ -7659,7 +7659,7 @@ LBB29_4:
 	WORD $0x894c; BYTE $0xfa       // movq         %r15, %rdx
 	LONG $0xffd05fe8; BYTE $0xff   // callq        _advance_ns, $-12193(%rip)
 	WORD $0x223c                   // cmpb         $34, %al
-	LONG $0x05d8850f; WORD $0x0000 // jne          LBB29_80, $1496(%rip)
+	LONG $0x05e7850f; WORD $0x0000 // jne          LBB29_81, $1511(%rip)
 	LONG $0x08458b49               // movq         $8(%r13), %rax
 	WORD $0x894c; BYTE $0xfb       // movq         %r15, %rbx
 	WORD $0x8b4c; BYTE $0x28       // movq         (%rax), %r13
@@ -7669,9 +7669,9 @@ LBB29_4:
 	WORD $0x8b4c; BYTE $0x23       // movq         (%rbx), %r12
 	WORD $0x894c; BYTE $0xe6       // movq         %r12, %rsi
 	LONG $0xb8558d48               // leaq         $-72(%rbp), %rdx
-	LONG $0x001d8fe8; BYTE $0x00   // callq        _advance_string_default, $7567(%rip)
+	LONG $0x001d9fe8; BYTE $0x00   // callq        _advance_string_default, $7583(%rip)
 	WORD $0x8548; BYTE $0xc0       // testq        %rax, %rax
-	LONG $0x05c0880f; WORD $0x0000 // js           LBB29_82, $1472(%rip)
+	LONG $0x05cf880f; WORD $0x0000 // js           LBB29_83, $1487(%rip)
 	WORD $0x8949; BYTE $0xd8       // movq         %rbx, %r8
 	WORD $0x8948; BYTE $0x03       // movq         %rax, (%rbx)
 	LONG $0xb84d8b48               // movq         $-72(%rbp), %rcx
@@ -7758,7 +7758,7 @@ LBB29_25:
 	WORD $0x394c; BYTE $0xe0                   // cmpq         %r12, %rax
 	WORD $0x8949; BYTE $0xc7                   // movq         %rax, %r15
 	LONG $0x03d6860f; WORD $0x0000             // jbe          LBB29_71, $982(%rip)
-	LONG $0x67358d4c; WORD $0x0094; BYTE $0x00 // leaq         $37991(%rip), %r14  /* __UnquoteTab(%rip) */
+	LONG $0x77358d4c; WORD $0x0094; BYTE $0x00 // leaq         $38007(%rip), %r14  /* __UnquoteTab(%rip) */
 	LONG $0xd05d8d48                           // leaq         $-48(%rbp), %rbx
 
 LBB29_28:
@@ -7769,13 +7769,13 @@ LBB29_28:
 	WORD $0x294c; BYTE $0xe1                   // subq         %r12, %rcx
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
 	WORD $0x8548; BYTE $0xc9                   // testq        %rcx, %rcx
-	LONG $0x04948e0f; WORD $0x0000             // jle          LBB29_86, $1172(%rip)
+	LONG $0x04a38e0f; WORD $0x0000             // jle          LBB29_87, $1187(%rip)
 	LONG $0x54b60f41; WORD $0x0124             // movzbl       $1(%r12), %edx
 	LONG $0x321c8a46                           // movb         (%rdx,%r14), %r11b
 	LONG $0xfffb8041                           // cmpb         $-1, %r11b
 	LONG $0x003e840f; WORD $0x0000             // je           LBB29_35, $62(%rip)
 	WORD $0x8445; BYTE $0xdb                   // testb        %r11b, %r11b
-	LONG $0x0465840f; WORD $0x0000             // je           LBB29_84, $1125(%rip)
+	LONG $0x0474840f; WORD $0x0000             // je           LBB29_85, $1140(%rip)
 	LONG $0xd05d8844                           // movb         %r11b, $-48(%rbp)
 	LONG $0x02c48349                           // addq         $2, %r12
 	LONG $0x000001b9; BYTE $0x00               // movl         $1, %ecx
@@ -7793,18 +7793,18 @@ LBB29_33:
 
 LBB29_35:
 	LONG $0x03f98348                           // cmpq         $3, %rcx
-	LONG $0x04358e0f; WORD $0x0000             // jle          LBB29_85, $1077(%rip)
+	LONG $0x04448e0f; WORD $0x0000             // jle          LBB29_86, $1092(%rip)
 	LONG $0x24448b41; BYTE $0x02               // movl         $2(%r12), %eax
 	WORD $0xc289                               // movl         %eax, %edx
 	WORD $0xd2f7                               // notl         %edx
 	LONG $0xcfd0b08d; WORD $0xcfcf             // leal         $-808464432(%rax), %esi
 	LONG $0x8080e281; WORD $0x8080             // andl         $-2139062144, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x03f9850f; WORD $0x0000             // jne          LBB29_83, $1017(%rip)
+	LONG $0x0408850f; WORD $0x0000             // jne          LBB29_84, $1032(%rip)
 	LONG $0x1919b08d; WORD $0x1919             // leal         $421075225(%rax), %esi
 	WORD $0xc609                               // orl          %eax, %esi
 	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
-	LONG $0x03e5850f; WORD $0x0000             // jne          LBB29_83, $997(%rip)
+	LONG $0x03f4850f; WORD $0x0000             // jne          LBB29_84, $1012(%rip)
 	WORD $0xc689                               // movl         %eax, %esi
 	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
 	LONG $0xc0c0b941; WORD $0xc0c0             // movl         $-1061109568, %r9d
@@ -7812,13 +7812,13 @@ LBB29_35:
 	LONG $0x469e8d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r11d
 	WORD $0x2141; BYTE $0xd1                   // andl         %edx, %r9d
 	WORD $0x8545; BYTE $0xd9                   // testl        %r11d, %r9d
-	LONG $0x03c1850f; WORD $0x0000             // jne          LBB29_83, $961(%rip)
+	LONG $0x03d0850f; WORD $0x0000             // jne          LBB29_84, $976(%rip)
 	LONG $0xe0e0b941; WORD $0xe0e0             // movl         $-522133280, %r9d
 	WORD $0x2941; BYTE $0xf1                   // subl         %esi, %r9d
 	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
 	WORD $0x2144; BYTE $0xca                   // andl         %r9d, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x03a7850f; WORD $0x0000             // jne          LBB29_83, $935(%rip)
+	LONG $0x03b6850f; WORD $0x0000             // jne          LBB29_84, $950(%rip)
 	WORD $0xc80f                               // bswapl       %eax
 	WORD $0xc289                               // movl         %eax, %edx
 	WORD $0xeac1; BYTE $0x04                   // shrl         $4, %edx
@@ -7904,13 +7904,13 @@ LBB29_59:
 
 LBB29_60:
 	LONG $0x06f98348                           // cmpq         $6, %rcx
-	LONG $0x02bb8c0f; WORD $0x0000             // jl           LBB29_88, $699(%rip)
+	LONG $0x02ca8c0f; WORD $0x0000             // jl           LBB29_89, $714(%rip)
 	LONG $0x00dbff3d; BYTE $0x00               // cmpl         $56319, %eax
-	LONG $0x02b0870f; WORD $0x0000             // ja           LBB29_88, $688(%rip)
+	LONG $0x02bf870f; WORD $0x0000             // ja           LBB29_89, $703(%rip)
 	LONG $0x5c398041                           // cmpb         $92, (%r9)
-	LONG $0x02a6850f; WORD $0x0000             // jne          LBB29_88, $678(%rip)
+	LONG $0x02b5850f; WORD $0x0000             // jne          LBB29_89, $693(%rip)
 	LONG $0x247c8041; WORD $0x7507             // cmpb         $117, $7(%r12)
-	LONG $0x029a850f; WORD $0x0000             // jne          LBB29_88, $666(%rip)
+	LONG $0x02a9850f; WORD $0x0000             // jne          LBB29_89, $681(%rip)
 	LONG $0x244c8d4d; BYTE $0x08               // leaq         $8(%r12), %r9
 	LONG $0x244c8b41; BYTE $0x08               // movl         $8(%r12), %ecx
 	WORD $0xca89                               // movl         %ecx, %edx
@@ -7918,11 +7918,11 @@ LBB29_60:
 	LONG $0xcfd0b18d; WORD $0xcfcf             // leal         $-808464432(%rcx), %esi
 	LONG $0x8080e281; WORD $0x8080             // andl         $-2139062144, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x026c850f; WORD $0x0000             // jne          LBB29_87, $620(%rip)
+	LONG $0x027b850f; WORD $0x0000             // jne          LBB29_88, $635(%rip)
 	LONG $0x1919b18d; WORD $0x1919             // leal         $421075225(%rcx), %esi
 	WORD $0xce09                               // orl          %ecx, %esi
 	LONG $0x8080c6f7; WORD $0x8080             // testl        $-2139062144, %esi
-	LONG $0x0258850f; WORD $0x0000             // jne          LBB29_87, $600(%rip)
+	LONG $0x0267850f; WORD $0x0000             // jne          LBB29_88, $615(%rip)
 	WORD $0xce89                               // movl         %ecx, %esi
 	LONG $0x7f7fe681; WORD $0x7f7f             // andl         $2139062143, %esi
 	LONG $0xc0c0bb41; WORD $0xc0c0             // movl         $-1061109568, %r11d
@@ -7930,13 +7930,13 @@ LBB29_60:
 	LONG $0x46b68d44; WORD $0x4646; BYTE $0x46 // leal         $1179010630(%rsi), %r14d
 	WORD $0x2141; BYTE $0xd3                   // andl         %edx, %r11d
 	WORD $0x8545; BYTE $0xf3                   // testl        %r14d, %r11d
-	LONG $0x0234850f; WORD $0x0000             // jne          LBB29_87, $564(%rip)
+	LONG $0x0243850f; WORD $0x0000             // jne          LBB29_88, $579(%rip)
 	LONG $0xe0e0bb41; WORD $0xe0e0             // movl         $-522133280, %r11d
 	WORD $0x2941; BYTE $0xf3                   // subl         %esi, %r11d
 	LONG $0x3939c681; WORD $0x3939             // addl         $960051513, %esi
 	WORD $0x2144; BYTE $0xda                   // andl         %r11d, %edx
 	WORD $0xf285                               // testl        %esi, %edx
-	LONG $0x021a850f; WORD $0x0000             // jne          LBB29_87, $538(%rip)
+	LONG $0x0229850f; WORD $0x0000             // jne          LBB29_88, $553(%rip)
 	WORD $0xc90f                               // bswapl       %ecx
 	WORD $0xca89                               // movl         %ecx, %edx
 	WORD $0xeac1; BYTE $0x04                   // shrl         $4, %edx
@@ -7951,7 +7951,7 @@ LBB29_60:
 	WORD $0xd189                               // movl         %edx, %ecx
 	LONG $0x0000e181; WORD $0x00fc             // andl         $16515072, %ecx
 	LONG $0x0000f981; WORD $0x00dc             // cmpl         $14417920, %ecx
-	LONG $0x01f1850f; WORD $0x0000             // jne          LBB29_88, $497(%rip)
+	LONG $0x0200850f; WORD $0x0000             // jne          LBB29_89, $512(%rip)
 	WORD $0xd189                               // movl         %edx, %ecx
 	WORD $0xe9c1; BYTE $0x08                   // shrl         $8, %ecx
 	LONG $0xff00e181; WORD $0x0000             // andl         $65280, %ecx
@@ -7978,7 +7978,7 @@ LBB29_60:
 	WORD $0x4588; BYTE $0xd3                   // movb         %al, $-45(%rbp)
 	LONG $0x0cc48349                           // addq         $12, %r12
 	LONG $0x000004b9; BYTE $0x00               // movl         $4, %ecx
-	LONG $0x2b358d4c; WORD $0x0091; BYTE $0x00 // leaq         $37163(%rip), %r14  /* __UnquoteTab(%rip) */
+	LONG $0x3b358d4c; WORD $0x0091; BYTE $0x00 // leaq         $37179(%rip), %r14  /* __UnquoteTab(%rip) */
 	LONG $0xd05d8d48                           // leaq         $-48(%rbp), %rbx
 	LONG $0x0d4c8d4c; BYTE $0xd0               // leaq         $-48(%rbp,%rcx), %r9
 	WORD $0x394d; BYTE $0xd5                   // cmpq         %r10, %r13
@@ -8010,7 +8010,7 @@ LBB29_22:
 	WORD $0x894c; BYTE $0xc2       // movq         %r8, %rdx
 	LONG $0xffcb55e8; BYTE $0xff   // callq        _advance_ns, $-13483(%rip)
 	WORD $0x3a3c                   // cmpb         $58, %al
-	LONG $0x00ce850f; WORD $0x0000 // jne          LBB29_80, $206(%rip)
+	LONG $0x00dd850f; WORD $0x0000 // jne          LBB29_81, $221(%rip)
 	WORD $0x854d; BYTE $0xf6       // testq        %r14, %r14
 	LONG $0x00a4850f; WORD $0x0000 // jne          LBB29_78, $164(%rip)
 	WORD $0x894c; BYTE $0xe7       // movq         %r12, %rdi
@@ -8038,9 +8038,9 @@ LBB29_71:
 
 LBB29_73:
 	WORD $0x5b3c                   // cmpb         $91, %al
-	LONG $0x0079850f; WORD $0x0000 // jne          LBB29_80, $121(%rip)
+	LONG $0x0088850f; WORD $0x0000 // jne          LBB29_81, $136(%rip)
 	WORD $0xf980; BYTE $0x02       // cmpb         $2, %cl
-	LONG $0x0070850f; WORD $0x0000 // jne          LBB29_80, $112(%rip)
+	LONG $0x007f850f; WORD $0x0000 // jne          LBB29_81, $127(%rip)
 	LONG $0x08458b49               // movq         $8(%r13), %rax
 	WORD $0x8b48; BYTE $0x18       // movq         (%rax), %rbx
 	WORD $0xff48; BYTE $0xc3       // incq         %rbx
@@ -8072,13 +8072,18 @@ LBB29_79:
 	WORD $0x894c; BYTE $0xe7     // movq         %r12, %rdi
 	WORD $0x894c; BYTE $0xfe     // movq         %r15, %rsi
 	LONG $0xffec24e8; BYTE $0xff // callq        _skip_one_fast, $-5084(%rip)
-	LONG $0x00000ae9; BYTE $0x00 // jmp          LBB29_81, $10(%rip)
+	LONG $0x000019e9; BYTE $0x00 // jmp          LBB29_82, $25(%rip)
 
 LBB29_80:
 	WORD $0xff49; BYTE $0x0f                   // decq         (%r15)
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0xdfc0c748; WORD $0xffff; BYTE $0xff // movq         $-33, %rax
+	LONG $0x00000ae9; BYTE $0x00               // jmp          LBB29_82, $10(%rip)
 
 LBB29_81:
+	WORD $0xff49; BYTE $0x0f                   // decq         (%r15)
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+
+LBB29_82:
 	LONG $0x28c48348 // addq         $40, %rsp
 	BYTE $0x5b       // popq         %rbx
 	WORD $0x5c41     // popq         %r12
@@ -8088,42 +8093,42 @@ LBB29_81:
 	BYTE $0x5d       // popq         %rbp
 	BYTE $0xc3       // retq
 
-LBB29_82:
+LBB29_83:
 	LONG $0xc8458b48                           // movq         $-56(%rbp), %rax
 	LONG $0x08408b48                           // movq         $8(%rax), %rax
 	WORD $0x8948; BYTE $0x03                   // movq         %rax, (%rbx)
 	LONG $0xffc0c748; WORD $0xffff; BYTE $0xff // movq         $-1, %rax
-	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_81, $-38(%rip)
-
-LBB29_83:
-	LONG $0x02c48349                           // addq         $2, %r12
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_86, $18(%rip)
+	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_82, $-38(%rip)
 
 LBB29_84:
-	WORD $0xff49; BYTE $0xc4                   // incq         %r12
-	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
-	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_86, $3(%rip)
+	LONG $0x02c48349                           // addq         $2, %r12
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000012e9; BYTE $0x00               // jmp          LBB29_87, $18(%rip)
 
 LBB29_85:
-	WORD $0xff49; BYTE $0xc4 // incq         %r12
+	WORD $0xff49; BYTE $0xc4                   // incq         %r12
+	LONG $0xfdc0c748; WORD $0xffff; BYTE $0xff // movq         $-3, %rax
+	LONG $0x000003e9; BYTE $0x00               // jmp          LBB29_87, $3(%rip)
 
 LBB29_86:
-	WORD $0x2949; BYTE $0xfc     // subq         %rdi, %r12
-	WORD $0x894d; BYTE $0x20     // movq         %r12, (%r8)
-	LONG $0xffffade9; BYTE $0xff // jmp          LBB29_81, $-83(%rip)
+	WORD $0xff49; BYTE $0xc4 // incq         %r12
 
 LBB29_87:
-	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
-	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_89, $7(%rip)
+	WORD $0x2949; BYTE $0xfc     // subq         %rdi, %r12
+	WORD $0x894d; BYTE $0x20     // movq         %r12, (%r8)
+	LONG $0xffffade9; BYTE $0xff // jmp          LBB29_82, $-83(%rip)
 
 LBB29_88:
-	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+	LONG $0xfec0c748; WORD $0xffff; BYTE $0xff // movq         $-2, %rax
+	LONG $0x000007e9; BYTE $0x00               // jmp          LBB29_90, $7(%rip)
 
 LBB29_89:
-	WORD $0x894d; BYTE $0xcc                   // movq         %r9, %r12
-	LONG $0xffffdae9; BYTE $0xff               // jmp          LBB29_86, $-38(%rip)
-	LONG $0x90909090; WORD $0x9090; BYTE $0x90 // .p2align 4, 0x90
+	LONG $0xfcc0c748; WORD $0xffff; BYTE $0xff // movq         $-4, %rax
+
+LBB29_90:
+	WORD $0x894d; BYTE $0xcc     // movq         %r9, %r12
+	LONG $0xffffdae9; BYTE $0xff // jmp          LBB29_87, $-38(%rip)
+	QUAD $0x9090909090909090     // .p2align 4, 0x90
 
 _validate_utf8:
 	BYTE $0x55                                             // pushq        %rbp
@@ -11556,7 +11561,7 @@ _Digits:
 	QUAD $0x3939383937393639                           // .ascii 8, '96979899'
 	QUAD $0x0000000000000000                           // .p2align 4, 0x00
 
-_LB_d943ffab: // _pow10_ceil_sig.g
+_LB_d7a2d665: // _pow10_ceil_sig.g
 	QUAD $0xff77b1fcbebcdc4f // .quad -38366372719436721
 	QUAD $0x25e8e89c13bb0f7b // .quad 2731688931043774331
 	QUAD $0x9faacf3df73609b1 // .quad -6941508010590729807
@@ -14211,7 +14216,7 @@ _P10_TAB:
 	QUAD $0x4480f0cf064dd592 // .quad 0x4480f0cf064dd592
 	QUAD $0x0000000000000000 // .p2align 4, 0x00
 
-_LB_1191cfee: // _pow10_ceil_sig_f32.g
+_LB_76da1fa4: // _pow10_ceil_sig_f32.g
 	QUAD $0x81ceb32c4b43fcf5 // .quad -9093133594791772939
 	QUAD $0xa2425ff75e14fc32 // .quad -6754730975062328270
 	QUAD $0xcad2f7f5359a3b3f // .quad -3831727700400522433
@@ -14302,7 +14307,7 @@ _entry:
 _f32toa:
 	MOVQ  out+0(FP), DI
 	MOVSD val+8(FP), X0
-	CALL  ·__native_entry__+29200(SB) // _f32toa
+	CALL  ·__native_entry__+29216(SB) // _f32toa
 	MOVQ  AX, ret+16(FP)
 	RET
 
@@ -14620,7 +14625,7 @@ _validate_utf8:
 	MOVQ s+0(FP), DI
 	MOVQ p+8(FP), SI
 	MOVQ m+16(FP), DX
-	CALL ·__native_entry__+27968(SB) // _validate_utf8
+	CALL ·__native_entry__+27984(SB) // _validate_utf8
 	MOVQ AX, ret+24(FP)
 	RET
 
@@ -14639,7 +14644,7 @@ _entry:
 
 _validate_utf8_fast:
 	MOVQ s+0(FP), DI
-	CALL ·__native_entry__+28640(SB) // _validate_utf8_fast
+	CALL ·__native_entry__+28656(SB) // _validate_utf8_fast
 	MOVQ AX, ret+8(FP)
 	RET
 

--- a/internal/native/sse/native_subr_amd64.go
+++ b/internal/native/sse/native_subr_amd64.go
@@ -9,7 +9,7 @@ package sse
 func __native_entry__() uintptr
 
 var (
-    _subr__f32toa             = __native_entry__() + 29200
+    _subr__f32toa             = __native_entry__() + 29216
     _subr__f64toa             = __native_entry__() + 448
     _subr__get_by_path        = __native_entry__() + 26208
     _subr__html_escape        = __native_entry__() + 9360
@@ -24,8 +24,8 @@ var (
     _subr__u64toa             = __native_entry__() + 3840
     _subr__unquote            = __native_entry__() + 6992
     _subr__validate_one       = __native_entry__() + 22576
-    _subr__validate_utf8      = __native_entry__() + 27968
-    _subr__validate_utf8_fast = __native_entry__() + 28640
+    _subr__validate_utf8      = __native_entry__() + 27984
+    _subr__validate_utf8_fast = __native_entry__() + 28656
     _subr__value              = __native_entry__() + 12560
     _subr__vnumber            = __native_entry__() + 16416
     _subr__vsigned            = __native_entry__() + 18064

--- a/internal/native/types/types.go
+++ b/internal/native/types/types.go
@@ -76,6 +76,10 @@ const (
     ERR_FLOAT_INFINITY     ParsingError = 8
     ERR_MISMATCH           ParsingError = 9
     ERR_INVALID_UTF8       ParsingError = 10
+
+    // error code used in ast
+    ERR_NOT_FOUND          ParsingError = 33
+    ERR_UNSUPPORT_TYPE     ParsingError = 34
 )
 
 var _ParsingErrors = []string{

--- a/native/scanning.c
+++ b/native/scanning.c
@@ -1827,10 +1827,14 @@ query:
     /* match type: should query key in object, query index in array */
     c = advance_ns(src, p);
     if (is_str(ps)) {
-        if (c != '{') goto err_inval;
+        if (c != '{') {
+            goto err_inval;
+        }
         goto skip_in_obj;
     } else if (is_int(ps)) {
-        if (c != '[') goto err_inval;
+        if (c != '[') {
+            goto err_inval;
+        }
         goto skip_in_arr;
     } else {
         goto err_inval;
@@ -1840,7 +1844,9 @@ skip_in_obj:
     c = advance_ns(src, p);
     if (c != '"') goto err_inval;
     found = match_key(src, p, get_str(ps));
-    if (found < 0) return found; // parse string errors
+    if (found < 0) {
+        return found; // parse string errors
+    }
 
     /* value should after : */
     c = advance_ns(src, p);
@@ -1851,7 +1857,7 @@ skip_in_obj:
     } else {
         skip_one_fast(src, p);
         c = advance_ns(src, p);
-        if (c != ',') goto err_inval; // not found key
+        if (c != ',') goto not_found; // not found key
         goto skip_in_obj;
     }
 
@@ -1861,13 +1867,16 @@ skip_in_arr:
     while (index-- > 0) {
         skip_one_fast(src, p);
         c = advance_ns(src, p);
-        if (c != ',') goto err_inval; // out of range
+        if (c != ',') goto not_found; // out of range
     }
     ps++;
     goto query;
 
-err_inval:
+not_found:
     *p -= 1; // backward error position
+    return -ERR_NOT_FOUND;
+err_inval:
+    *p -= 1;
     return -ERR_INVAL;
 }
 

--- a/native/types.h
+++ b/native/types.h
@@ -37,6 +37,9 @@
 #define ERR_MISMATCH    9
 #define ERR_INVAL_UTF8  10
 
+#define ERR_NOT_FOUND      33
+#define ERR_UNSUPPORT_TYPE 34
+
 #define MAX_RECURSE     4096
 
 #endif


### PR DESCRIPTION
return ErrorNoExist when the key or index is not found for GetFromString API.