### PR TITLE
test scalability for json lib

### DIFF
--- a/timing_test.go
+++ b/timing_test.go
@@ -1,0 +1,188 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sonic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWork(t *testing.T) {
+	N, err := strconv.Atoi(os.Args[len(os.Args)-1])
+	if err != nil {
+		return
+	}
+	p, err := strconv.Atoi(os.Args[len(os.Args)-2])
+	if err != nil {
+		return
+	}
+	j := os.Args[len(os.Args)-3]
+	var obj = map[string]interface{}{}
+	for i:=0; i<100; i++ {
+		obj[strconv.Itoa(i)] = i
+	}
+	var work func()
+	if j == "sonic" {
+		work = func() {
+			for i:=0; i<N; i++ {
+				out, _ := ConfigStd.Marshal(obj)
+				var v interface{}
+				_ = ConfigStd.Unmarshal(out, &v)
+			}
+		}
+	} else {
+		work = func() {
+			for i:=0; i<N; i++ {
+				out, _ := json.Marshal(obj)
+				var v interface{}
+				_ = json.Unmarshal(out, &v)
+			}
+		}
+	}
+	s := time.Now()
+	work()
+	fmt.Printf("process %d cost: %vus\n", p, time.Since(s).Microseconds())
+}
+
+//go:generate go test -c -o ptest.bin .
+func TestScalability_Process(t *testing.T) {
+	var T = runtime.NumCPU()
+	var N = 300
+	var tests = func(t* testing.T, name string) {
+		var test = func(t *testing.T, p, n int) {
+			var ch = make(chan error, T)
+			s := time.Now()
+			for i:=0; i<p; i++ {
+				var buf = bytes.NewBuffer(nil)
+				cmd := exec.Command("./ptest.bin", "-test.run", "TestWork", name, strconv.Itoa(i), strconv.Itoa(n))
+				cmd.Stdout = buf
+				// cmd.Stderr = buf
+				if err := cmd.Start(); err != nil {
+					t.Fatal(err)
+				}
+				go func(i int) {
+					e := cmd.Wait()
+					// println(buf.String())
+					ch <- e
+				}(i)
+			}
+			for i:=0; i<p; i++ {
+				e := <- ch
+				if e != nil {
+					t.Fatal(e)
+				}
+			}
+			fmt.Printf("%d processes total cost: %dus\n", p, time.Since(s).Microseconds())
+		}
+	
+		println("single-process")
+		test(t, 1, T*N)
+		println("1/4-processes")
+		test(t, T/4, N*4)
+		println("half-processes")
+		test(t, T/2, N*2)
+		println("3/4-processes")
+		test(t, T/4*3, N/3*4)
+		println("full-processes")
+		test(t, T, N)
+		println("full-processes-1")
+		test(t, T-1, N+N/(T-1))
+	}
+	
+	t.Run("sonic", func(t *testing.T) {
+		tests(t, "sonic")
+	})
+	t.Run("std", func(t *testing.T) {
+		tests(t, "std")
+	})
+}
+
+func TestScalability_Thread(t *testing.T) {
+	const N = 300
+	var T = runtime.NumCPU()
+	println("num cpu:", T)
+
+	var obj = map[string]interface{}{}
+	for i:=0; i<100; i++ {
+		obj[strconv.Itoa(i)] = i
+	}
+	out, err := ConfigStd.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var x interface{}
+	err = ConfigStd.Unmarshal(out, &x)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tests = func(t *testing.T, work func()) {
+		var test = func(t *testing.T, p int, n int) {
+			wg := sync.WaitGroup{}
+			s := time.Now()
+			for i:=0; i<p; i++ {
+				wg.Add(1)
+				go func ()  {
+					for j:=0; j<n; j++ {
+						work()
+					}
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+			fmt.Printf("%d threads total cost: %vus\n", p, time.Since(s).Microseconds())
+		}
+		println("single-thread")
+		test(t, 1, T*N)
+		println("1/4-threads")
+		test(t, T/4, N*4)
+		println("half-threads")
+		test(t, T/2, N*2)
+		println("3/4-threads")
+		test(t, T/4*3, N/3*4)
+		println("full-threads")
+		test(t, T, N)
+		println("full-threads-1")
+		test(t, T-1, N+N/(T-1))
+	}
+
+	t.Run("sonic", func(t *testing.T) {
+		work := func() {
+			out, _ := ConfigStd.Marshal(obj)
+			var x interface{}
+			_ = ConfigStd.Unmarshal(out, &x)
+		}
+		tests(t, work)
+	})
+
+	t.Run("std", func(t *testing.T) {
+		work := func() {
+			out, _ := json.Marshal(obj)
+			var x interface{}
+			_ = json.Unmarshal(out, &x)
+		}
+		tests(t, work)
+	})
+}
+
+


### PR DESCRIPTION
## Case
- Repeatedly marshal the same object and unmarshal outcome json into a new object, for N times
- Create T number of threads (or processes) to execute above task.
- Adjust T and N meanwhile, ensuring total works always equal to T*N
## Environment
```
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
```
## Result
It's very clear that for JSON lib, its processability **doesn't grow linearly with the number of CPUs**. And there is **a abvious threshold** once paralleled threads (or processes) number goes above **half of the CPU cores**
```
=== RUN   TestScalability_Process
=== RUN   TestScalability_Process/sonic
single-process
1 processes total cost: 169785us
1/4-processes
4 processes total cost: 73421us
half-processes
8 processes total cost: 72286us
3/4-processes
12 processes total cost: 85187us
full-processes
16 processes total cost: 100788us
full-processes-1
15 processes total cost: 99805us
=== RUN   TestScalability_Process/std
single-process
1 processes total cost: 315315us
1/4-processes
4 processes total cost: 105815us
half-processes
8 processes total cost: 90710us
3/4-processes
12 processes total cost: 107567us
full-processes
16 processes total cost: 115681us
full-processes-1
15 processes total cost: 117348us
--- PASS: TestScalability_Process (1.45s)
    --- PASS: TestScalability_Process/sonic (0.60s)
    --- PASS: TestScalability_Process/std (0.85s)
=== RUN   TestScalability_Thread
num cpu: 16
=== RUN   TestScalability_Thread/sonic
single-thread
1 threads total cost: 150786us
1/4-threads
4 threads total cost: 51560us
half-threads
8 threads total cost: 37515us
3/4-threads
12 threads total cost: 36387us
full-threads
16 threads total cost: 39338us
full-threads-1
15 threads total cost: 40201us
=== RUN   TestScalability_Thread/std
single-thread
1 threads total cost: 287707us
1/4-threads
4 threads total cost: 96182us
half-threads
8 threads total cost: 88373us
3/4-threads
12 threads total cost: 96573us
full-threads
16 threads total cost: 115144us
full-threads-1
15 threads total cost: 110567us
```