### PR TITLE
Allow the disabling of the newline in the encoder

### DIFF
--- a/api.go
+++ b/api.go
@@ -73,6 +73,9 @@ type Config struct {
     // NoValidateJSONMarshaler indicates that the encoder should not validate the output string
     // after encoding the JSONMarshaler to JSON.
     NoValidateJSONMarshaler       bool
+    
+    // NoEncoderNewline indicates that the encoder should not add a newline after every message
+    NoEncoderNewline bool
 }
  
 var (

--- a/encoder/encoder_amd64.go
+++ b/encoder/encoder_amd64.go
@@ -63,6 +63,9 @@ const (
     // after encoding the JSONMarshaler to JSON.
     NoValidateJSONMarshaler Options = encoder.NoValidateJSONMarshaler
 
+    // NoEncoderNewline indicates that the encoder should not add a newline after every message
+    NoEncoderNewline Options = encoder.NoEncoderNewline
+
     // CompatibleWithStd is used to be compatible with std encoder.
     CompatibleWithStd Options = encoder.CompatibleWithStd
 )

--- a/encoder/encoder_compat.go
+++ b/encoder/encoder_compat.go
@@ -42,6 +42,7 @@ const (
     bitNoNullSliceOrMap
     bitValidateString
     bitNoValidateJSONMarshaler
+    bitNoEncoderNewline
 
     // used for recursive compile
     bitPointerValue = 63
@@ -77,6 +78,9 @@ const (
     // NoValidateJSONMarshaler indicates that the encoder should not validate the output string
     // after encoding the JSONMarshaler to JSON.
     NoValidateJSONMarshaler Options = 1 << bitNoValidateJSONMarshaler
+
+    // NoEncoderNewline indicates that the encoder should not add a newline after every message
+    NoEncoderNewline Options = 1 << bitNoEncoderNewline
   
     // CompatibleWithStd is used to be compatible with std encoder.
     CompatibleWithStd Options = SortMapKeys | EscapeHTML | CompactMarshaler
@@ -127,6 +131,15 @@ func (self *Encoder) SetNoValidateJSONMarshaler(f bool) {
         self.Opts |= NoValidateJSONMarshaler
     } else {
         self.Opts &= ^NoValidateJSONMarshaler
+    }
+}
+
+// SetNoEncoderNewline specifies if option NoEncoderNewline opens
+func (self *Encoder) SetNoEncoderNewline(f bool) {
+    if f {
+        self.Opts |= NoEncoderNewline
+    } else {
+        self.Opts &= ^NoEncoderNewline
     }
 }
 

--- a/internal/encoder/encoder.go
+++ b/internal/encoder/encoder.go
@@ -41,6 +41,7 @@ const (
     bitNoNullSliceOrMap
     bitValidateString
     bitNoValidateJSONMarshaler
+    bitNoEncoderNewline 
 
     // used for recursive compile
     bitPointerValue = 63
@@ -76,6 +77,9 @@ const (
     // NoValidateJSONMarshaler indicates that the encoder should not validate the output string
     // after encoding the JSONMarshaler to JSON.
     NoValidateJSONMarshaler Options = 1 << bitNoValidateJSONMarshaler
+
+    // NoEncoderNewline indicates that the encoder should not add a newline after every message
+    NoEncoderNewline Options = 1 << bitNoEncoderNewline
   
     // CompatibleWithStd is used to be compatible with std encoder.
     CompatibleWithStd Options = SortMapKeys | EscapeHTML | CompactMarshaler
@@ -128,6 +132,16 @@ func (self *Encoder) SetNoValidateJSONMarshaler(f bool) {
         self.Opts &= ^NoValidateJSONMarshaler
     }
 }
+
+// SetNoEncoderNewline specifies if option NoEncoderNewline opens
+func (self *Encoder) SetNoEncoderNewline(f bool) {
+    if f {
+        self.Opts |= NoEncoderNewline
+    } else {
+        self.Opts &= ^NoEncoderNewline
+    }
+}
+
 
 // SetCompactMarshaler specifies if option CompactMarshaler opens
 func (self *Encoder) SetCompactMarshaler(f bool) {

--- a/internal/encoder/stream.go
+++ b/internal/encoder/stream.go
@@ -55,7 +55,9 @@ func (enc *StreamEncoder) Encode(val interface{}) (err error) {
         }
 
         // according to standard library, terminate each value with a newline...
-        buf.WriteByte('\n')
+        if enc.Opts & NoEncoderNewline == 0 {
+            buf.WriteByte('\n')
+        }
 
         /* copy into io.Writer */
         _, err = io.Copy(enc.w, buf)
@@ -76,7 +78,9 @@ func (enc *StreamEncoder) Encode(val interface{}) (err error) {
         }
 
         // according to standard library, terminate each value with a newline...
-        enc.w.Write([]byte{'\n'})
+        if enc.Opts & NoEncoderNewline == 0 {
+            enc.w.Write([]byte{'\n'})
+        }
     }
 
 free_bytes:

--- a/sonic.go
+++ b/sonic.go
@@ -61,6 +61,9 @@ func (cfg Config) Froze() API {
     if cfg.NoValidateJSONMarshaler {
         api.encoderOpts |= encoder.NoValidateJSONMarshaler
     }
+    if cfg.NoEncoderNewline {
+        api.encoderOpts |= encoder.NoEncoderNewline
+    }
 
     // configure decoder options:
     if cfg.UseInt64 {


### PR DESCRIPTION
Adds an option which allows to not write that extra newline between each message.