### PR TITLE
opt:(ast) pass `skipnumber` flag to avoid decoding numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A blazingly fast JSON serializing &amp; deserializing library, accelerated by JI
 
 ## Requirement
 - Go 1.16~1.20
-- Linux/MacOS/Windows(需要go1.17以上)
+- Linux/MacOS/Windows(need go1.17 above)
 - Amd64 ARCH
 
 ## Features
@@ -76,6 +76,8 @@ BenchmarkSetOne_Jsoniter-16                            79475 ns/op         163.8
 BenchmarkSetOne_Parallel_Sonic-16                      850.9 ns/op       15305.31 MB/s        1584 B/op         17 allocs/op
 BenchmarkSetOne_Parallel_Sjson-16                      18194 ns/op         715.77 MB/s       52247 B/op          9 allocs/op
 BenchmarkSetOne_Parallel_Jsoniter-16                   33560 ns/op         388.05 MB/s       45892 B/op        964 allocs/op
+BenchmarkLoadNode/LoadAll()-16                          4918 ns/op        2647.98 MB/s        7175 B/op         25 allocs/op
+BenchmarkLoadNode/Interface()-16                        9417 ns/op        1382.89 MB/s       15425 B/op         88 allocs/op
 ```
 - [Small](https://github.com/bytedance/sonic/blob/main/testdata/small.go) (400B, 11 keys, 3 layers)
 ![small benchmarks](./docs/imgs/bench-small.png)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A blazingly fast JSON serializing &amp; deserializing library, accelerated by JI
 
 ## Requirement
 - Go 1.16~1.20
-- Linux/MacOS/Windows(need go1.17 above)
+- Linux / MacOS / Windows(need go1.17 above)
 - Amd64 ARCH
 
 ## Features
@@ -76,8 +76,10 @@ BenchmarkSetOne_Jsoniter-16                            79475 ns/op         163.8
 BenchmarkSetOne_Parallel_Sonic-16                      850.9 ns/op       15305.31 MB/s        1584 B/op         17 allocs/op
 BenchmarkSetOne_Parallel_Sjson-16                      18194 ns/op         715.77 MB/s       52247 B/op          9 allocs/op
 BenchmarkSetOne_Parallel_Jsoniter-16                   33560 ns/op         388.05 MB/s       45892 B/op        964 allocs/op
-BenchmarkLoadNode/LoadAll()-16                          4918 ns/op        2647.98 MB/s        7175 B/op         25 allocs/op
-BenchmarkLoadNode/Interface()-16                        9417 ns/op        1382.89 MB/s       15425 B/op         88 allocs/op
+BenchmarkLoadNode/LoadAll()-16                         11384 ns/op        1143.93 MB/s        6307 B/op         25 allocs/op
+BenchmarkLoadNode_Parallel/LoadAll()-16                 5493 ns/op        2370.68 MB/s        7145 B/op         25 allocs/op
+BenchmarkLoadNode/Interface()-16                       17722 ns/op         734.85 MB/s       13323 B/op         88 allocs/op
+BenchmarkLoadNode_Parallel/Interface()-16              10330 ns/op        1260.70 MB/s       15178 B/op         88 allocs/op
 ```
 - [Small](https://github.com/bytedance/sonic/blob/main/testdata/small.go) (400B, 11 keys, 3 layers)
 ![small benchmarks](./docs/imgs/bench-small.png)

--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -6,8 +6,8 @@
 
 ## 依赖
 
-- Go 1.15~1.20
-- Linux/MacOS/Windows
+- Go 1.16~1.20
+- Linux / MacOS / Windows（需要 Go1.17 以上）
 - Amd64 架构
 
 ## 特色
@@ -79,6 +79,10 @@ BenchmarkSetOne_Jsoniter-16                            79475 ns/op         163.8
 BenchmarkSetOne_Parallel_Sonic-16                      850.9 ns/op       15305.31 MB/s        1584 B/op         17 allocs/op
 BenchmarkSetOne_Parallel_Sjson-16                      18194 ns/op         715.77 MB/s       52247 B/op          9 allocs/op
 BenchmarkSetOne_Parallel_Jsoniter-16                   33560 ns/op         388.05 MB/s       45892 B/op        964 allocs/op
+BenchmarkLoadNode/LoadAll()-16                         11384 ns/op        1143.93 MB/s        6307 B/op         25 allocs/op
+BenchmarkLoadNode_Parallel/LoadAll()-16                 5493 ns/op        2370.68 MB/s        7145 B/op         25 allocs/op
+BenchmarkLoadNode/Interface()-16                       17722 ns/op         734.85 MB/s       13323 B/op         88 allocs/op
+BenchmarkLoadNode_Parallel/Interface()-16              10330 ns/op        1260.70 MB/s       15178 B/op         88 allocs/op
 ```
 - [小型](https://github.com/bytedance/sonic/blob/main/testdata/small.go) (400B, 11 个键, 3 层)
 ![small benchmarks](./docs/imgs/bench-small.png)

--- a/ast/api_amd64.go
+++ b/ast/api_amd64.go
@@ -85,9 +85,19 @@ func encodeBase64(src []byte) string {
     return base64x.StdEncoding.EncodeToString(src)
 }
 
-func (self *Parser) decodeValue() (val types.JsonState) {
+func (self *Parser) decodeValue(skipNumber bool) (val types.JsonState) {
     sv := (*rt.GoString)(unsafe.Pointer(&self.s))
-    self.p = native.Value(sv.Ptr, sv.Len, self.p, &val, 0)
+    flag := uint64(0)
+    if !skipNumber {
+        val.Dbuf = types.NewDbuf()
+        val.Dcap = types.MaxDigitNums
+    } else {
+        flag = types.F_USE_NUMBER
+    }
+    self.p = native.Value(sv.Ptr, sv.Len, self.p, &val, flag)
+    if !skipNumber {
+        types.FreeDbuf(val.Dbuf)
+    }
     return
 }
 

--- a/ast/api_amd64.go
+++ b/ast/api_amd64.go
@@ -85,19 +85,15 @@ func encodeBase64(src []byte) string {
     return base64x.StdEncoding.EncodeToString(src)
 }
 
-func (self *Parser) decodeValue(skipNumber bool) (val types.JsonState) {
+func (self *Parser) decodeValue() (val types.JsonState) {
     sv := (*rt.GoString)(unsafe.Pointer(&self.s))
-    flag := uint64(0)
-    if !skipNumber {
-        val.Dbuf = types.NewDbuf()
+    flag := types.F_USE_NUMBER
+    if self.dbuf != nil {
+        flag = 0
+        val.Dbuf = self.dbuf
         val.Dcap = types.MaxDigitNums
-    } else {
-        flag = types.F_USE_NUMBER
     }
-    self.p = native.Value(sv.Ptr, sv.Len, self.p, &val, flag)
-    if !skipNumber {
-        types.FreeDbuf(val.Dbuf)
-    }
+    self.p = native.Value(sv.Ptr, sv.Len, self.p, &val, uint64(flag))
     return
 }
 

--- a/ast/api_compat.go
+++ b/ast/api_compat.go
@@ -52,8 +52,8 @@ func encodeBase64(src []byte) string {
     return base64.StdEncoding.EncodeToString(src)
 }
 
-func (self *Parser) decodeValue() (val types.JsonState) {
-    e, v := decodeValue(self.s, self.p)
+func (self *Parser) decodeValue(skipNumber bool) (val types.JsonState) {
+    e, v := decodeValue(self.s, self.p, skipNumber)
     if e < 0 {
         return v
     }

--- a/ast/api_compat.go
+++ b/ast/api_compat.go
@@ -52,8 +52,8 @@ func encodeBase64(src []byte) string {
     return base64.StdEncoding.EncodeToString(src)
 }
 
-func (self *Parser) decodeValue(skipNumber bool) (val types.JsonState) {
-    e, v := decodeValue(self.s, self.p, skipNumber)
+func (self *Parser) decodeValue() (val types.JsonState) {
+    e, v := decodeValue(self.s, self.p, self.dbuf == nil)
     if e < 0 {
         return v
     }

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -1184,6 +1184,56 @@ func BenchmarkLoadNode(b *testing.B) {
     b.Run("Interface()", func(b *testing.B) {
         b.SetBytes(int64(len(_TwitterJson)))
         b.ResetTimer()
+        for i:=0; i<b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _, _ = root.Interface()
+        }
+    })
+
+    b.Run("LoadAll()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i:=0; i<b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _ = root.LoadAll()
+        }
+    })
+
+    b.Run("InterfaceUseNode()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i:=0; i<b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _, _ = root.InterfaceUseNode()
+        }
+    })
+
+    b.Run("Load()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i:=0; i<b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _ = root.Load()
+        }
+    })
+}
+
+func BenchmarkLoadNode_Parallel(b *testing.B) {
+    b.Run("Interface()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
         b.RunParallel(func(pb *testing.PB) {
             for pb.Next() {
                 root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -17,11 +17,10 @@
 package ast
 
 import (
-	"fmt"
-	"sync"
+    `fmt`
 
-	"github.com/bytedance/sonic/internal/native/types"
-	"github.com/bytedance/sonic/internal/rt"
+    `github.com/bytedance/sonic/internal/native/types`
+    `github.com/bytedance/sonic/internal/rt`
 )
 
 const (
@@ -626,24 +625,18 @@ func NewParserObj(src string) Parser {
     return Parser{s: src}
 }
 
-var parserPool = sync.Pool {
-    New: func() interface{} {
-        return &Parser{dbuf: types.NewDbuf()}
-    },
-}
-
-// newParserDecodeNum returns new parser with Dbuf allocated
-func newParserDecodeNum(src string) *Parser {
-    ret := parserPool.Get().(*Parser)
-    ret.s = src
-    return ret
-}
-
-func freeParserDecodeNum(p *Parser) {
-    if p.dbuf == nil {
-        panic("parser must have dbuf allocated")
+// decodeNumber controls if parser decodes the number values instead of skip them
+//   WARN: once you set decodeNumber(true), please set decodeNumber(false) before you drop the parser 
+//   otherwise the memory CANNOT be reused
+func (self *Parser) decodeNumber(decode bool) {
+    if !decode && self.dbuf != nil {
+        types.FreeDbuf(self.dbuf)
+        self.dbuf = nil
+        return
     }
-    parserPool.Put(p)
+    if decode && self.dbuf == nil {
+        self.dbuf = types.NewDbuf()
+    }
 }
 
 // ExportError converts types.ParsingError to std Error

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -17,9 +17,11 @@
 package ast
 
 import (
-    `fmt`
-    `github.com/bytedance/sonic/internal/native/types`
-    `github.com/bytedance/sonic/internal/rt`
+	"fmt"
+	"sync"
+
+	"github.com/bytedance/sonic/internal/native/types"
+	"github.com/bytedance/sonic/internal/rt"
 )
 
 const (
@@ -42,6 +44,7 @@ type Parser struct {
     s           string
     noLazy      bool
     skipValue   bool
+    dbuf        *byte
 }
 
 /** Parser Private Methods **/
@@ -195,7 +198,7 @@ func (self *Parser) decodeObject(ret *linkedPairs) (Node, types.ParsingError) {
         var err types.ParsingError
 
         /* decode the key */
-        if njs = self.decodeValue(true); njs.Vt != types.V_STRING {
+        if njs = self.decodeValue(); njs.Vt != types.V_STRING {
             return Node{}, types.ERR_INVALID_CHAR
         }
 
@@ -287,7 +290,7 @@ func (self *Parser) Pos() int {
 }
 
 func (self *Parser) Parse() (Node, types.ParsingError) {
-    switch val := self.decodeValue(true); val.Vt {
+    switch val := self.decodeValue(); val.Vt {
         case types.V_EOF     : return Node{}, types.ERR_EOF
         case types.V_NULL    : return nullNode, 0
         case types.V_TRUE    : return trueNode, 0
@@ -340,7 +343,7 @@ func (self *Parser) searchKey(match string) types.ParsingError {
     for {
 
         /* decode the key */
-        if njs = self.decodeValue(true); njs.Vt != types.V_STRING {
+        if njs = self.decodeValue(); njs.Vt != types.V_STRING {
             return types.ERR_INVALID_CHAR
         }
 
@@ -521,7 +524,7 @@ func (self *Node) skipNextPair() (*Pair) {
     var err types.ParsingError
 
     /* decode the key */
-    if njs = parser.decodeValue(true); njs.Vt != types.V_STRING {
+    if njs = parser.decodeValue(); njs.Vt != types.V_STRING {
         return &Pair{"", *newSyntaxError(parser.syntaxError(types.ERR_INVALID_CHAR))}
     }
 
@@ -621,6 +624,26 @@ func NewParser(src string) *Parser {
 // NewParser returns new allocated parser
 func NewParserObj(src string) Parser {
     return Parser{s: src}
+}
+
+var parserPool = sync.Pool {
+    New: func() interface{} {
+        return &Parser{dbuf: types.NewDbuf()}
+    },
+}
+
+// newParserDecodeNum returns new parser with Dbuf allocated
+func newParserDecodeNum(src string) *Parser {
+    ret := parserPool.Get().(*Parser)
+    ret.s = src
+    return ret
+}
+
+func freeParserDecodeNum(p *Parser) {
+    if p.dbuf == nil {
+        panic("parser must have dbuf allocated")
+    }
+    parserPool.Put(p)
 }
 
 // ExportError converts types.ParsingError to std Error

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -195,7 +195,7 @@ func (self *Parser) decodeObject(ret *linkedPairs) (Node, types.ParsingError) {
         var err types.ParsingError
 
         /* decode the key */
-        if njs = self.decodeValue(); njs.Vt != types.V_STRING {
+        if njs = self.decodeValue(true); njs.Vt != types.V_STRING {
             return Node{}, types.ERR_INVALID_CHAR
         }
 
@@ -287,7 +287,7 @@ func (self *Parser) Pos() int {
 }
 
 func (self *Parser) Parse() (Node, types.ParsingError) {
-    switch val := self.decodeValue(); val.Vt {
+    switch val := self.decodeValue(true); val.Vt {
         case types.V_EOF     : return Node{}, types.ERR_EOF
         case types.V_NULL    : return nullNode, 0
         case types.V_TRUE    : return trueNode, 0
@@ -340,7 +340,7 @@ func (self *Parser) searchKey(match string) types.ParsingError {
     for {
 
         /* decode the key */
-        if njs = self.decodeValue(); njs.Vt != types.V_STRING {
+        if njs = self.decodeValue(true); njs.Vt != types.V_STRING {
             return types.ERR_INVALID_CHAR
         }
 
@@ -521,7 +521,7 @@ func (self *Node) skipNextPair() (*Pair) {
     var err types.ParsingError
 
     /* decode the key */
-    if njs = parser.decodeValue(); njs.Vt != types.V_STRING {
+    if njs = parser.decodeValue(true); njs.Vt != types.V_STRING {
         return &Pair{"", *newSyntaxError(parser.syntaxError(types.ERR_INVALID_CHAR))}
     }
 

--- a/decoder/decoder_compat.go
+++ b/decoder/decoder_compat.go
@@ -35,14 +35,14 @@ func init() {
 }
 
 const (
-     _F_use_int64 = iota
-     _F_use_number
-     _F_disable_urc
-     _F_disable_unknown
-     _F_copy_string
-     _F_validate_string
-
-     _F_allow_control = 31
+     _F_use_int64       = 0
+     _F_disable_urc     = 2
+     _F_disable_unknown = 3
+     _F_copy_string     = 4
+ 
+     _F_use_number      = types.B_USE_NUMBER
+     _F_validate_string = types.B_VALIDATE_STRING
+     _F_allow_control   = types.B_ALLOW_CONTROL
 )
 
 type Options uint64

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -30,14 +30,14 @@ import (
 )
 
 const (
-    _F_use_int64 = iota
-    _F_use_number
-    _F_disable_urc
-    _F_disable_unknown
-    _F_copy_string
-    _F_validate_string
+    _F_use_int64       = 0
+    _F_disable_urc     = 2
+    _F_disable_unknown = 3
+    _F_copy_string     = 4
 
-    _F_allow_control = 31
+    _F_use_number      = types.B_USE_NUMBER
+    _F_validate_string = types.B_VALIDATE_STRING
+    _F_allow_control   = types.B_ALLOW_CONTROL
 )
 
 type Options uint64

--- a/internal/decoder/pools.go
+++ b/internal/decoder/pools.go
@@ -29,7 +29,7 @@ const (
     _MinSlice = 2
     _MaxStack = 4096 // 4k slots
     _MaxStackBytes = _MaxStack * _PtrBytes
-    _MaxDigitNums = 800  // used in atof fallback algorithm
+    _MaxDigitNums = types.MaxDigitNums  // used in atof fallback algorithm
 )
 
 const (


### PR DESCRIPTION
## Benchmark
```
name                                     old time/op    new time/op    delta
LoadNode_Parallel/LoadAll()-16             6.08µs ± 4%    5.76µs ±26%     ~     (p=0.203 n=8+10)
LoadNode_Parallel/Load()-16                1.80µs ± 3%    2.02µs ±22%     ~     (p=0.055 n=10+10)
LoadNode/Load()-16                         5.54µs ± 5%    5.16µs ± 2%   -6.97%  (p=0.000 n=10+10)
LoadNode_Parallel/InterfaceUseNode()-16    2.91µs ± 5%    2.68µs ±16%   -7.80%  (p=0.003 n=10+9)
LoadNode/InterfaceUseNode()-16             6.77µs ± 4%    6.22µs ± 4%   -8.18%  (p=0.000 n=10+9)
LoadNode_Parallel/Interface()-16           12.1µs ± 2%    10.3µs ± 4%  -14.36%  (p=0.000 n=6+10)
LoadNode/LoadAll()-16                      13.6µs ± 8%    11.5µs ±10%  -15.28%  (p=0.000 n=10+10)
LoadNode/Interface()-16                    26.7µs ±18%    17.7µs ± 0%  -33.59%  (p=0.000 n=10+8)

name                                     old speed      new speed      delta
LoadNode_Parallel/LoadAll()-16           2.11GB/s ±11%  2.29GB/s ±21%     ~     (p=0.133 n=9+10)
LoadNode_Parallel/Load()-16              7.24GB/s ± 3%  6.56GB/s ±19%     ~     (p=0.063 n=10+10)
LoadNode/Load()-16                       2.35GB/s ± 5%  2.53GB/s ± 2%   +7.46%  (p=0.000 n=10+10)
LoadNode/InterfaceUseNode()-16           1.92GB/s ± 4%  2.09GB/s ± 4%   +8.89%  (p=0.000 n=10+9)
LoadNode_Parallel/InterfaceUseNode()-16  4.48GB/s ± 5%  4.87GB/s ±14%   +8.89%  (p=0.003 n=10+9)
LoadNode_Parallel/Interface()-16         1.08GB/s ± 2%  1.26GB/s ± 4%  +16.84%  (p=0.000 n=6+10)
LoadNode/LoadAll()-16                     960MB/s ± 8%  1135MB/s ±10%  +18.21%  (p=0.000 n=10+10)
LoadNode/Interface()-16                   493MB/s ±16%   734MB/s ± 0%  +49.02%  (p=0.000 n=10+8)

name                                     old alloc/op   new alloc/op   delta
LoadNode/Load()-16                         1.06kB ± 0%    1.09kB ± 0%   +2.95%  (p=0.000 n=9+10)
LoadNode_Parallel/Load()-16                1.20kB ± 1%    1.24kB ± 1%   +2.75%  (p=0.000 n=10+10)
LoadNode_Parallel/InterfaceUseNode()-16    2.99kB ± 1%    3.03kB ± 3%   +1.31%  (p=0.004 n=10+10)
LoadNode/InterfaceUseNode()-16             2.62kB ± 0%    2.65kB ± 0%   +1.31%  (p=0.000 n=10+10)
LoadNode/Interface()-16                    13.3kB ± 0%    13.3kB ± 0%   +0.25%  (p=0.000 n=10+10)
LoadNode/LoadAll()-16                      6.30kB ± 0%    6.31kB ± 0%   +0.06%  (p=0.045 n=10+9)
LoadNode_Parallel/Interface()-16           15.0kB ± 2%    15.1kB ± 1%     ~     (p=0.243 n=9+10)
LoadNode_Parallel/LoadAll()-16             7.08kB ± 2%    7.10kB ± 2%     ~     (p=0.684 n=10+10)

name                                     old allocs/op  new allocs/op  delta
LoadNode/Interface()-16                      88.0 ± 0%      88.0 ± 0%     ~     (all equal)
LoadNode/LoadAll()-16                        25.0 ± 0%      25.0 ± 0%     ~     (all equal)
LoadNode/InterfaceUseNode()-16               7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LoadNode/Load()-16                           5.00 ± 0%      5.00 ± 0%     ~     (all equal)
LoadNode_Parallel/Interface()-16             88.0 ± 0%      88.0 ± 0%     ~     (all equal)
LoadNode_Parallel/LoadAll()-16               25.0 ± 0%      25.0 ± 0%     ~     (all equal)
LoadNode_Parallel/InterfaceUseNode()-16      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
LoadNode_Parallel/Load()-16                  5.00 ± 0%      5.00 ± 0%     ~     (all equal)
```