### PR TITLE
fix/test: t.Fatal should be called from `g` running the test or benchmark func

### DIFF
--- a/ast/encode_test.go
+++ b/ast/encode_test.go
@@ -48,12 +48,14 @@ func TestGC_Encode(t *testing.T) {
             defer wg.Done()
             root, err := NewSearcher(_TwitterJson).GetByPath()
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             root.Load()
             _, err = root.MarshalJSON()
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             runtime.GC()
         }(wg)

--- a/ast/parser_test.go
+++ b/ast/parser_test.go
@@ -66,7 +66,8 @@ func TestGC_Parse(t *testing.T) {
             defer wg.Done()
             _, _, err := Loads(_TwitterJson)
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             runtime.GC()
         }(wg)

--- a/ast/search_test.go
+++ b/ast/search_test.go
@@ -46,7 +46,8 @@ func TestGC_Search(t *testing.T) {
             defer wg.Done()
             _, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0, "id")
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             runtime.GC()
         }(wg)

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -67,10 +67,12 @@ func TestGC(t *testing.T) {
             var w interface{}
             out, err := decode(TwitterJson, &w, true)
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             if out != len(TwitterJson) {
-                t.Fatal(out)
+                t.Error(out)
+                return
             }
             runtime.GC()
         }(wg)

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -64,10 +64,12 @@ func TestGC(t *testing.T) {
             defer wg.Done()
             out, err := Encode(_GenericValue, 0)
             if err != nil {
-                t.Fatal(err)
+                t.Error(err)
+                return
             }
             if len(out) != size {
-                t.Fatal(len(out), size)
+                t.Error(len(out), size)
+                return
             }
             runtime.GC()
         }(wg, n)


### PR DESCRIPTION
The linter complains: the goroutine calls T.Fatal, which must be called in the same goroutine as the testSA2002(default).

testing.T.Fail will calls testing.common.FailNow(), this function will marks the test failing and call runtime.GoExit(). Sure, it could let the calling goroutine exit, but this is a misuse.

t.Fail should be used for marks the test failing and let the goroutine which runs this test or the benchmark func exit. So, just use t.Error+return instead.