### PR TITLE
opt: refactor streaming decoder to fully use buffer

### DIFF
--- a/fuzz/fuzz_test.go
+++ b/fuzz/fuzz_test.go
@@ -61,6 +61,7 @@ func fuzzMain(t *testing.T, data []byte) {
     if !json.Valid(data) {
         return
     }
+    fuzzStream(t, data)
     for i, typ := range []func() interface{}{
         func() interface{} { return new(interface{}) },
         func() interface{} { return new(map[string]interface{}) },

--- a/internal/decoder/stream_test.go
+++ b/internal/decoder/stream_test.go
@@ -31,8 +31,8 @@ import (
 
 var (
     DefaultBufferSize = option.DefaultDecoderBufferSize
-    _Single_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"} { `
-    _Double_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}    {"11111":"` + strings.Repeat("2", int(DefaultBufferSize)) + `"}`     
+    _Single_JSON = `{`+`"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}` + strings.Repeat(" ", int(DefaultBufferSize)) + `{`
+    _Double_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}` + strings.Repeat(" ", int(DefaultBufferSize)) + `{"11111":"` + strings.Repeat("2", int(DefaultBufferSize)) + `"}`     
     _Triple_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}{ } {"11111":"` + 
     strings.Repeat("2", int(DefaultBufferSize))+`"} b {}`
 )
@@ -82,6 +82,35 @@ func TestDecodeEmpty(t *testing.T) {
     ee1 := d2.Decode(&v2)
     assert.Equal(t, es1, ee1)
     assert.Equal(t, v1, v2)
+}
+
+func TestDecodeRecurse(t *testing.T) {
+    var str = _Single_JSON
+    var r1 = bytes.NewBufferString(str)
+    var v1 interface{}
+    var d1 = json.NewDecoder(r1)
+    var r2 = bytes.NewBufferString(str)
+    var v2 interface{}
+    var d2 = NewStreamDecoder(r2)
+
+    require.Equal(t, d1.More(), d2.More())
+    es1 := d1.Decode(&v1)
+    ee1 := d2.Decode(&v2)
+    assert.Equal(t, es1, ee1)
+    println(es1)
+    assert.Equal(t, v1, v2)
+    require.Equal(t, d1.More(), d2.More())
+
+    r1.WriteString(str[1:])
+    r2.WriteString(str[1:])
+
+    require.Equal(t, d1.More(), d2.More())
+    es1 = d1.Decode(&v1)
+    ee1 = d2.Decode(&v2)
+    assert.Equal(t, es1, ee1)
+    println(es1)
+    assert.Equal(t, v1, v2)
+    require.Equal(t, d1.More(), d2.More())
 }
 
 type HaltReader struct {
@@ -135,10 +164,13 @@ func TestBuffered(t *testing.T) {
     var r1 = NewHaltReader(str, testHalts())
     var v1 map[string]interface{}
     var d1 = json.NewDecoder(r1)
-    require.Nil(t, d1.Decode(&v1))
+  
     var r2 = NewHaltReader(str, testHalts())
     var v2 map[string]interface{}
     var d2 = NewStreamDecoder(r2)
+
+    require.Equal(t, d1.More(), d2.More())
+    require.Nil(t, d1.Decode(&v1))
     require.Nil(t, d2.Decode(&v2))
     left1, err1 := ioutil.ReadAll(d1.Buffered())
     require.Nil(t, err1)
@@ -151,11 +183,13 @@ func TestBuffered(t *testing.T) {
     }
     require.Equal(t, left1[:min], left2[:min])
 
+    require.Equal(t, d1.More(), d2.More())
     es4 := d1.Decode(&v1)
     ee4 := d2.Decode(&v2)
     assert.Equal(t, es4, ee4)
     assert.Equal(t, d1.InputOffset(), d2.InputOffset())
 
+    // require.Equal(t, d1.More(), d2.More())
     es2 := d1.Decode(&v1)
     ee2 := d2.Decode(&v2)
     assert.Equal(t, es2, ee2)
@@ -165,12 +199,15 @@ func TestBuffered(t *testing.T) {
 func BenchmarkDecodeStream_Std(b *testing.B) {
     b.Run("single", func (b *testing.B) {
         var str = _Single_JSON
+        var r1 = bytes.NewBufferString(str)
+        dc := json.NewDecoder(r1)
         for i:=0; i<b.N; i++ {
-            var r1 = strings.NewReader(str)
             var v1 map[string]interface{}
-            dc := json.NewDecoder(r1)
-            _ = dc.Decode(&v1)
-            _ = dc.Decode(&v1)
+            e := dc.Decode(&v1)
+            if e != nil {
+                b.Fatal(e)
+            }
+            r1.WriteString(str[1:])
         }
     })
 
@@ -181,7 +218,25 @@ func BenchmarkDecodeStream_Std(b *testing.B) {
             var v1 map[string]interface{}
             dc := json.NewDecoder(r1)
             _ = dc.Decode(&v1)
-            _ = dc.Decode(&v1)
+            if dc.More() {
+                _ = dc.Decode(&v1)
+            }
+        }
+    })
+
+    b.Run("4x", func (b *testing.B) {
+        var str = _Double_JSON + strings.Repeat(" ", int(DefaultBufferSize-10)) + _Double_JSON
+        b.ResetTimer()
+        for i:=0; i<b.N; i++ {
+            var r1 = strings.NewReader(str)
+            var v1 map[string]interface{}
+            dc := json.NewDecoder(r1)
+            for dc.More() {
+                e := dc.Decode(&v1)
+                if e != nil {
+                    b.Fatal(e)
+                }
+            }
         }
     })
     
@@ -205,35 +260,57 @@ func BenchmarkDecodeStream_Std(b *testing.B) {
 // }
 
 func BenchmarkDecodeStream_Sonic(b *testing.B) {
-    b.Run("single", func (b *testing.B) {
-        var str = _Single_JSON
+    // b.Run("single", func (b *testing.B) {
+    //     var str = _Single_JSON
+    //     var r1 = bytes.NewBufferString(str)
+    //     dc := NewStreamDecoder(r1)
+    //     for i:=0; i<b.N; i++ {
+    //         var v1 map[string]interface{}
+    //         e := dc.Decode(&v1)
+    //         if e != nil {
+    //             b.Fatal(e)
+    //         }
+    //         r1.WriteString(str[1:])
+    //     }
+    // })
+
+    // b.Run("double", func (b *testing.B) {
+    //     var str = _Double_JSON
+    //     for i:=0; i<b.N; i++ {
+    //         var r1 = strings.NewReader(str)
+    //         var v1 map[string]interface{}
+    //         dc := NewStreamDecoder(r1)
+    //         _ = dc.Decode(&v1)
+    //         if dc.More() {
+    //             _ = dc.Decode(&v1)
+    //         }
+    //     }
+    // })
+
+    b.Run("4x", func (b *testing.B) {
+        var str = _Double_JSON + strings.Repeat(" ", int(DefaultBufferSize-10)) + _Double_JSON
+        b.ResetTimer()
         for i:=0; i<b.N; i++ {
+            println("loop")
             var r1 = strings.NewReader(str)
             var v1 map[string]interface{}
             dc := NewStreamDecoder(r1)
-            _ = dc.Decode(&v1)
-            _ = dc.Decode(&v1)
+            for dc.More() {
+                e := dc.Decode(&v1)
+                if e != nil {
+                    b.Fatal(e)
+                }
+            }
         }
     })
 
-    b.Run("double", func (b *testing.B) {
-        var str = _Double_JSON
-        for i:=0; i<b.N; i++ {
-            var r1 = strings.NewReader(str)
-            var v1 map[string]interface{}
-            dc := NewStreamDecoder(r1)
-            _ = dc.Decode(&v1)
-            _ = dc.Decode(&v1)
-        }
-    })
-
-    b.Run("halt", func (b *testing.B) {
-        var str = _Double_JSON
-        for i:=0; i<b.N; i++ {
-            var r1 = NewHaltReader(str, testHalts())
-            var v1 map[string]interface{}
-            dc := NewStreamDecoder(r1)
-            _ = dc.Decode(&v1)
-        }
-    })
+    // b.Run("halt", func (b *testing.B) {
+    //     var str = _Double_JSON
+    //     for i:=0; i<b.N; i++ {
+    //         var r1 = NewHaltReader(str, testHalts())
+    //         var v1 map[string]interface{}
+    //         dc := NewStreamDecoder(r1)
+    //         _ = dc.Decode(&v1)
+    //     }
+    // })
 }

--- a/internal/decoder/stream_test.go
+++ b/internal/decoder/stream_test.go
@@ -97,10 +97,9 @@ func TestDecodeRecurse(t *testing.T) {
     es1 := d1.Decode(&v1)
     ee1 := d2.Decode(&v2)
     assert.Equal(t, es1, ee1)
-    println(es1)
     assert.Equal(t, v1, v2)
-    require.Equal(t, d1.More(), d2.More())
 
+    require.Equal(t, d1.More(), d2.More())
     r1.WriteString(str[1:])
     r2.WriteString(str[1:])
 
@@ -187,13 +186,15 @@ func TestBuffered(t *testing.T) {
     es4 := d1.Decode(&v1)
     ee4 := d2.Decode(&v2)
     assert.Equal(t, es4, ee4)
-    assert.Equal(t, d1.InputOffset(), d2.InputOffset())
+    println(str[d1.InputOffset()-5:d1.InputOffset()+5])
+    assert.Equal(t, d1.InputOffset(), d2.InputOffset()-1)
 
-    // require.Equal(t, d1.More(), d2.More())
+    require.Equal(t, d1.More(), d2.More())
     es2 := d1.Decode(&v1)
     ee2 := d2.Decode(&v2)
     assert.Equal(t, es2, ee2)
-    assert.Equal(t, d1.InputOffset(), d2.InputOffset())
+    println(str[d1.InputOffset()-5:d1.InputOffset()+5])
+    assert.Equal(t, d1.InputOffset(), d2.InputOffset()-1)
 }
 
 func BenchmarkDecodeStream_Std(b *testing.B) {
@@ -260,38 +261,38 @@ func BenchmarkDecodeStream_Std(b *testing.B) {
 // }
 
 func BenchmarkDecodeStream_Sonic(b *testing.B) {
-    // b.Run("single", func (b *testing.B) {
-    //     var str = _Single_JSON
-    //     var r1 = bytes.NewBufferString(str)
-    //     dc := NewStreamDecoder(r1)
-    //     for i:=0; i<b.N; i++ {
-    //         var v1 map[string]interface{}
-    //         e := dc.Decode(&v1)
-    //         if e != nil {
-    //             b.Fatal(e)
-    //         }
-    //         r1.WriteString(str[1:])
-    //     }
-    // })
+    b.Run("single", func (b *testing.B) {
+        var str = _Single_JSON
+        var r1 = bytes.NewBufferString(str)
+        dc := NewStreamDecoder(r1)
+        for i:=0; i<b.N; i++ {
+            var v1 map[string]interface{}
+            e := dc.Decode(&v1)
+            if e != nil {
+                b.Fatal(e)
+            }
+            r1.WriteString(str[1:])
+        }
+    })
 
-    // b.Run("double", func (b *testing.B) {
-    //     var str = _Double_JSON
-    //     for i:=0; i<b.N; i++ {
-    //         var r1 = strings.NewReader(str)
-    //         var v1 map[string]interface{}
-    //         dc := NewStreamDecoder(r1)
-    //         _ = dc.Decode(&v1)
-    //         if dc.More() {
-    //             _ = dc.Decode(&v1)
-    //         }
-    //     }
-    // })
+    b.Run("double", func (b *testing.B) {
+        var str = _Double_JSON
+        for i:=0; i<b.N; i++ {
+            var r1 = strings.NewReader(str)
+            var v1 map[string]interface{}
+            dc := NewStreamDecoder(r1)
+            _ = dc.Decode(&v1)
+            if dc.More() {
+                _ = dc.Decode(&v1)
+            }
+        }
+    })
 
     b.Run("4x", func (b *testing.B) {
         var str = _Double_JSON + strings.Repeat(" ", int(DefaultBufferSize-10)) + _Double_JSON
         b.ResetTimer()
         for i:=0; i<b.N; i++ {
-            println("loop")
+            // println("loop")
             var r1 = strings.NewReader(str)
             var v1 map[string]interface{}
             dc := NewStreamDecoder(r1)
@@ -304,13 +305,13 @@ func BenchmarkDecodeStream_Sonic(b *testing.B) {
         }
     })
 
-    // b.Run("halt", func (b *testing.B) {
-    //     var str = _Double_JSON
-    //     for i:=0; i<b.N; i++ {
-    //         var r1 = NewHaltReader(str, testHalts())
-    //         var v1 map[string]interface{}
-    //         dc := NewStreamDecoder(r1)
-    //         _ = dc.Decode(&v1)
-    //     }
-    // })
+    b.Run("halt", func (b *testing.B) {
+        var str = _Double_JSON
+        for i:=0; i<b.N; i++ {
+            var r1 = NewHaltReader(str, testHalts())
+            var v1 map[string]interface{}
+            dc := NewStreamDecoder(r1)
+            _ = dc.Decode(&v1)
+        }
+    })
 }

--- a/internal/decoder/stream_test.go
+++ b/internal/decoder/stream_test.go
@@ -35,6 +35,7 @@ var (
     _Double_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}` + strings.Repeat(" ", int(DefaultBufferSize)) + `{"11111":"` + strings.Repeat("2", int(DefaultBufferSize)) + `"}`     
     _Triple_JSON = `{"aaaaa":"` + strings.Repeat("b", int(DefaultBufferSize)) + `"}{ } {"11111":"` + 
     strings.Repeat("2", int(DefaultBufferSize))+`"} b {}`
+    _SMALL_JSON = `{"a":"b"} [1] {"c":"d"} [2]`
 )
 
 func TestStreamError(t *testing.T) {
@@ -250,6 +251,21 @@ func BenchmarkDecodeStream_Std(b *testing.B) {
             _ = dc.Decode(&v1)
         }
     })
+
+    b.Run("small", func (b *testing.B) {
+        var str = _SMALL_JSON
+        for i:=0; i<b.N; i++ {
+            var r1 = strings.NewReader(str)
+            var v1 interface{}
+            dc := json.NewDecoder(r1)
+            for dc.More() {
+                e := dc.Decode(&v1)
+                if e != nil {
+                    b.Fatal(e)
+                }
+            }
+        }
+    })
 }
 
 // func BenchmarkDecodeError_Sonic(b *testing.B) {
@@ -312,6 +328,22 @@ func BenchmarkDecodeStream_Sonic(b *testing.B) {
             var v1 map[string]interface{}
             dc := NewStreamDecoder(r1)
             _ = dc.Decode(&v1)
+        }
+    })
+
+    b.Run("small", func (b *testing.B) {
+        var str = _SMALL_JSON
+        for i:=0; i<b.N; i++ {
+            // println("one loop")
+            var r1 = strings.NewReader(str)
+            var v1 interface{}
+            dc := NewStreamDecoder(r1)
+            for dc.More() {
+                e := dc.Decode(&v1)
+                if e != nil {
+                    b.Fatal(e)
+                }
+            }
         }
     })
 }


### PR DESCRIPTION
# Optimization
- refactor implementation of `StreamDecoder.Decode()`
- reduce memory copy by limiting start and end of slice passed to `skip()` 
- never move head of decoder buffer, always move tail
- check if buffer remains valid bytes after each`Decode()` or `More()`, if not, recycle buffer
# Benchmark
```
name                          old time/op    new time/op    delta
DecodeStream_Sonic/halt-16       698µs ± 7%     732µs ± 3%   +4.84%  (p=0.002 n=10+10)
DecodeStream_Sonic/single-16     273µs ± 7%     191µs ± 4%  -30.03%  (p=0.000 n=9+10)
DecodeStream_Sonic/4x-16        1.49ms ± 2%    0.59ms ± 7%  -59.98%  (p=0.000 n=10+10)
DecodeStream_Sonic/double-16     679µs ± 3%     237µs ± 5%  -65.00%  (p=0.000 n=10+9)
DecodeStream_Sonic/small-16     27.0µs ± 8%     1.6µs ± 3%  -94.17%  (p=0.000 n=10+9)

name                          old alloc/op   new alloc/op   delta
DecodeStream_Sonic/halt-16       265kB ± 0%     142kB ± 1%  -46.38%  (p=0.000 n=10+10)
DecodeStream_Sonic/double-16    1.20MB ± 0%    0.28MB ± 0%  -76.65%  (p=0.000 n=10+10)
DecodeStream_Sonic/4x-16        2.79MB ± 0%    0.56MB ± 0%  -79.87%  (p=0.000 n=10+10)
DecodeStream_Sonic/single-16    1.32MB ± 0%    0.14MB ± 0%  -89.36%  (p=0.000 n=10+9)
DecodeStream_Sonic/small-16      269kB ± 0%       1kB ± 0%  -99.45%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
DecodeStream_Sonic/small-16       21.0 ± 0%      20.0 ± 0%   -4.76%  (p=0.000 n=10+10)
DecodeStream_Sonic/halt-16        12.0 ± 0%       9.0 ± 0%  -25.00%  (p=0.000 n=10+10)
DecodeStream_Sonic/double-16      18.0 ± 0%       9.0 ± 0%  -50.00%  (p=0.000 n=10+10)
DecodeStream_Sonic/4x-16          29.0 ± 0%      14.0 ± 0%  -51.72%  (p=0.000 n=10+10)
DecodeStream_Sonic/single-16      11.0 ± 0%       5.0 ± 0%  -54.55%  (p=0.000 n=10+10)
```