### PR TITLE
fix: initialize the elem when slice grow in decode

### DIFF
--- a/decoder/assembler_amd64_go117.go
+++ b/decoder/assembler_amd64_go117.go
@@ -348,8 +348,8 @@ func (self *_Assembler) epilogue() {
     self.Emit("MOVQ", _EP, _CX)                     // MOVQ BX, CX
     self.Emit("MOVQ", _ET, _BX)                     // MOVQ AX, BX
     self.Emit("MOVQ", _IC, _AX)                     // MOVQ IC, AX
-    self.Emit("MOVQ", jit.Imm(0), _ARG_sp)        // MOVQ $0, sv.p<>+48(FP)
-    self.Emit("MOVQ", jit.Imm(0), _ARG_vp)        // MOVQ $0, sv.p<>+48(FP)
+    self.Emit("MOVQ", jit.Imm(0), _ARG_sp)          // MOVQ $0, sv.p<>+48(FP)
+    self.Emit("MOVQ", jit.Imm(0), _ARG_vp)          // MOVQ $0, sv.p<>+48(FP)
     self.Emit("MOVQ", jit.Imm(0), _ARG_sv_p)        // MOVQ $0, sv.p<>+48(FP)
     self.Emit("MOVQ", jit.Imm(0), _ARG_vk)          // MOVQ $0, vk<>+64(FP)
     self.Emit("MOVQ", jit.Ptr(_SP, _FP_offs), _BP)  // MOVQ _FP_offs(SP), BP
@@ -480,6 +480,7 @@ var (
 var (
     _V_stackOverflow              = jit.Imm(int64(uintptr(unsafe.Pointer(&stackOverflow))))
     _I_json_UnsupportedValueError = jit.Itab(_T_error, reflect.TypeOf(new(json.UnsupportedValueError)))
+    _I_json_MismatchTypeError     = jit.Itab(_T_error, reflect.TypeOf(new(MismatchTypeError)))
 )
 
 func (self *_Assembler) type_error() {
@@ -489,7 +490,11 @@ func (self *_Assembler) type_error() {
 }
 
 func (self *_Assembler) mismatch_error() {
-    self.Link(_LB_mismatch_error)               // _type_error:
+    self.Link(_LB_mismatch_error)                     // _type_error:
+    self.Emit("MOVQ", _VAR_et, _ET)                   // MOVQ _VAR_et, _ET
+    self.Emit("MOVQ", _VAR_ic, _EP)                   // MOVQ _VAR_ic, _EP
+    self.Emit("CMPQ", _ET, _I_json_MismatchTypeError) // CMPQ _ET, _I_json_MismatchType
+    self.Sjmp("JE"  , _LB_error)                      // JE _LB_error
     self.Emit("MOVQ", _ARG_sp, _AX)
     self.Emit("MOVQ", _ARG_sl, _BX)
     self.Emit("MOVQ", _VAR_ic, _CX)
@@ -1119,7 +1124,7 @@ func (self *_Assembler) decode_dynamic(vt obj.Addr, vp obj.Addr) {
     self.Emit("MOVQ", _ARG_sp, _AX)            // MOVQ    sp, AX
     self.Emit("MOVQ", _ARG_sl, _BX)            // MOVQ    sp, BX
     self.Emit("MOVQ" , _IC, _CX)                // MOVQ    IC, CX
-    self.Emit("MOVQ" , _ST, _R8)                // MOVQ    ST, R8
+    self.Emit("MOVQ" , _ST, _R8)                // MOVQ    ST, R8 
     self.Emit("MOVQ" , _ARG_fv, _R9)            // MOVQ    fv, R9
     self.save(_REG_rt...)
     self.Emit("MOVQ", _F_decodeTypedPointer, _IL)  // MOVQ ${fn}, R11
@@ -1129,7 +1134,12 @@ func (self *_Assembler) decode_dynamic(vt obj.Addr, vp obj.Addr) {
     self.Emit("MOVQ" , _BX, _ET)                // MOVQ    BX, ET
     self.Emit("MOVQ" , _CX, _EP)                // MOVQ    CX, EP
     self.Emit("TESTQ", _ET, _ET)                // TESTQ   ET, ET
-    self.Sjmp("JNZ"  , _LB_error)               // JNZ     _error
+    self.Sjmp("JE", "_decode_dynamic_end_{n}")  // JE, _decode_dynamic_end_{n}
+    self.Emit("CMPQ",  _ET, _I_json_MismatchTypeError)
+    self.Sjmp("JNE"  , _LB_error)               // JNE  LB_error
+    self.Emit("MOVQ", _EP, _VAR_ic)             // MOVQ EP, VAR_ic
+    self.Emit("MOVQ", _ET, _VAR_et)             // MOVQ ET, VAR_et
+    self.Link("_decode_dynamic_end_{n}")
 }
 
 /** OpCode Assembler Functions **/

--- a/decoder/assembler_amd64_go117.go
+++ b/decoder/assembler_amd64_go117.go
@@ -1646,6 +1646,28 @@ func (self *_Assembler) _asm_OP_slice_append(p *_Instr) {
     self.WritePtrAX(8, jit.Ptr(_VP, 0), false)          // MOVQ    AX, (VP)
     self.Emit("MOVQ" , _BX, jit.Ptr(_VP, 8))            // MOVQ    BX, 8(VP)
     self.Emit("MOVQ" , _CX, jit.Ptr(_VP, 16))           // MOVQ    CX, 16(VP)
+
+    // because growslice not zero memory {oldcap, newlen} when append et not has ptrdata.
+    // but we should zero it, avoid decode it as random values.
+    if rt.UnpackType(p.vt()).PtrData == 0 {
+        self.Emit("MOVQ" , _CX, _DI)                        // MOVQ    CX, DI
+        self.Emit("SUBQ" , _BX, _DI)                        // MOVQ    BX, DI
+    
+        self.Emit("ADDQ" , jit.Imm(1), jit.Ptr(_VP, 8))     // ADDQ    $1, 8(VP)
+        self.Emit("MOVQ" , _AX, _VP)                        // MOVQ    AX, VP
+        self.Emit("MOVQ" , jit.Imm(int64(p.vlen())), _CX)   // MOVQ    ${p.vlen()}, CX
+        self.Emit("MOVQ" , _BX, _AX)                        // MOVQ    BX, AX 
+        self.From("MULQ" , _CX)                             // MULQ    CX
+        self.Emit("ADDQ" , _AX, _VP)                        // ADDQ    AX, VP
+
+        self.Emit("MOVQ" , _DI, _AX)                        // MOVQ    SI, AX
+        self.From("MULQ" , _CX)                             // MULQ    BX
+        self.Emit("MOVQ" , _AX, _BX)                        // ADDQ    AX, BX
+        self.Emit("MOVQ" , _VP, _AX)                        // MOVQ    VP, AX
+        self.mem_clear_fn(true)                             // CALL_GO memclr{Has,NoHeap}
+        self.Sjmp("JMP", "_append_slice_end_{n}")
+    }
+
     self.Emit("MOVQ" , _BX, _AX)                        // MOVQ    BX, AX
     self.Link("_index_{n}")                             // _index_{n}:
     self.Emit("ADDQ" , jit.Imm(1), jit.Ptr(_VP, 8))     // ADDQ    $1, 8(VP)
@@ -1653,6 +1675,7 @@ func (self *_Assembler) _asm_OP_slice_append(p *_Instr) {
     self.Emit("MOVQ" , jit.Imm(int64(p.vlen())), _CX)   // MOVQ    ${p.vlen()}, CX
     self.From("MULQ" , _CX)                             // MULQ    CX
     self.Emit("ADDQ" , _AX, _VP)                        // ADDQ    AX, VP
+    self.Link("_append_slice_end_{n}")
 }
 
 func (self *_Assembler) _asm_OP_object_skip(_ *_Instr) {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -134,9 +134,9 @@ func TestSkipMismatchTypeError(t *testing.T) {
             t.Fatal("invalid error")
         }
     })
-    t.Run("array", func(t *testing.T) {
+    t.Run("short array", func(t *testing.T) {
         var obj, obj2 = &[]int{}, &[]int{}
-        var data = `["",1,true]`
+        var data = `[""]`
         d := NewDecoder(data)
         err := d.Decode(obj)
         err2 := json.Unmarshal([]byte(data), obj2)
@@ -145,6 +145,32 @@ func TestSkipMismatchTypeError(t *testing.T) {
         // assert.Equal(t, len(data), d.i)
         assert.Equal(t, obj2, obj)
     })
+
+    t.Run("int ", func(t *testing.T) {
+        var obj int = 123
+        var obj2 int = 123
+        var data = `[""]`
+        d := NewDecoder(data)
+        err := d.Decode(&obj)
+        err2 := json.Unmarshal([]byte(data), &obj2)
+        println(err.Error(), obj, obj2)
+        assert.Equal(t, err2 == nil, err == nil)
+        // assert.Equal(t, len(data), d.i)
+        assert.Equal(t, obj2, obj)
+    })
+
+    t.Run("array", func(t *testing.T) {
+        var obj, obj2 = &[]int{}, &[]int{}
+        var data = `["",true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true]`
+        d := NewDecoder(data)
+        err := d.Decode(obj)
+        err2 := json.Unmarshal([]byte(data), obj2)
+        // println(err2.Error())
+        assert.Equal(t, err2 == nil, err == nil)
+        // assert.Equal(t, len(data), d.i)
+        assert.Equal(t, obj2, obj)
+    })
+
     t.Run("map", func(t *testing.T) {
         var obj, obj2 = &map[int]int{}, &map[int]int{}
         var data = `{"true" : { },"1":1,"2" : true,"3":3}`


### PR DESCRIPTION
As #325.

Initialize the elem when slice grow in decode, so that the elem is the default value when mismatching type.

