### PR TITLE
build: perfect build tag for mmap_unix.go

### DIFF
--- a/loader/mmap_unix.go
+++ b/loader/mmap_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || linux
-// +build darwin linux
+//go:build unix
+// +build unix
 
 /**
  * Copyright 2023 ByteDance Inc.

--- a/loader/mmap_unix.go
+++ b/loader/mmap_unix.go
@@ -1,5 +1,5 @@
-//go:build unix
-// +build unix
+//go:build !windows
+// +build !windows
 
 /**
  * Copyright 2023 ByteDance Inc.


### PR DESCRIPTION
fix #564 