### PR TITLE
fix: unmarshal into defined ptr type

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -128,15 +128,13 @@ func (self *Decoder) Decode(val interface{}) error {
         return &json.InvalidUnmarshalError{Type: vv.Type.Pack()}
     }
 
-    /* check the defined pointer type for issue 379
-     * type's Flags always be 0xf */
     etp := rt.PtrElem(vv.Type)
-    if vv.Type.Flags == 0xf {
-        // New a pointer
-        var newp unsafe.Pointer = vp
-        nv := reflect.NewAt(vv.Type.Pack(), unsafe.Pointer(&newp))
-        etp = vv.Type
-        vp  = rt.UnpackValue(nv).Ptr
+
+    /* check the defined pointer type for issue 379 */
+    if vv.Type.IsNamed() {
+        newp := vp
+        etp  = vv.Type
+        vp   = unsafe.Pointer(&newp)
     }
 
     /* create a new stack, and call the decoder */

--- a/internal/rt/fastvalue.go
+++ b/internal/rt/fastvalue.go
@@ -25,16 +25,19 @@ var (
     reflectRtypeItab = findReflectRtypeItab()
 )
 
+// GoType.KindFlags const
 const (
     F_direct    = 1 << 5
     F_kind_mask = (1 << 5) - 1
 )
 
-type GoValue struct {
-    Typ  *GoType
-    Ptr  unsafe.Pointer
-    Flag uintptr
-}
+// GoType.Flags const
+const (
+    tflagUncommon      uint8 = 1 << 0
+    tflagExtraStar     uint8 = 1 << 1
+    tflagNamed         uint8 = 1 << 2
+    tflagRegularMemory uint8 = 1 << 3
+)
 
 type GoType struct {
     Size       uintptr
@@ -48,6 +51,10 @@ type GoType struct {
     GCData     *byte
     Str        int32
     PtrToSelf  int32
+}
+
+func (self *GoType) IsNamed() bool {
+    return (self.Flags & tflagNamed) != 0
 }
 
 func (self *GoType) Kind() reflect.Kind {
@@ -198,10 +205,6 @@ func UnpackEface(v interface{}) GoEface {
 
 func UnpackIface(v interface{}) GoIface {
     return *(*GoIface)(unsafe.Pointer(&v))
-}
-
-func UnpackValue(v reflect.Value) GoValue {
-    return *(*GoValue)(unsafe.Pointer(&v))
 }
 
 func findReflectRtypeItab() *GoItab {

--- a/internal/rt/fastvalue.go
+++ b/internal/rt/fastvalue.go
@@ -22,13 +22,19 @@ import (
 )
 
 var (
-	reflectRtypeItab = findReflectRtypeItab()
+    reflectRtypeItab = findReflectRtypeItab()
 )
 
 const (
     F_direct    = 1 << 5
     F_kind_mask = (1 << 5) - 1
 )
+
+type GoValue struct {
+    Typ  *GoType
+    Ptr  unsafe.Pointer
+    Flag uintptr
+}
 
 type GoType struct {
     Size       uintptr
@@ -192,6 +198,10 @@ func UnpackEface(v interface{}) GoEface {
 
 func UnpackIface(v interface{}) GoIface {
     return *(*GoIface)(unsafe.Pointer(&v))
+}
+
+func UnpackValue(v reflect.Value) GoValue {
+    return *(*GoValue)(unsafe.Pointer(&v))
 }
 
 func findReflectRtypeItab() *GoItab {

--- a/issue_test/issue379_test.go
+++ b/issue_test/issue379_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package issue_test
 
 import (
@@ -81,8 +97,3 @@ func TestIssue379(t *testing.T) {
         require.Equal(t, jerr, serr)
     }
 }
-// *Foo TypeInfo:
-//reflect.rtype {size: 8, ptrdata: 8, hash: 3423087479, tflag: tflagUncommon|tflagRegularMemory (9), align: 8, fieldAlign: 8, kind: 54, equal: runtime.memequal64, gcdata: *1, str: 48583, ptrToThis: 0}
-
-// MyPtrType TypeInfo:
-// reflect.rtype {size: 8, ptrdata: 8, hash: 3863140068, tflag: tflagUncommon|tflagExtraStar|tflagNamed|tflagRegularMemory (15), align: 8, fieldAlign: 8, kind: 54, equal: runtime.memequal64, gcdata: *1, str: 56864, ptrToThis: 135104}

--- a/issue_test/issue379_test.go
+++ b/issue_test/issue379_test.go
@@ -1,0 +1,88 @@
+package issue_test
+
+import (
+    `testing`
+    `encoding/json`
+    `github.com/bytedance/sonic`
+    `github.com/stretchr/testify/require`
+)
+
+type Foo struct {
+    Name string
+}
+
+func (f *Foo) UnmarshalJSON(data []byte) error {
+    f.Name = "Unmarshaler"
+    return nil
+}
+
+type MyPtr *Foo
+
+func TestIssue379(t *testing.T) {
+    tests := []struct{
+        data  string
+        newf  func() interface{} 
+    } {
+        {
+            data: `{"Name":"MyPtr"}`,
+            newf:  func() interface{} { return &Foo{} },
+        },
+        {
+            data: `{"Name":"MyPtr"}`,
+            newf:  func() interface{} { return MyPtr(&Foo{}) },
+        },
+        {
+            data: `{"Name":"MyPtr"}`,
+            newf:  func() interface{} { ptr := MyPtr(&Foo{}); return &ptr },
+        },
+        {
+            data: `null`,
+            newf:  func() interface{} { return MyPtr(&Foo{}) },
+        },
+        {
+            data: `null`,
+            newf:  func() interface{} { return &Foo{} },
+        },
+        {
+            data: `null`,
+            newf:  func() interface{} { ptr := MyPtr(&Foo{}); return &ptr },
+        },
+        {
+            data: `{"map":{"Name":"MyPtr"}}`,
+            newf:  func() interface{} { return new(map[string]MyPtr) },
+        },
+        {
+            data: `{"map":{"Name":"MyPtr"}}`,
+            newf:  func() interface{} { return new(map[string]*Foo) },
+        },
+        {
+            data: `{"map":{"Name":"MyPtr"}}`,
+            newf:  func() interface{} { return new(map[string]*MyPtr) },
+        },
+        {
+            data: `[{"Name":"MyPtr"}]`,
+            newf:  func() interface{} { return new([]MyPtr) },
+        },
+        {
+            data: `[{"Name":"MyPtr"}]`,
+            newf:  func() interface{} { return new([]*MyPtr) },
+        },
+        {
+            data: `[{"Name":"MyPtr"}]`,
+            newf:  func() interface{} { return new([]*Foo) },
+        },
+    }
+
+    for _, tt := range tests {
+        jv, sv := tt.newf(), tt.newf()
+        jerr := json.Unmarshal([]byte(tt.data), jv)
+        serr := sonic.Unmarshal([]byte(tt.data), sv)
+        require.Equal(t, jv, sv)
+        require.Equal(t, jerr, serr)
+    }
+}
+// *Foo TypeInfo:
+//reflect.rtype {size: 8, ptrdata: 8, hash: 3423087479, tflag: tflagUncommon|tflagRegularMemory (9), align: 8, fieldAlign: 8, kind: 54, equal: runtime.memequal64, gcdata: *1, str: 48583, ptrToThis: 0}
+
+// MyPtrType TypeInfo:
+// reflect.rtype {size: 8, ptrdata: 8, hash: 3863140068, tflag: tflagUncommon|tflagExtraStar|tflagNamed|tflagRegularMemory (15), align: 8, fieldAlign: 8, kind: 54, equal: runtime.memequal64, gcdata: *1, str: 56864, ptrToThis: 135104}


### PR DESCRIPTION
Try to fix #379.
1. Deal with the defined pointer type (elem with marshaler methods) as encoding/json.
2. Not inline when compiling the pointer.