### PR TITLE
fix: didn't pass non-exist value when call `Node.Interface()`

### DIFF
--- a/ast/iterator.go
+++ b/ast/iterator.go
@@ -32,7 +32,11 @@ func (self *Node) Values() (ListIterator, error) {
     if err := self.should(types.V_ARRAY, "an array"); err != nil {
         return ListIterator{}, err
     }
-    return ListIterator{Iterator{p: self}}, nil
+    return self.values(), nil
+}
+
+func (self *Node) values() ListIterator {
+    return ListIterator{Iterator{p: self}}
 }
 
 // Properties returns iterator for object's children traversal
@@ -40,7 +44,11 @@ func (self *Node) Properties() (ObjectIterator, error) {
     if err := self.should(types.V_OBJECT, "an object"); err != nil {
         return ObjectIterator{}, err
     }
-    return ObjectIterator{Iterator{p: self}}, nil
+    return self.properties(), nil
+}
+
+func (self *Node) properties() ObjectIterator {
+    return ObjectIterator{Iterator{p: self}}
 }
 
 type Iterator struct {

--- a/ast/node.go
+++ b/ast/node.go
@@ -1353,17 +1353,16 @@ func (self *Node) toGenericArray() ([]interface{}, error) {
     if nb == 0 {
         return []interface{}{}, nil
     }
-    ret := make([]interface{}, nb)
+    ret := make([]interface{}, 0, nb)
     
     /* convert each item */
-    var s = (*linkedNodes)(self.p)
-    for i := 0; i < nb; i++ {
-        p := s.At(i)
-        x, err := p.Interface()
+    it := self.values()
+    for v := it.next(); v != nil; v = it.next() {
+        vv, err := v.Interface()
         if err != nil {
             return nil, err
         }
-        ret[i] = x
+        ret = append(ret, vv)
     }
 
     /* all done */
@@ -1375,17 +1374,16 @@ func (self *Node) toGenericArrayUseNumber() ([]interface{}, error) {
     if nb == 0 {
         return []interface{}{}, nil
     }
-    ret := make([]interface{}, nb)
+    ret := make([]interface{}, 0, nb)
 
     /* convert each item */
-    var s = (*linkedNodes)(self.p)
-    for i := 0; i < nb; i++ {
-        p := s.At(i)
-        x, err := p.InterfaceUseNumber()
+    it := self.values()
+    for v := it.next(); v != nil; v = it.next() {
+        vv, err := v.InterfaceUseNumber()
         if err != nil {
             return nil, err
         }
-        ret[i] = x
+        ret = append(ret, vv)
     }
 
     /* all done */
@@ -1413,14 +1411,13 @@ func (self *Node) toGenericObject() (map[string]interface{}, error) {
     ret := make(map[string]interface{}, nb)
 
     /* convert each item */
-    var s = (*linkedPairs)(self.p)
-    for i := 0; i < nb; i++ {
-        p := s.At(i)
-        x, err := p.Value.Interface()
+    it := self.properties()
+    for v := it.next(); v != nil; v = it.next() {
+        vv, err := v.Value.Interface()
         if err != nil {
             return nil, err
         }
-        ret[p.Key] = x
+        ret[v.Key] = vv
     }
 
     /* all done */
@@ -1436,14 +1433,13 @@ func (self *Node) toGenericObjectUseNumber() (map[string]interface{}, error) {
     ret := make(map[string]interface{}, nb)
 
     /* convert each item */
-    var s = (*linkedPairs)(self.p)
-    for i := 0; i < nb; i++ {
-        p := s.At(i)
-        x, err := p.Value.InterfaceUseNumber()
+    it := self.properties()
+    for v := it.next(); v != nil; v = it.next() {
+        vv, err := v.Value.InterfaceUseNumber()
         if err != nil {
             return nil, err
         }
-        ret[p.Key] = x
+        ret[v.Key] = vv
     }
 
     /* all done */

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -791,6 +791,21 @@ func TestUnset(t *testing.T) {
     if entities.len() != 3 { 
         t.Fatal(entities.len())
     }
+
+    es, err := entities.Interface()
+    require.NoError(t, err)
+    require.Equal(t, map[string]interface{}{
+        "hashtags": []interface{}{
+            map[string]interface{}{
+                "text": "freebandnames",
+                "indices": []interface{}{
+                    float64(20), float64(34),
+                },
+            },
+        },
+        "user_mentions": []interface{}{},
+    },es)
+
     out, err := entities.MarshalJSON()
     require.NoError(t, err)
     println(string(out))
@@ -821,7 +836,6 @@ func TestUnset(t *testing.T) {
     if e.Exists() {
         t.Fatal()
     }
-  
 
     hashtags := entities.Get("hashtags").Index(0)
     hashtags.Set("text2", newRawNode(`{}`, types.V_OBJECT))
@@ -848,6 +862,11 @@ func TestUnset(t *testing.T) {
     if !exist || err != nil {
         t.Fatal()
     }
+
+    umses, err := ums.Interface()
+    require.NoError(t, err)
+    require.Equal(t, []interface{}{interface{}(nil), true},umses)
+
     v1, _ := ums.Index(0).Interface()
     v2, _ := ums.Index(1).Interface() // NOTICE: unseted index 1 still can be find here
     v3, _ := ums.Index(2).Interface()


### PR DESCRIPTION
# Issue
After `Unset()` some nodes for its parent, call parent.Interface() will return errors like `unsupported type`
# Reason
That's because since # , sonic/ast didn't delete node memory after `Unset()` meanwhile `Interface()` logic counted the actually non-exist node