### PR TITLE
fix:(ast) implement soft delete for `Unset()` 

### DIFF
--- a/ast/buffer.go
+++ b/ast/buffer.go
@@ -73,29 +73,81 @@ func (self *linkedNodes) At(i int) (*Node) {
     return nil
 }
 
-func (self *linkedNodes) Add(v Node) {
-    if self.size < _DEFAULT_NODE_CAP {
-        self.head[self.size] = v
-        self.size++
+func (self *linkedNodes) MoveOne(source int,  target int) {
+    if source == target {
         return
     }
+    if source < 0 || source >= self.size || target < 0 || target >= self.size {
+        return
+    }
+    // reserve source
+    n := *self.At(source)
+    if source < target {
+        // move every element (source,target] one step back
+        for i:=source; i<target; i++ {
+            *self.At(i) = *self.At(i+1)
+        } 
+    } else {
+        // move every element [target,source) one step forward
+        for i:=source; i>target; i-- {
+            *self.At(i) = *self.At(i-1)
+        }
+    } 
+    // set target
+    *self.At(target) = n
+}
 
-    a, b, c := self.size/_DEFAULT_NODE_CAP-1 , self.size%_DEFAULT_NODE_CAP, cap(self.tail)
-    if a - c >= 0 {
+func (self *linkedNodes) Pop() {
+    if self == nil || self.size == 0 {
+        return
+    }
+    self.Set(self.size-1, Node{})
+    self.size--
+}
+
+func (self *linkedNodes) Push(v Node) {
+    self.Set(self.size, v)
+}
+
+func (self *linkedNodes) Set(i int, v Node) {
+    if i < _DEFAULT_NODE_CAP {
+        self.head[i] = v
+        if self.size <= i {
+            self.size = i+1
+        }
+        return
+    }
+    a, b := i/_DEFAULT_NODE_CAP-1, i%_DEFAULT_NODE_CAP
+    if a < 0 {
+        self.head[b] = v
+    } else {
+        self.growTailLength(a+1)
+        var n = &self.tail[a]
+        if *n == nil {
+            *n = new(nodeChunk)
+        }
+        (*n)[b] = v
+    }
+    if self.size <= i {
+        self.size = i+1
+    }
+}
+
+func (self *linkedNodes) growTailLength(l int) {
+    if l <= len(self.tail) {
+        return
+    }
+    c := cap(self.tail)
+    for c < l {
         c += 1 + c>>_APPEND_GROW_SHIFT
-        tmp := make([]*nodeChunk, a + 1, c)
-        copy(tmp, self.tail)
-        self.tail = tmp
-    } else if a >= len(self.tail) {
-        self.tail = self.tail[:a+1]
     }
-    
-    var n = &self.tail[a]
-    if *n == nil {
-        *n = new(nodeChunk)
+    if c == cap(self.tail) {
+        self.tail = self.tail[:l]
+        return
     }
-    (*n)[b] = v
-    self.size++
+    tmp := make([]*nodeChunk, l, c)
+    copy(tmp, self.tail)
+    self.tail = tmp
 }
 
 func (self *linkedNodes) ToSlice(con []Node) {
@@ -184,29 +236,81 @@ func (self *linkedPairs) At(i int) *Pair {
     return nil
 }
 
-func (self *linkedPairs) Add(v Pair) {
-    if self.size < _DEFAULT_NODE_CAP {
-        self.head[self.size] = v
-        self.size++
+func (self *linkedPairs) Push(v Pair) {
+    self.Set(self.size, v)
+}
+
+func (self *linkedPairs) MoveOne(source int,  target int) {
+    if source == target {
         return
     }
+    if source < 0 || source >= self.size || target < 0 || target >= self.size {
+        return
+    }
+    // reserve source
+    n := *self.At(source)
+    if source < target {
+        // move every element (source,target] one step back
+        for i:=source; i<target; i++ {
+            *self.At(i) = *self.At(i+1)
+        } 
+    } else {
+        // move every element [target,source) one step forward
+        for i:=source; i>target; i-- {
+            *self.At(i) = *self.At(i-1)
+        }
+    } 
+    // set target
+    *self.At(target) = n
+}
 
-    a, b, c := self.size/_DEFAULT_NODE_CAP-1 , self.size%_DEFAULT_NODE_CAP, cap(self.tail)
-    if a - c >= 0 {
+func (self *linkedPairs) Pop() {
+    if self == nil || self.size == 0 {
+        return
+    }
+    self.Set(self.size-1, Pair{})
+    self.size--
+}
+
+func (self *linkedPairs) Set(i int, v Pair) {
+    if i < _DEFAULT_NODE_CAP {
+        self.head[i] = v
+        if self.size <= i {
+            self.size = i+1
+        }
+        return
+    }
+    a, b := i/_DEFAULT_NODE_CAP-1, i%_DEFAULT_NODE_CAP
+    if a < 0 {
+        self.head[b] = v
+    } else {
+        self.growTailLength(a+1)
+        var n = &self.tail[a]
+        if *n == nil {
+            *n = new(pairChunk)
+        }
+        (*n)[b] = v
+    }
+    if self.size <= i {
+        self.size = i+1
+    }
+}
+
+func (self *linkedPairs) growTailLength(l int) {
+    if l <= len(self.tail) {
+        return
+    }
+    c := cap(self.tail)
+    for c < l {
         c += 1 + c>>_APPEND_GROW_SHIFT
-        tmp := make([]*pairChunk, a + 1, c)
-        copy(tmp, self.tail)
-        self.tail = tmp
-    } else if a >= len(self.tail) {
-        self.tail = self.tail[:a+1]
     }
-
-    var n = &self.tail[a]
-    if *n == nil {
-        *n = new(pairChunk)
+    if c == cap(self.tail) {
+        self.tail = self.tail[:l]
+        return
     }
-    (*n)[b] = v
-    self.size++
+    tmp := make([]*pairChunk, l, c)
+    copy(tmp, self.tail)
+    self.tail = tmp
 }
 
 // linear search

--- a/ast/buffer.go
+++ b/ast/buffer.go
@@ -43,6 +43,21 @@ func (self *linkedNodes) Len() int {
     return self.size 
 }
 
+func (self *linkedNodes) Get(i int) (*Node) {
+    if self == nil {
+        return nil
+    }
+    if i >= 0 && i<self.size && i < _DEFAULT_NODE_CAP {
+        return &self.head[i]
+    } else if i >= _DEFAULT_NODE_CAP && i<self.size  {
+        a, b := i/_DEFAULT_NODE_CAP-1, i%_DEFAULT_NODE_CAP
+        if a < len(self.tail) {
+            return &self.tail[a][b]
+        }
+    }
+    return nil
+}
+
 func (self *linkedNodes) At(i int) (*Node) {
     if self == nil {
         return nil

--- a/ast/buffer.go
+++ b/ast/buffer.go
@@ -43,21 +43,6 @@ func (self *linkedNodes) Len() int {
     return self.size 
 }
 
-func (self *linkedNodes) Get(i int) (*Node) {
-    if self == nil {
-        return nil
-    }
-    if i >= 0 && i<self.size && i < _DEFAULT_NODE_CAP {
-        return &self.head[i]
-    } else if i >= _DEFAULT_NODE_CAP && i<self.size  {
-        a, b := i/_DEFAULT_NODE_CAP-1, i%_DEFAULT_NODE_CAP
-        if a < len(self.tail) {
-            return &self.tail[a][b]
-        }
-    }
-    return nil
-}
-
 func (self *linkedNodes) At(i int) (*Node) {
     if self == nil {
         return nil
@@ -102,6 +87,14 @@ func (self *linkedNodes) Pop() {
         return
     }
     self.Set(self.size-1, Node{})
+    self.size--
+}
+
+func (self *linkedPairs) Pop() {
+    if self == nil || self.size == 0 {
+        return
+    }
+    self.Set(self.size-1, Pair{})
     self.size--
 }
 
@@ -238,38 +231,6 @@ func (self *linkedPairs) At(i int) *Pair {
 
 func (self *linkedPairs) Push(v Pair) {
     self.Set(self.size, v)
-}
-
-func (self *linkedPairs) MoveOne(source int,  target int) {
-    if source == target {
-        return
-    }
-    if source < 0 || source >= self.size || target < 0 || target >= self.size {
-        return
-    }
-    // reserve source
-    n := *self.At(source)
-    if source < target {
-        // move every element (source,target] one step back
-        for i:=source; i<target; i++ {
-            *self.At(i) = *self.At(i+1)
-        } 
-    } else {
-        // move every element [target,source) one step forward
-        for i:=source; i>target; i-- {
-            *self.At(i) = *self.At(i-1)
-        }
-    } 
-    // set target
-    *self.At(target) = n
-}
-
-func (self *linkedPairs) Pop() {
-    if self == nil || self.size == 0 {
-        return
-    }
-    self.Set(self.size-1, Pair{})
-    self.size--
 }
 
 func (self *linkedPairs) Set(i int, v Pair) {

--- a/ast/buffer_test.go
+++ b/ast/buffer_test.go
@@ -17,325 +17,224 @@
 package ast
 
 import (
-	"strconv"
-	"testing"
+    `strconv`
+    `testing`
 
-	"github.com/stretchr/testify/require"
+    `github.com/stretchr/testify/require`
 )
 
 func makeNodes(l int) []Node {
-	r := make([]Node, l)
-	for i := 0; i < l; i++ {
-		r[i] = NewBool(true)
-	}
-	return r
+    r := make([]Node, l)
+    for i := 0; i < l; i++ {
+        r[i] = NewBool(true)
+    }
+    return r
 }
 
 func makePairs(l int) []Pair {
-	r := make([]Pair, l)
-	for i := 0; i < l; i++ {
-		r[i] = Pair{strconv.Itoa(i), NewBool(true)}
-	}
-	return r
+    r := make([]Pair, l)
+    for i := 0; i < l; i++ {
+        r[i] = Pair{strconv.Itoa(i), NewBool(true)}
+    }
+    return r
 }
 
 func Test_linkedPairs_Push(t *testing.T) {
-	type args struct {
-		in  []Pair
-		v Pair
-		exp []Pair
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "add empty",
-			args: args{
-				in: []Pair{},
-				v: Pair{"a", NewBool(true)},
-				exp: []Pair{Pair{"a", NewBool(true)}},
-			},
-		},
-		{
-			name: "add one",
-			args: args{
-				in: []Pair{{"a", NewBool(false)}},
-				v: Pair{"b", NewBool(true)},
-				exp: []Pair{{"a", NewBool(false)}, {"b", NewBool(true)}},
-			},
-		},
-		{
-			name: "add _DEFAULT_NODE_CAP",
-			args: args{
-				in: makePairs(_DEFAULT_NODE_CAP),
-				v: Pair{strconv.Itoa(_DEFAULT_NODE_CAP), NewBool(true)},
-				exp: makePairs(_DEFAULT_NODE_CAP+1),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedPairs{}
-			self.FromSlice(tt.args.in)
-			self.Push(tt.args.v)
-			act := make([]Pair, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
+    type args struct {
+        in  []Pair
+        v Pair
+        exp []Pair
+    }
+    tests := []struct {
+        name   string
+        args   args
+    }{
+        {
+            name: "add empty",
+            args: args{
+                in: []Pair{},
+                v: Pair{"a", NewBool(true)},
+                exp: []Pair{Pair{"a", NewBool(true)}},
+            },
+        },
+        {
+            name: "add one",
+            args: args{
+                in: []Pair{{"a", NewBool(false)}},
+                v: Pair{"b", NewBool(true)},
+                exp: []Pair{{"a", NewBool(false)}, {"b", NewBool(true)}},
+            },
+        },
+        {
+            name: "add _DEFAULT_NODE_CAP",
+            args: args{
+                in: makePairs(_DEFAULT_NODE_CAP),
+                v: Pair{strconv.Itoa(_DEFAULT_NODE_CAP), NewBool(true)},
+                exp: makePairs(_DEFAULT_NODE_CAP+1),
+            },
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            self := &linkedPairs{}
+            self.FromSlice(tt.args.in)
+            self.Push(tt.args.v)
+            act := make([]Pair, self.Len())
+            self.ToSlice(act)
+            require.Equal(t, tt.args.exp, act)
+        })
+    }
 }
 
-func Test_linkedPairs_Pop(t *testing.T) {
-	type args struct {
-		in  []Pair
-		exp []Pair
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "remove empty",
-			args: args{
-				in: []Pair{},
-				exp: []Pair{},
-			},
-		},
-		{
-			name: "remove one",
-			args: args{
-				in: []Pair{{"a", NewBool(false)}},
-				exp: []Pair{},
-			},
-		},
-		{
-			name: "add _DEFAULT_NODE_CAP",
-			args: args{
-				in: makePairs(_DEFAULT_NODE_CAP),
-				exp: makePairs(_DEFAULT_NODE_CAP-1),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedPairs{}
-			self.FromSlice(tt.args.in)
-			self.Pop()
-			act := make([]Pair, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
-}
 
 func Test_linkedNodes_Push(t *testing.T) {
-	type args struct {
-		in  []Node
-		v Node
-		exp []Node
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "add empty",
-			args: args{
-				in: []Node{},
-				v: NewBool(true),
-				exp: []Node{NewBool(true)},
-			},
-		},
-		{
-			name: "add one",
-			args: args{
-				in: []Node{NewBool(false)},
-				v: NewBool(true),
-				exp: []Node{NewBool(false), NewBool(true)},
-			},
-		},
-		{
-			name: "add _DEFAULT_NODE_CAP",
-			args: args{
-				in: makeNodes(_DEFAULT_NODE_CAP),
-				v: NewBool(true),
-				exp: makeNodes(_DEFAULT_NODE_CAP+1),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedNodes{}
-			self.FromSlice(tt.args.in)
-			self.Push(tt.args.v)
-			act := make([]Node, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
+    type args struct {
+        in  []Node
+        v Node
+        exp []Node
+    }
+    tests := []struct {
+        name   string
+        args   args
+    }{
+        {
+            name: "add empty",
+            args: args{
+                in: []Node{},
+                v: NewBool(true),
+                exp: []Node{NewBool(true)},
+            },
+        },
+        {
+            name: "add one",
+            args: args{
+                in: []Node{NewBool(false)},
+                v: NewBool(true),
+                exp: []Node{NewBool(false), NewBool(true)},
+            },
+        },
+        {
+            name: "add _DEFAULT_NODE_CAP",
+            args: args{
+                in: makeNodes(_DEFAULT_NODE_CAP),
+                v: NewBool(true),
+                exp: makeNodes(_DEFAULT_NODE_CAP+1),
+            },
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            self := &linkedNodes{}
+            self.FromSlice(tt.args.in)
+            self.Push(tt.args.v)
+            act := make([]Node, self.Len())
+            self.ToSlice(act)
+            require.Equal(t, tt.args.exp, act)
+        })
+    }
 }
 
 func Test_linkedNodes_Pop(t *testing.T) {
-	type args struct {
-		in  []Node
-		exp []Node
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "remove empty",
-			args: args{
-				in: []Node{},
-				exp: []Node{},
-			},
-		},
-		{
-			name: "remove one",
-			args: args{
-				in: []Node{NewBool(false)},
-				exp: []Node{},
-			},
-		},
-		{
-			name: "add _DEFAULT_NODE_CAP",
-			args: args{
-				in: makeNodes(_DEFAULT_NODE_CAP),
-				exp: makeNodes(_DEFAULT_NODE_CAP-1),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedNodes{}
-			self.FromSlice(tt.args.in)
-			self.Pop()
-			act := make([]Node, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
+    type args struct {
+        in  []Node
+        exp []Node
+    }
+    tests := []struct {
+        name   string
+        args   args
+    }{
+        {
+            name: "remove empty",
+            args: args{
+                in: []Node{},
+                exp: []Node{},
+            },
+        },
+        {
+            name: "remove one",
+            args: args{
+                in: []Node{NewBool(false)},
+                exp: []Node{},
+            },
+        },
+        {
+            name: "add _DEFAULT_NODE_CAP",
+            args: args{
+                in: makeNodes(_DEFAULT_NODE_CAP),
+                exp: makeNodes(_DEFAULT_NODE_CAP-1),
+            },
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            self := &linkedNodes{}
+            self.FromSlice(tt.args.in)
+            self.Pop()
+            act := make([]Node, self.Len())
+            self.ToSlice(act)
+            require.Equal(t, tt.args.exp, act)
+        })
+    }
 }
 
 func Test_linkedNodes_MoveOne(t *testing.T) {
-	type args struct {
-		in  []Node
-		source int
-		target int
-		exp []Node
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "over index",
-			args: args{
-				in: []Node{NewBool(true)},
-				source: 1,
-				target: 0,
-				exp: []Node{NewBool(true)},
-			},
-		},
-		{
-			name: "equal index",
-			args: args{
-				in: []Node{NewBool(true)},
-				source: 0,
-				target: 0,
-				exp: []Node{NewBool(true)},
-			},
-		},
-		{
-			name: "forward index",
-			args: args{
-				in: []Node{NewString("a"), NewString("b"), NewString("c")},
-				source: 0,
-				target: 2,
-				exp: []Node{NewString("b"), NewString("c"), NewString("a")},
-			},
-		},
-		{
-			name: "backward index",
-			args: args{
-				in: []Node{NewString("a"), NewString("b"), NewString("c")},
-				source: 2,
-				target: 1,
-				exp: []Node{NewString("a"), NewString("c"), NewString("b")},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedNodes{}
-			self.FromSlice(tt.args.in)
-			self.MoveOne(tt.args.source, tt.args.target)
-			act := make([]Node, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
+    type args struct {
+        in  []Node
+        source int
+        target int
+        exp []Node
+    }
+    tests := []struct {
+        name   string
+        args   args
+    }{
+        {
+            name: "over index",
+            args: args{
+                in: []Node{NewBool(true)},
+                source: 1,
+                target: 0,
+                exp: []Node{NewBool(true)},
+            },
+        },
+        {
+            name: "equal index",
+            args: args{
+                in: []Node{NewBool(true)},
+                source: 0,
+                target: 0,
+                exp: []Node{NewBool(true)},
+            },
+        },
+        {
+            name: "forward index",
+            args: args{
+                in: []Node{NewString("a"), NewString("b"), NewString("c")},
+                source: 0,
+                target: 2,
+                exp: []Node{NewString("b"), NewString("c"), NewString("a")},
+            },
+        },
+        {
+            name: "backward index",
+            args: args{
+                in: []Node{NewString("a"), NewString("b"), NewString("c")},
+                source: 2,
+                target: 1,
+                exp: []Node{NewString("a"), NewString("c"), NewString("b")},
+            },
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            self := &linkedNodes{}
+            self.FromSlice(tt.args.in)
+            self.MoveOne(tt.args.source, tt.args.target)
+            act := make([]Node, self.Len())
+            self.ToSlice(act)
+            require.Equal(t, tt.args.exp, act)
+        })
+    }
 }
 
-func Test_linkedPairs_MoveOne(t *testing.T) {
-	type args struct {
-		in  []Pair
-		source int
-		target int
-		exp []Pair
-	}
-	tests := []struct {
-		name   string
-		args   args
-	}{
-		{
-			name: "over index",
-			args: args{
-				in: []Pair{{"a", NewBool(true)}},
-				source: 1,
-				target: 0,
-				exp: []Pair{{"a", NewBool(true)}},
-			},
-		},
-		{
-			name: "equal index",
-			args: args{
-				in: []Pair{{"a", NewBool(true)}},
-				source: 0,
-				target: 0,
-				exp: []Pair{{"a", NewBool(true)}},
-			},
-		},
-		{
-			name: "forward index",
-			args: args{
-				in: []Pair{{"a", NewString("a")}, {"b", NewString("b")}, {"c", NewString("c")}},
-				source: 0,
-				target: 2,
-				exp: []Pair{{"b", NewString("b")}, {"c", NewString("c")}, {"a", NewString("a")}},
-			},
-		},
-		{
-			name: "backward index",
-			args: args{
-				in: []Pair{{"a", NewString("a")}, {"b", NewString("b")}, {"c", NewString("c")}},
-				source: 2,
-				target: 1,
-				exp: []Pair{{"a", NewString("a")}, {"c", NewString("c")}, {"b", NewString("b")}},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			self := &linkedPairs{}
-			self.FromSlice(tt.args.in)
-			self.MoveOne(tt.args.source, tt.args.target)
-			act := make([]Pair, self.Len())
-			self.ToSlice(act)
-			require.Equal(t, tt.args.exp, act)
-		})
-	}
-}
 

--- a/ast/buffer_test.go
+++ b/ast/buffer_test.go
@@ -1,0 +1,341 @@
+/**
+ * Copyright 2023 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeNodes(l int) []Node {
+	r := make([]Node, l)
+	for i := 0; i < l; i++ {
+		r[i] = NewBool(true)
+	}
+	return r
+}
+
+func makePairs(l int) []Pair {
+	r := make([]Pair, l)
+	for i := 0; i < l; i++ {
+		r[i] = Pair{strconv.Itoa(i), NewBool(true)}
+	}
+	return r
+}
+
+func Test_linkedPairs_Push(t *testing.T) {
+	type args struct {
+		in  []Pair
+		v Pair
+		exp []Pair
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "add empty",
+			args: args{
+				in: []Pair{},
+				v: Pair{"a", NewBool(true)},
+				exp: []Pair{Pair{"a", NewBool(true)}},
+			},
+		},
+		{
+			name: "add one",
+			args: args{
+				in: []Pair{{"a", NewBool(false)}},
+				v: Pair{"b", NewBool(true)},
+				exp: []Pair{{"a", NewBool(false)}, {"b", NewBool(true)}},
+			},
+		},
+		{
+			name: "add _DEFAULT_NODE_CAP",
+			args: args{
+				in: makePairs(_DEFAULT_NODE_CAP),
+				v: Pair{strconv.Itoa(_DEFAULT_NODE_CAP), NewBool(true)},
+				exp: makePairs(_DEFAULT_NODE_CAP+1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedPairs{}
+			self.FromSlice(tt.args.in)
+			self.Push(tt.args.v)
+			act := make([]Pair, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+
+func Test_linkedPairs_Pop(t *testing.T) {
+	type args struct {
+		in  []Pair
+		exp []Pair
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "remove empty",
+			args: args{
+				in: []Pair{},
+				exp: []Pair{},
+			},
+		},
+		{
+			name: "remove one",
+			args: args{
+				in: []Pair{{"a", NewBool(false)}},
+				exp: []Pair{},
+			},
+		},
+		{
+			name: "add _DEFAULT_NODE_CAP",
+			args: args{
+				in: makePairs(_DEFAULT_NODE_CAP),
+				exp: makePairs(_DEFAULT_NODE_CAP-1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedPairs{}
+			self.FromSlice(tt.args.in)
+			self.Pop()
+			act := make([]Pair, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+
+func Test_linkedNodes_Push(t *testing.T) {
+	type args struct {
+		in  []Node
+		v Node
+		exp []Node
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "add empty",
+			args: args{
+				in: []Node{},
+				v: NewBool(true),
+				exp: []Node{NewBool(true)},
+			},
+		},
+		{
+			name: "add one",
+			args: args{
+				in: []Node{NewBool(false)},
+				v: NewBool(true),
+				exp: []Node{NewBool(false), NewBool(true)},
+			},
+		},
+		{
+			name: "add _DEFAULT_NODE_CAP",
+			args: args{
+				in: makeNodes(_DEFAULT_NODE_CAP),
+				v: NewBool(true),
+				exp: makeNodes(_DEFAULT_NODE_CAP+1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedNodes{}
+			self.FromSlice(tt.args.in)
+			self.Push(tt.args.v)
+			act := make([]Node, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+
+func Test_linkedNodes_Pop(t *testing.T) {
+	type args struct {
+		in  []Node
+		exp []Node
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "remove empty",
+			args: args{
+				in: []Node{},
+				exp: []Node{},
+			},
+		},
+		{
+			name: "remove one",
+			args: args{
+				in: []Node{NewBool(false)},
+				exp: []Node{},
+			},
+		},
+		{
+			name: "add _DEFAULT_NODE_CAP",
+			args: args{
+				in: makeNodes(_DEFAULT_NODE_CAP),
+				exp: makeNodes(_DEFAULT_NODE_CAP-1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedNodes{}
+			self.FromSlice(tt.args.in)
+			self.Pop()
+			act := make([]Node, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+
+func Test_linkedNodes_MoveOne(t *testing.T) {
+	type args struct {
+		in  []Node
+		source int
+		target int
+		exp []Node
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "over index",
+			args: args{
+				in: []Node{NewBool(true)},
+				source: 1,
+				target: 0,
+				exp: []Node{NewBool(true)},
+			},
+		},
+		{
+			name: "equal index",
+			args: args{
+				in: []Node{NewBool(true)},
+				source: 0,
+				target: 0,
+				exp: []Node{NewBool(true)},
+			},
+		},
+		{
+			name: "forward index",
+			args: args{
+				in: []Node{NewString("a"), NewString("b"), NewString("c")},
+				source: 0,
+				target: 2,
+				exp: []Node{NewString("b"), NewString("c"), NewString("a")},
+			},
+		},
+		{
+			name: "backward index",
+			args: args{
+				in: []Node{NewString("a"), NewString("b"), NewString("c")},
+				source: 2,
+				target: 1,
+				exp: []Node{NewString("a"), NewString("c"), NewString("b")},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedNodes{}
+			self.FromSlice(tt.args.in)
+			self.MoveOne(tt.args.source, tt.args.target)
+			act := make([]Node, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+
+func Test_linkedPairs_MoveOne(t *testing.T) {
+	type args struct {
+		in  []Pair
+		source int
+		target int
+		exp []Pair
+	}
+	tests := []struct {
+		name   string
+		args   args
+	}{
+		{
+			name: "over index",
+			args: args{
+				in: []Pair{{"a", NewBool(true)}},
+				source: 1,
+				target: 0,
+				exp: []Pair{{"a", NewBool(true)}},
+			},
+		},
+		{
+			name: "equal index",
+			args: args{
+				in: []Pair{{"a", NewBool(true)}},
+				source: 0,
+				target: 0,
+				exp: []Pair{{"a", NewBool(true)}},
+			},
+		},
+		{
+			name: "forward index",
+			args: args{
+				in: []Pair{{"a", NewString("a")}, {"b", NewString("b")}, {"c", NewString("c")}},
+				source: 0,
+				target: 2,
+				exp: []Pair{{"b", NewString("b")}, {"c", NewString("c")}, {"a", NewString("a")}},
+			},
+		},
+		{
+			name: "backward index",
+			args: args{
+				in: []Pair{{"a", NewString("a")}, {"b", NewString("b")}, {"c", NewString("c")}},
+				source: 2,
+				target: 1,
+				exp: []Pair{{"a", NewString("a")}, {"c", NewString("c")}, {"b", NewString("b")}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			self := &linkedPairs{}
+			self.FromSlice(tt.args.in)
+			self.MoveOne(tt.args.source, tt.args.target)
+			act := make([]Pair, self.Len())
+			self.ToSlice(act)
+			require.Equal(t, tt.args.exp, act)
+		})
+	}
+}
+

--- a/ast/encode.go
+++ b/ast/encode.go
@@ -193,20 +193,9 @@ func (self *Node) encodeArray(buf *[]byte) error {
     
     *buf = append(*buf, '[')
 
-    var s = (*linkedNodes)(self.p)
     var started bool
-    if nb > 0 {
-        n := s.At(0)
-        if n.Exists() {
-            if err := n.encode(buf); err != nil {
-                return err
-            }
-            started = true
-        }
-    }
-
-    for i := 1; i < nb; i++ {
-        n := s.At(i)
+    for i := 0; i < nb; i++ {
+        n := self.nodeAt(i)
         if !n.Exists() {
             continue
         }
@@ -250,21 +239,10 @@ func (self *Node) encodeObject(buf *[]byte) error {
     
     *buf = append(*buf, '{')
 
-    var s = (*linkedPairs)(self.p)
     var started bool
-    if nb > 0 {
-        n := s.At(0)
-        if n.Value.Exists() {
-            if err := n.encode(buf); err != nil {
-                return err
-            }
-            started = true
-        }
-    }
-
-    for i := 1; i < nb; i++ {
-        n := s.At(i)
-        if !n.Value.Exists() {
+    for i := 0; i < nb; i++ {
+        n := self.pairAt(i)
+        if n == nil || !n.Value.Exists() {
             continue
         }
         if started {

--- a/ast/iterator.go
+++ b/ast/iterator.go
@@ -122,7 +122,7 @@ next_start:
     } else {
         n := self.p.pairAt(self.i)
         self.i++
-        if !n.Value.Exists() {
+        if n == nil || !n.Value.Exists() {
             goto next_start
         }
         return n

--- a/ast/iterator_test.go
+++ b/ast/iterator_test.go
@@ -231,7 +231,7 @@ func TestExist(t *testing.T) {
         if path.Key != nil && *path.Key == "a" {
             t.Fatal()
         }
-        if path.Index == 1 {
+        if path.Index == 0 {
             if *path.Key != "b" {
                 t.Fatal()
             }
@@ -247,7 +247,7 @@ func TestExist(t *testing.T) {
             })
         }
 
-        if path.Index == 2 {
+        if path.Index == 1 {
             if *path.Key != "c" {
                 t.Fatal()
             }

--- a/ast/node.go
+++ b/ast/node.go
@@ -617,7 +617,10 @@ func (self *Node) SetAnyByIndex(index int, val interface{}) (bool, error) {
     return self.SetByIndex(index, NewAny(val))
 }
 
-// UnsetByIndex REOMVE (soft) the node of given index
+// UnsetByIndex REOMVE (soft) the node of given index.
+//
+// Deprecated: this will change index of elements, which is a dangerous action. 
+// Use Unset() for object or Pop() for array instead
 func (self *Node) UnsetByIndex(index int) (bool, error) {
     if err := self.checkRaw(); err != nil {
         return false, err
@@ -699,6 +702,7 @@ func (self *Node) Pop() error {
     return nil
 }
 
+// Move moves the child at src index to dst index. 
 func (self *Node) Move(src, dst int) error {
     if err := self.should(types.V_ARRAY, "an array"); err != nil {
         return err
@@ -1405,6 +1409,7 @@ func (self *Node) removePair(i int) {
     *last = Pair{}
     // NOTICE: should be consistent with linkedPair.Len()
     self.l--
+    if self.
 }
 
 func (self *Node) toGenericArray() ([]interface{}, error) {

--- a/ast/node.go
+++ b/ast/node.go
@@ -751,7 +751,6 @@ func (self *Node) Move(dst, src int) error {
 
     // check if any unset node exists
     if l :=  s.Len(); self.len() != l {
-        println("unset", dst, src)
         di, si := dst, src
         // find real pos of src and dst
         for i := 0; i < l; i++ {
@@ -771,7 +770,6 @@ func (self *Node) Move(dst, src int) error {
                 break
             }
         }
-        println("unset2", dst, src)
     }
 
     s.MoveOne(src, dst)

--- a/ast/node.go
+++ b/ast/node.go
@@ -627,7 +627,7 @@ func (self *Node) UnsetByIndex(index int) (bool, error) {
     it := self.itype()
     if it == types.V_ARRAY {
         p = self.Index(index)
-    }else if it == types.V_OBJECT {
+    } else if it == types.V_OBJECT {
         if err := self.checkRaw(); err != nil {
             return false, err
         }
@@ -1174,6 +1174,19 @@ func (self *Node) nodeAt(i int) *Node {
         p = &stack.v
     } else {
         p = (*linkedNodes)(self.p)
+        if l := p.Len(); l != self.len() {
+            // some nodes got unset, iterate to skip them
+            for j:=0; j<l; j++ {
+                v := p.At(j)
+                if v.Exists() {
+                    i--
+                }
+                if i < 0 {
+                    return v
+                }
+            }
+            return nil
+        } 
     }
     return p.At(i)
 }
@@ -1185,6 +1198,19 @@ func (self *Node) pairAt(i int) *Pair {
         p = &stack.v
     } else {
         p = (*linkedPairs)(self.p)
+        if l := p.Len(); l != self.len() {
+            // some nodes got unset, iterate to skip them
+            for j:=0; j<l; j++ {
+                v := p.At(j)
+                if v != nil && v.Value.Exists() {
+                    i--
+                }
+                if i < 0 {
+                    return v
+                }
+            }
+           return nil
+       } 
     }
     return p.At(i)
 }
@@ -1336,8 +1362,8 @@ func (self *Node) removeNode(i int) {
         return
     }
     *node = Node{}
-    // NOTICE: for consistency with linkedNodes, we DOSEN'T reduce size here
-    // self.l--
+    // NOTICE: not be consistent with linkedNode.Len()
+    self.l--
 }
 
 func (self *Node) removePair(i int) {
@@ -1346,8 +1372,8 @@ func (self *Node) removePair(i int) {
         return
     }
     *last = Pair{}
-    // NOTICE: for consistency with linkedNodes, we DOSEN'T reduce size here
-    // self.l--
+    // NOTICE: should be consistent with linkedPair.Len()
+    self.l--
 }
 
 func (self *Node) toGenericArray() ([]interface{}, error) {

--- a/ast/node.go
+++ b/ast/node.go
@@ -491,7 +491,6 @@ func (self *Node) StrictFloat64() (float64, error) {
 
 // Len returns children count of a array|object|string node
 // WARN: For partially loaded node, it also works but only counts the parsed children
-// WARN: For ARRAY|OBJECT nodes which has been conducted `UnsetXX()`, its length WON'T change
 func (self *Node) Len() (int, error) {
     if err := self.checkRaw(); err != nil {
         return 0, err
@@ -567,8 +566,7 @@ func (self *Node) SetAny(key string, val interface{}) (bool, error) {
     return self.Set(key, NewAny(val))
 }
 
-// Unset RESET the node of given key under object parent, and reports if the key has existed.
-// WARN: After conducting `UnsetXX()`, the node's length WON'T change
+// Unset REMOVE (soft) the node of given key under object parent, and reports if the key has existed.
 func (self *Node) Unset(key string) (bool, error) {
     if err := self.should(types.V_OBJECT, "an object"); err != nil {
         return false, err
@@ -619,8 +617,7 @@ func (self *Node) SetAnyByIndex(index int, val interface{}) (bool, error) {
     return self.SetByIndex(index, NewAny(val))
 }
 
-// UnsetByIndex remove the node of given index
-// WARN: After conducting `UnsetXX()`, the node's length WON'T change
+// UnsetByIndex REOMVE (soft) the node of given index
 func (self *Node) UnsetByIndex(index int) (bool, error) {
     if err := self.checkRaw(); err != nil {
         return false, err
@@ -732,8 +729,6 @@ func (self *Node) Get(key string) *Node {
 
 // Index indexies node at given idx,
 // node type CAN be either V_OBJECT or V_ARRAY
-// WARN: After conducting `UnsetXX()`, the node's length WON'T change,
-// thus its children's indexing WON'T change too
 func (self *Node) Index(idx int) *Node {
     if err := self.checkRaw(); err != nil {
         return unwrapError(err)
@@ -757,8 +752,6 @@ func (self *Node) Index(idx int) *Node {
 
 // IndexPair indexies pair at given idx,
 // node type MUST be either V_OBJECT
-// WARN: After conducting `UnsetXX()`, the node's length WON'T change,
-// thus its children's indexing WON'T change too
 func (self *Node) IndexPair(idx int) *Pair {
     if err := self.should(types.V_OBJECT, "an object"); err != nil {
         return nil

--- a/ast/node.go
+++ b/ast/node.go
@@ -549,7 +549,7 @@ func (self *Node) Set(key string, node Node) (bool, error) {
             *self = newObject(new(linkedPairs))
         }
         s := (*linkedPairs)(self.p)
-        s.Add(Pair{key, node})
+        s.Push(Pair{key, node})
         self.l++
         return false, nil
 
@@ -678,11 +678,40 @@ func (self *Node) Add(node Node) error {
         return err
     }
 
-    s.Add(node)
+    s.Push(node)
     self.l++
     return nil
 }
 
+// Pop remove the last child of the V_Array node.
+func (self *Node) Pop() error {
+    if err := self.should(types.V_ARRAY, "an array"); err != nil {
+        return err
+    }
+
+    s, err := self.unsafeArray()
+    if err != nil {
+        return err
+    }
+
+    s.Pop()
+    self.l--
+    return nil
+}
+
+func (self *Node) Move(src, dst int) error {
+    if err := self.should(types.V_ARRAY, "an array"); err != nil {
+        return err
+    }
+
+    s, err := self.unsafeArray()
+    if err != nil {
+        return err
+    }
+
+    s.MoveOne(src, dst)
+    return nil
+}
 
 // SetAny wraps val with V_ANY node, and Add() the node.
 func (self *Node) AddAny(val interface{}) error {

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -17,758 +17,755 @@
 package ast
 
 import (
-    `bytes`
-    `encoding/json`
-    `errors`
-    `fmt`
-    `reflect`
-    `runtime`
-    `runtime/debug`
-    `strconv`
-    `testing`
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"testing"
 
-    `github.com/bytedance/sonic/internal/native/types`
-    `github.com/bytedance/sonic/internal/rt`
-    `github.com/stretchr/testify/assert`
-    `github.com/stretchr/testify/require`
+	"github.com/bytedance/sonic/internal/native/types"
+	"github.com/bytedance/sonic/internal/rt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-
 func TestNodeSortKeys(t *testing.T) {
-    var src = `{"b":1,"a":2,"c":3}`
-    root, err := NewSearcher(src).GetByPath()
-    if err != nil {
-        t.Fatal(err)
-    }
-    obj, err := root.MapUseNumber()
-    if err != nil {
-        t.Fatal(err)
-    }
-    exp, err := json.Marshal(obj)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if err := root.SortKeys(true); err != nil {
-        t.Fatal(err)
-    }
-    act, err := root.MarshalJSON()
-    if err != nil {
-        t.Fatal(err)
-    }
-    assert.Equal(t, len(exp), len(act))
-    assert.Equal(t, string(exp), string(act))
+	var src = `{"b":1,"a":2,"c":3}`
+	root, err := NewSearcher(src).GetByPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := root.MapUseNumber()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.SortKeys(true); err != nil {
+		t.Fatal(err)
+	}
+	act, err := root.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(exp), len(act))
+	assert.Equal(t, string(exp), string(act))
 
-    src = `[[1], {"b":1,"a":2,"c":3}, [], {}, [{"b":1,"a":2,"c":3,"d":[],"e":{}}]]`
-    root, err = NewSearcher(src).GetByPath()
-    if err != nil {
-        t.Fatal(err)
-    }
-    vv, err := root.Interface()
-    if err != nil {
-        t.Fatal(err)
-    }
-    exp, err = json.Marshal(vv)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if err := root.SortKeys(true); err != nil {
-        t.Fatal(err)
-    }
-    act, err = root.MarshalJSON()
-    if err != nil {
-        t.Fatal(err)
-    }
-    assert.Equal(t, string(exp), string(act))
+	src = `[[1], {"b":1,"a":2,"c":3}, [], {}, [{"b":1,"a":2,"c":3,"d":[],"e":{}}]]`
+	root, err = NewSearcher(src).GetByPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vv, err := root.Interface()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp, err = json.Marshal(vv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := root.SortKeys(true); err != nil {
+		t.Fatal(err)
+	}
+	act, err = root.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, string(exp), string(act))
 
 }
 
 func BenchmarkNodeSortKeys(b *testing.B) {
-    root, err := NewSearcher(_TwitterJson).GetByPath()
-    if err != nil {
-        b.Fatal(err)
-    }
-    if err := root.LoadAll(); err != nil {
-        b.Fatal(err)
-    }
-    
-    b.Run("single", func(b *testing.B) {
-        r := root.Get("statuses")
-        if r.Check() != nil {
-            b.Fatal(r.Error())
-        }
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            _ = root.SortKeys(false)
-        }
-    })
-    b.Run("recurse", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            _ = root.SortKeys(true)
-        }
-    })
+	root, err := NewSearcher(_TwitterJson).GetByPath()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := root.LoadAll(); err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("single", func(b *testing.B) {
+		r := root.Get("statuses")
+		if r.Check() != nil {
+			b.Fatal(r.Error())
+		}
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = root.SortKeys(false)
+		}
+	})
+	b.Run("recurse", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = root.SortKeys(true)
+		}
+	})
 }
 
 //go:noinline
 func stackObj() interface{} {
-    var a int = 1
-    return rt.UnpackEface(a).Pack()
+	var a int = 1
+	return rt.UnpackEface(a).Pack()
 }
 
 func TestStackAny(t *testing.T) {
-    var obj = stackObj()
-    any := NewAny(obj)
-    fmt.Printf("any: %#v\n", any)
-    runtime.GC()
-    debug.FreeOSMemory()
-    println("finish GC")
-    buf, err := any.MarshalJSON()
-    println("finish marshal")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if string(buf) != `1` {
-        t.Fatal(string(buf))
-    }
+	var obj = stackObj()
+	any := NewAny(obj)
+	fmt.Printf("any: %#v\n", any)
+	runtime.GC()
+	debug.FreeOSMemory()
+	println("finish GC")
+	buf, err := any.MarshalJSON()
+	println("finish marshal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != `1` {
+		t.Fatal(string(buf))
+	}
 }
 
 func TestLoadAll(t *testing.T) {
-    e := Node{}
-    err := e.Load()
-    if err != nil {
-        t.Fatal(err)
-    }
-    err = e.LoadAll()
-    if err != nil {
-        t.Fatal(err)
-    }
+	e := Node{}
+	err := e.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = e.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    root, err := NewSearcher(`{"a":{"1":[1],"2":2},"b":[{"1":1},2],"c":[1,2]}`).GetByPath()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if err = root.Load(); err != nil {
-        t.Fatal(err)
-    }
-    if root.len() != 3 {
-        t.Fatal(root.len())
-    }
+	root, err := NewSearcher(`{"a":{"1":[1],"2":2},"b":[{"1":1},2],"c":[1,2]}`).GetByPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = root.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if root.len() != 3 {
+		t.Fatal(root.len())
+	}
 
-    c := root.Get("c")
-    if !c.IsRaw() {
-        t.Fatal(err)
-    }
-    err = c.LoadAll()
-    if err != nil {
-        t.Fatal(err)
-    }
-    if c.len() != 2 {
-        t.Fatal(c.len())
-    }
-    c1 := c.nodeAt(0)
-    if n, err := c1.Int64(); err != nil || n != 1 {
-        t.Fatal(n, err)
-    }
+	c := root.Get("c")
+	if !c.IsRaw() {
+		t.Fatal(err)
+	}
+	err = c.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.len() != 2 {
+		t.Fatal(c.len())
+	}
+	c1 := c.nodeAt(0)
+	if n, err := c1.Int64(); err != nil || n != 1 {
+		t.Fatal(n, err)
+	}
 
-    a := root.pairAt(0)
-    if a.Key != "a" {
-        t.Fatal(a.Key)
-    } else if !a.Value.IsRaw() {
-        t.Fatal(a.Value.itype())
-    } else if n, err := a.Value.Len(); n != 0 || err != nil {
-        t.Fatal(n, err)
-    }
-    if err := a.Value.Load(); err != nil {
-        t.Fatal(err)
-    }
-    if a.Value.len() != 2 {
-        t.Fatal(a.Value.len())
-    }
-    a1 := a.Value.Get("1")
-    if !a1.IsRaw() {
-        t.Fatal(a1)
-    }
-    a.Value.LoadAll()
-    if a1.t != types.V_ARRAY || a1.len() != 1 {
-        t.Fatal(a1.t, a1.len())
-    }
+	a := root.pairAt(0)
+	if a.Key != "a" {
+		t.Fatal(a.Key)
+	} else if !a.Value.IsRaw() {
+		t.Fatal(a.Value.itype())
+	} else if n, err := a.Value.Len(); n != 0 || err != nil {
+		t.Fatal(n, err)
+	}
+	if err := a.Value.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if a.Value.len() != 2 {
+		t.Fatal(a.Value.len())
+	}
+	a1 := a.Value.Get("1")
+	if !a1.IsRaw() {
+		t.Fatal(a1)
+	}
+	a.Value.LoadAll()
+	if a1.t != types.V_ARRAY || a1.len() != 1 {
+		t.Fatal(a1.t, a1.len())
+	}
 
-    b := root.pairAt(1)
-    if b.Key != "b" {
-        t.Fatal(b.Key)
-    } else if !b.Value.IsRaw() {
-        t.Fatal(b.Value.itype())
-    } else if n, err := b.Value.Len(); n != 0 || err != nil {
-        t.Fatal(n, err)
-    }
-    if err := b.Value.Load(); err != nil {
-        t.Fatal(err)
-    }
-    if b.Value.len() != 2 {
-        t.Fatal(b.Value.len())
-    }
-    b1 := b.Value.Index(0)
-    if !b1.IsRaw() {
-        t.Fatal(b1)
-    }
-    b.Value.LoadAll()
-    if b1.t != types.V_OBJECT || b1.len() != 1 {
-        t.Fatal(a1.t, a1.len())
-    }
+	b := root.pairAt(1)
+	if b.Key != "b" {
+		t.Fatal(b.Key)
+	} else if !b.Value.IsRaw() {
+		t.Fatal(b.Value.itype())
+	} else if n, err := b.Value.Len(); n != 0 || err != nil {
+		t.Fatal(n, err)
+	}
+	if err := b.Value.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if b.Value.len() != 2 {
+		t.Fatal(b.Value.len())
+	}
+	b1 := b.Value.Index(0)
+	if !b1.IsRaw() {
+		t.Fatal(b1)
+	}
+	b.Value.LoadAll()
+	if b1.t != types.V_OBJECT || b1.len() != 1 {
+		t.Fatal(a1.t, a1.len())
+	}
 }
 
 func TestIndexPair(t *testing.T) {
-    root, _ := NewParser(`{"a":1,"b":2}`).Parse()
-    a := root.IndexPair(0)
-    if a == nil || a.Key != "a" {
-        t.Fatal(a)
-    }
-    b := root.IndexPair(1)
-    if b == nil || b.Key != "b" {
-        t.Fatal(b)
-    }
-    c := root.IndexPair(2)
-    if c != nil {
-        t.Fatal(c)
-    }
+	root, _ := NewParser(`{"a":1,"b":2}`).Parse()
+	a := root.IndexPair(0)
+	if a == nil || a.Key != "a" {
+		t.Fatal(a)
+	}
+	b := root.IndexPair(1)
+	if b == nil || b.Key != "b" {
+		t.Fatal(b)
+	}
+	c := root.IndexPair(2)
+	if c != nil {
+		t.Fatal(c)
+	}
 }
 
 func TestIndexOrGet(t *testing.T) {
-    root, _ := NewParser(`{"a":1,"b":2}`).Parse()
-    a := root.IndexOrGet(0, "a")
-    if v, err := a.Int64(); err != nil || v != int64(1) {
-        t.Fatal(a)
-    }
-    a = root.IndexOrGet(0, "b")
-    if v, err := a.Int64(); err != nil || v != int64(2) {
-        t.Fatal(a)
-    }
-    a = root.IndexOrGet(0, "c")
-    if a.Valid()  {
-        t.Fatal(a)
-    }
+	root, _ := NewParser(`{"a":1,"b":2}`).Parse()
+	a := root.IndexOrGet(0, "a")
+	if v, err := a.Int64(); err != nil || v != int64(1) {
+		t.Fatal(a)
+	}
+	a = root.IndexOrGet(0, "b")
+	if v, err := a.Int64(); err != nil || v != int64(2) {
+		t.Fatal(a)
+	}
+	a = root.IndexOrGet(0, "c")
+	if a.Valid() {
+		t.Fatal(a)
+	}
 }
 
 func TestTypeCast(t *testing.T) {
-    type tcase struct {
-        method string
-        node Node
-        exp interface{}
-        err error
-    }
-    var nonEmptyErr error = errors.New("")
-    a1 := NewAny(1)
-    lazyArray, _ := NewParser("[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]").Parse()
-    lazyObject, _ := NewParser(`{"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12,"13":13,"14":14,"15":15,"16":16}`).Parse()
-    var cases = []tcase{
-        {"Interface", Node{}, interface{}(nil), ErrUnsupportType},
-        {"Interface", NewAny(NewNumber("1")), float64(1), nil},
-        {"Interface", NewAny(int64(1)), int64(1), nil},
-        {"Interface", NewNumber("1"), float64(1), nil},
-        {"InterfaceUseNode", Node{}, Node{}, nil},
-        {"InterfaceUseNode", a1, a1, nil},
-        {"InterfaceUseNode", NewNumber("1"), NewNumber("1"), nil},
-        {"InterfaceUseNumber", Node{}, interface{}(nil), ErrUnsupportType},
-        {"InterfaceUseNumber", NewAny(1), 1, nil},
-        {"InterfaceUseNumber", NewNumber("1"), json.Number("1"), nil},
-        {"Map", Node{}, map[string]interface{}(nil), ErrUnsupportType},
-        {"Map", NewAny(map[string]Node{"a":NewNumber("1")}), map[string]interface{}(nil), ErrUnsupportType},
-        {"Map", NewAny(map[string]interface{}{"a":1}), map[string]interface{}{"a":1}, nil},
-        {"Map", NewObject([]Pair{{"a",NewNumber("1")}}), map[string]interface{}{"a":float64(1.0)}, nil},
-        {"MapUseNode", Node{}, map[string]Node(nil), ErrUnsupportType},
-        {"MapUseNode", NewAny(map[string]interface{}{"a":1}), map[string]Node(nil), ErrUnsupportType},
-        {"MapUseNode", NewAny(map[string]Node{"a":NewNumber("1")}), map[string]Node{"a":NewNumber("1")}, nil},
-        {"MapUseNode", NewObject([]Pair{{"a",NewNumber("1")}}), map[string]Node{"a":NewNumber("1")}, nil},
-        {"MapUseNumber", Node{}, map[string]interface{}(nil), ErrUnsupportType},
-        {"MapUseNumber", NewAny(map[string]interface{}{"a":1}), map[string]interface{}{"a":1}, nil},
-        {"MapUseNumber", NewObject([]Pair{{"a",NewNumber("1")}}), map[string]interface{}{"a":json.Number("1")}, nil},
-        {"Array", Node{}, []interface{}(nil), ErrUnsupportType},
-        {"Array", NewAny([]interface{}{1}), []interface{}{1}, nil},
-        {"Array", NewArray([]Node{NewNumber("1")}), []interface{}{float64(1.0)}, nil},
-        {"ArrayUseNode", Node{}, []Node(nil), ErrUnsupportType},
-        {"ArrayUseNode", NewAny([]interface{}{1}), []Node(nil), ErrUnsupportType},
-        {"ArrayUseNode", NewAny([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
-        {"ArrayUseNode", NewArray([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
-        {"ArrayUseNumber", Node{}, []interface{}(nil), ErrUnsupportType},
-        {"ArrayUseNumber", NewAny([]interface{}{1}), []interface{}{1}, nil},
-        {"ArrayUseNumber", NewAny([]Node{NewNumber("1")}), []interface{}(nil), ErrUnsupportType},
-        {"ArrayUseNumber", NewArray([]Node{NewNumber("1")}), []interface{}{json.Number("1")}, nil},
-        {"Raw", Node{}, "", ErrNotExist},
-        {"Raw", NewAny(""), `""`, nil},
-        {"Raw", NewRaw(" "), "", nonEmptyErr},
-        {"Raw", NewRaw(" [ ] "), "[ ]", nil},
-        {"Raw", NewRaw("[ ]"), "[ ]", nil},
-        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] } `), `{ "a" : [ true, -1.2e34 ] }`, nil},
-        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] `), "", nonEmptyErr},
-        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 }`), "", nonEmptyErr},
-        {"Raw", NewBool(true), "true", nil},
-        {"Raw", NewNumber("-0.0"), "-0.0", nil},
-        {"Raw", NewString(""), `""`, nil},
-        {"Raw", NewBytes([]byte("hello, world")), `"aGVsbG8sIHdvcmxk"`, nil},
-        {"Bool", Node{}, false, ErrUnsupportType},
-        {"Bool", NewAny(true), true, nil},
-        {"Bool", NewAny(false), false, nil},
-        {"Bool", NewAny(int(0)), false, nil},
-        {"Bool", NewAny(int8(1)), true, nil},
-        {"Bool", NewAny(int16(1)), true, nil},
-        {"Bool", NewAny(int32(1)), true, nil},
-        {"Bool", NewAny(int64(1)), true, nil},
-        {"Bool", NewAny(uint(1)), true, nil},
-        {"Bool", NewAny(uint16(1)), true, nil},
-        {"Bool", NewAny(uint32(1)), true, nil},
-        {"Bool", NewAny(uint64(1)), true, nil},
-        {"Bool", NewAny(float64(0)), false, nil},
-        {"Bool", NewAny(float32(1)), true, nil},
-        {"Bool", NewAny(float64(1)), true, nil},
-        {"Bool", NewAny(json.Number("0")), false, nil},
-        {"Bool", NewAny(json.Number("1")), true, nil},
-        {"Bool", NewAny(json.Number("1.1")), true, nil},
-        {"Bool", NewAny(json.Number("+x1.1")), false, nonEmptyErr},
-        {"Bool", NewAny(string("0")), false, nil},
-        {"Bool", NewAny(string("t")), true, nil},
-        {"Bool", NewAny([]byte{0}), false, nonEmptyErr},
-        {"Bool", NewRaw("true"), true, nil},
-        {"Bool", NewRaw("false"), false, nil},
-        {"Bool", NewRaw("null"), false, nil},
-        {"Bool", NewString(`true`), true, nil},
-        {"Bool", NewString(`false`), false, nil},
-        {"Bool", NewString(``), false, nonEmptyErr},
-        {"Bool", NewNumber("2"), true, nil},
-        {"Bool", NewNumber("-2.1"), true, nil},
-        {"Bool", NewNumber("-x-2.1"), false, nonEmptyErr},
-        {"Int64", NewRaw("true"), int64(1), nil},
-        {"Int64", NewRaw("false"), int64(0), nil},
-        {"Int64", NewRaw("\"1\""), int64(1), nil},
-        {"Int64", NewRaw("\"1.1\""), int64(1), nil},
-        {"Int64", NewRaw("\"1.0\""), int64(1), nil},
-        {"Int64", NewNumber("+x.0"), int64(0), nonEmptyErr},
-        {"Int64", NewAny(false), int64(0), nil},
-        {"Int64", NewAny(true), int64(1), nil},
-        {"Int64", NewAny(int(1)), int64(1), nil},
-        {"Int64", NewAny(int8(1)), int64(1), nil},
-        {"Int64", NewAny(int16(1)), int64(1), nil},
-        {"Int64", NewAny(int32(1)), int64(1), nil},
-        {"Int64", NewAny(int64(1)), int64(1), nil},
-        {"Int64", NewAny(uint(1)), int64(1), nil},
-        {"Int64", NewAny(uint8(1)), int64(1), nil},
-        {"Int64", NewAny(uint32(1)), int64(1), nil},
-        {"Int64", NewAny(uint64(1)), int64(1), nil},
-        {"Int64", NewAny(float32(1)), int64(1), nil},
-        {"Int64", NewAny(float64(1)), int64(1), nil},
-        {"Int64", NewAny("1"), int64(1), nil},
-        {"Int64", NewAny("1.1"), int64(1), nil},
-        {"Int64", NewAny("+1x.1"), int64(0), nonEmptyErr},
-        {"Int64", NewAny(json.Number("1")), int64(1), nil},
-        {"Int64", NewAny(json.Number("1.1")), int64(1), nil},
-        {"Int64", NewAny(json.Number("+1x.1")), int64(0), nonEmptyErr},
-        {"Int64", NewAny([]byte{0}), int64(0), ErrUnsupportType},
-        {"Int64", Node{}, int64(0), ErrUnsupportType},
-        {"Int64", NewRaw("0"), int64(0), nil},
-        {"Int64", NewRaw("null"), int64(0), nil},
-        {"StrictInt64", NewRaw("true"), int64(0), ErrUnsupportType},
-        {"StrictInt64", NewRaw("false"), int64(0), ErrUnsupportType},
-        {"StrictInt64", NewAny(int(0)), int64(0), nil},
-        {"StrictInt64", NewAny(int8(0)), int64(0), nil},
-        {"StrictInt64", NewAny(int16(0)), int64(0), nil},
-        {"StrictInt64", NewAny(int32(0)), int64(0), nil},
-        {"StrictInt64", NewAny(int64(0)), int64(0), nil},
-        {"StrictInt64", NewAny(uint(0)), int64(0), nil},
-        {"StrictInt64", NewAny(uint8(0)), int64(0), nil},
-        {"StrictInt64", NewAny(uint32(0)), int64(0), nil},
-        {"StrictInt64", NewAny(uint64(0)), int64(0), nil},
-        {"StrictInt64", Node{}, int64(0), ErrUnsupportType},
-        {"StrictInt64", NewRaw("0"), int64(0), nil},
-        {"StrictInt64", NewRaw("null"), int64(0), ErrUnsupportType},
-        {"Float64", NewRaw("true"), float64(1), nil},
-        {"Float64", NewRaw("false"), float64(0), nil},
-        {"Float64", NewRaw("\"1.0\""), float64(1.0), nil},
-        {"Float64", NewRaw("\"xx\""), float64(0), nonEmptyErr},
-        {"Float64", Node{}, float64(0), ErrUnsupportType},
-        {"Float64", NewAny(false), float64(0), nil},
-        {"Float64", NewAny(true), float64(1), nil},
-        {"Float64", NewAny(int(1)), float64(1), nil},
-        {"Float64", NewAny(int8(1)), float64(1), nil},
-        {"Float64", NewAny(int16(1)), float64(1), nil},
-        {"Float64", NewAny(int32(1)), float64(1), nil},
-        {"Float64", NewAny(int64(1)), float64(1), nil},
-        {"Float64", NewAny(uint(1)), float64(1), nil},
-        {"Float64", NewAny(uint8(1)), float64(1), nil},
-        {"Float64", NewAny(uint32(1)), float64(1), nil},
-        {"Float64", NewAny(uint64(1)), float64(1), nil},
-        {"Float64", NewAny(float32(1)), float64(1), nil},
-        {"Float64", NewAny(float64(1)), float64(1), nil},
-        {"Float64", NewAny("1.1"), float64(1.1), nil},
-        {"Float64", NewAny("+1x.1"), float64(0), nonEmptyErr},
-        {"Float64", NewAny(json.Number("0")), float64(0), nil},
-        {"Float64", NewAny(json.Number("x")), float64(0), nonEmptyErr},
-        {"Float64", NewAny([]byte{0}), float64(0), ErrUnsupportType},
-        {"Float64", NewRaw("0.0"), float64(0.0), nil},
-        {"Float64", NewRaw("1"), float64(1.0), nil},
-        {"Float64", NewRaw("null"), float64(0.0), nil},
-        {"StrictFloat64", NewRaw("true"), float64(0), ErrUnsupportType},
-        {"StrictFloat64", NewRaw("false"), float64(0), ErrUnsupportType},
-        {"StrictFloat64", Node{}, float64(0), ErrUnsupportType},
-        {"StrictFloat64", NewAny(float32(0)), float64(0), nil},
-        {"StrictFloat64", NewAny(float64(0)), float64(0), nil},
-        {"StrictFloat64", NewRaw("0.0"), float64(0.0), nil},
-        {"StrictFloat64", NewRaw("null"), float64(0.0), ErrUnsupportType},
-        {"Number", Node{}, json.Number(""), ErrUnsupportType},
-        {"Number", NewAny(false), json.Number("0"), nil},
-        {"Number", NewAny(true), json.Number("1"), nil},
-        {"Number", NewAny(int(1)), json.Number("1"), nil},
-        {"Number", NewAny(int8(1)), json.Number("1"), nil},
-        {"Number", NewAny(int16(1)), json.Number("1"), nil},
-        {"Number", NewAny(int32(1)), json.Number("1"), nil},
-        {"Number", NewAny(int64(1)), json.Number("1"), nil},
-        {"Number", NewAny(uint(1)), json.Number("1"), nil},
-        {"Number", NewAny(uint8(1)), json.Number("1"), nil},
-        {"Number", NewAny(uint32(1)), json.Number("1"), nil},
-        {"Number", NewAny(uint64(1)), json.Number("1"), nil},
-        {"Number", NewAny(float32(1)), json.Number("1"), nil},
-        {"Number", NewAny(float64(1)), json.Number("1"), nil},
-        {"Number", NewAny("1.1"), json.Number("1.1"), nil},
-        {"Number", NewAny("+1x.1"), json.Number(""), nonEmptyErr},
-        {"Number", NewAny(json.Number("0")), json.Number("0"), nil},
-        {"Number", NewAny(json.Number("x")), json.Number("x"), nil},
-        {"Number", NewAny(json.Number("+1x.1")), json.Number("+1x.1"), nil},
-        {"Number", NewAny([]byte{0}), json.Number(""), ErrUnsupportType},
-        {"Number", NewRaw("x"), json.Number(""), nonEmptyErr},
-        {"Number", NewRaw("0.0"), json.Number("0.0"), nil},
-        {"Number", NewRaw("\"1\""), json.Number("1"), nil},
-        {"Number", NewRaw("\"1.1\""), json.Number("1.1"), nil},
-        {"Number", NewRaw("\"0.x0\""), json.Number(""), nonEmptyErr},
-        {"Number", NewRaw("{]"), json.Number(""), nonEmptyErr},
-        {"Number", NewRaw("true"), json.Number("1"), nil},
-        {"Number", NewRaw("false"), json.Number("0"), nil},
-        {"Number", NewRaw("null"), json.Number("0"), nil},
-        {"StrictNumber", NewRaw("true"), json.Number(""), ErrUnsupportType},
-        {"StrictNumber", NewRaw("false"), json.Number(""), ErrUnsupportType},
-        {"StrictNumber", Node{}, json.Number(""), ErrUnsupportType},
-        {"StrictNumber", NewAny(json.Number("0")), json.Number("0"), nil},
-        {"StrictNumber", NewRaw("0.0"), json.Number("0.0"), nil},
-        {"StrictNumber", NewRaw("null"), json.Number(""), ErrUnsupportType},
-        {"String", Node{}, "", ErrUnsupportType},
-        {"String", NewAny(`\u263a`), `\u263a`, nil},
-        {"String", NewRaw(`"\u263a"`), `☺`, nil},
-        {"String", NewString(`\u263a`), `\u263a`, nil},
-        {"String", NewRaw(`0.0`), "0.0", nil},
-        {"String", NewRaw(`true`), "true", nil},
-        {"String", NewRaw(`false`), "false", nil},
-        {"String", NewRaw(`null`), "", nil},
-        {"String", NewAny(false), "false", nil},
-        {"String", NewAny(true), "true", nil},
-        {"String", NewAny(int(1)), "1", nil},
-        {"String", NewAny(int8(1)), "1", nil},
-        {"String", NewAny(int16(1)), "1", nil},
-        {"String", NewAny(int32(1)), "1", nil},
-        {"String", NewAny(int64(1)), "1", nil},
-        {"String", NewAny(uint(1)), "1", nil},
-        {"String", NewAny(uint8(1)), "1", nil},
-        {"String", NewAny(uint32(1)), "1", nil},
-        {"String", NewAny(uint64(1)), "1", nil},
-        {"String", NewAny(float32(1)), "1", nil},
-        {"String", NewAny(float64(1)), "1", nil},
-        {"String", NewAny("1.1"), "1.1", nil},
-        {"String", NewAny("+1x.1"), "+1x.1", nil},
-        {"String", NewAny(json.Number("0")), ("0"), nil},
-        {"String", NewAny(json.Number("x")), ("x"), nil},
-        {"String", NewAny([]byte{0}), (""), ErrUnsupportType},
-        {"StrictString", Node{}, "", ErrUnsupportType},
-        {"StrictString", NewAny(`\u263a`), `\u263a`, nil},
-        {"StrictString", NewRaw(`"\u263a"`), `☺`, nil},
-        {"StrictString", NewString(`\u263a`), `\u263a`, nil},
-        {"StrictString", NewRaw(`0.0`), "", ErrUnsupportType},
-        {"StrictString", NewRaw(`true`), "", ErrUnsupportType},
-        {"StrictString", NewRaw(`false`), "", ErrUnsupportType},
-        {"StrictString", NewRaw(`null`), "", ErrUnsupportType},
-        {"Len", Node{}, 0, nil},
-        {"Len", NewAny(0), 0, ErrUnsupportType},
-        {"Len", NewNull(), 0, nil},
-        {"Len", NewRaw(`"1"`), 1, nil},
-        {"Len", NewRaw(`[1]`), 0, nil},
-        {"Len", NewArray([]Node{NewNull()}), 1, nil},
-        {"Len", lazyArray, 0, nil},
-        {"Len", NewRaw(`{"a":1}`), 0, nil},
-        {"Len", lazyObject, 0, nil},
-        {"Cap", Node{}, 0, nil},
-        {"Cap", NewAny(0), 0, ErrUnsupportType},
-        {"Cap", NewNull(), 0, nil},
-        {"Cap", NewRaw(`[1]`), _DEFAULT_NODE_CAP, nil},
-        {"Cap", NewObject([]Pair{{"",NewNull()}}), _DEFAULT_NODE_CAP, nil},
-        {"Cap", NewRaw(`{"a":1}`), _DEFAULT_NODE_CAP, nil},
-    }
-    lazyArray.skipAllIndex()
-    lazyObject.skipAllKey()
-    cases = append(cases, 
-        tcase{"Len", lazyArray, 17, nil},
-        tcase{"Len", lazyObject, 17, nil},
-        tcase{"Cap", lazyArray, _DEFAULT_NODE_CAP*3, nil},
-        tcase{"Cap", lazyObject, _DEFAULT_NODE_CAP*3, nil},
-    )
+	type tcase struct {
+		method string
+		node   Node
+		exp    interface{}
+		err    error
+	}
+	var nonEmptyErr error = errors.New("")
+	a1 := NewAny(1)
+	lazyArray, _ := NewParser("[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]").Parse()
+	lazyObject, _ := NewParser(`{"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12,"13":13,"14":14,"15":15,"16":16}`).Parse()
+	var cases = []tcase{
+		{"Interface", Node{}, interface{}(nil), ErrUnsupportType},
+		{"Interface", NewAny(NewNumber("1")), float64(1), nil},
+		{"Interface", NewAny(int64(1)), int64(1), nil},
+		{"Interface", NewNumber("1"), float64(1), nil},
+		{"InterfaceUseNode", Node{}, Node{}, nil},
+		{"InterfaceUseNode", a1, a1, nil},
+		{"InterfaceUseNode", NewNumber("1"), NewNumber("1"), nil},
+		{"InterfaceUseNumber", Node{}, interface{}(nil), ErrUnsupportType},
+		{"InterfaceUseNumber", NewAny(1), 1, nil},
+		{"InterfaceUseNumber", NewNumber("1"), json.Number("1"), nil},
+		{"Map", Node{}, map[string]interface{}(nil), ErrUnsupportType},
+		{"Map", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]interface{}(nil), ErrUnsupportType},
+		{"Map", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
+		{"Map", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": float64(1.0)}, nil},
+		{"MapUseNode", Node{}, map[string]Node(nil), ErrUnsupportType},
+		{"MapUseNode", NewAny(map[string]interface{}{"a": 1}), map[string]Node(nil), ErrUnsupportType},
+		{"MapUseNode", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]Node{"a": NewNumber("1")}, nil},
+		{"MapUseNode", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]Node{"a": NewNumber("1")}, nil},
+		{"MapUseNumber", Node{}, map[string]interface{}(nil), ErrUnsupportType},
+		{"MapUseNumber", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
+		{"MapUseNumber", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": json.Number("1")}, nil},
+		{"Array", Node{}, []interface{}(nil), ErrUnsupportType},
+		{"Array", NewAny([]interface{}{1}), []interface{}{1}, nil},
+		{"Array", NewArray([]Node{NewNumber("1")}), []interface{}{float64(1.0)}, nil},
+		{"ArrayUseNode", Node{}, []Node(nil), ErrUnsupportType},
+		{"ArrayUseNode", NewAny([]interface{}{1}), []Node(nil), ErrUnsupportType},
+		{"ArrayUseNode", NewAny([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
+		{"ArrayUseNode", NewArray([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
+		{"ArrayUseNumber", Node{}, []interface{}(nil), ErrUnsupportType},
+		{"ArrayUseNumber", NewAny([]interface{}{1}), []interface{}{1}, nil},
+		{"ArrayUseNumber", NewAny([]Node{NewNumber("1")}), []interface{}(nil), ErrUnsupportType},
+		{"ArrayUseNumber", NewArray([]Node{NewNumber("1")}), []interface{}{json.Number("1")}, nil},
+		{"Raw", Node{}, "", ErrNotExist},
+		{"Raw", NewAny(""), `""`, nil},
+		{"Raw", NewRaw(" "), "", nonEmptyErr},
+		{"Raw", NewRaw(" [ ] "), "[ ]", nil},
+		{"Raw", NewRaw("[ ]"), "[ ]", nil},
+		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] } `), `{ "a" : [ true, -1.2e34 ] }`, nil},
+		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] `), "", nonEmptyErr},
+		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 }`), "", nonEmptyErr},
+		{"Raw", NewBool(true), "true", nil},
+		{"Raw", NewNumber("-0.0"), "-0.0", nil},
+		{"Raw", NewString(""), `""`, nil},
+		{"Raw", NewBytes([]byte("hello, world")), `"aGVsbG8sIHdvcmxk"`, nil},
+		{"Bool", Node{}, false, ErrUnsupportType},
+		{"Bool", NewAny(true), true, nil},
+		{"Bool", NewAny(false), false, nil},
+		{"Bool", NewAny(int(0)), false, nil},
+		{"Bool", NewAny(int8(1)), true, nil},
+		{"Bool", NewAny(int16(1)), true, nil},
+		{"Bool", NewAny(int32(1)), true, nil},
+		{"Bool", NewAny(int64(1)), true, nil},
+		{"Bool", NewAny(uint(1)), true, nil},
+		{"Bool", NewAny(uint16(1)), true, nil},
+		{"Bool", NewAny(uint32(1)), true, nil},
+		{"Bool", NewAny(uint64(1)), true, nil},
+		{"Bool", NewAny(float64(0)), false, nil},
+		{"Bool", NewAny(float32(1)), true, nil},
+		{"Bool", NewAny(float64(1)), true, nil},
+		{"Bool", NewAny(json.Number("0")), false, nil},
+		{"Bool", NewAny(json.Number("1")), true, nil},
+		{"Bool", NewAny(json.Number("1.1")), true, nil},
+		{"Bool", NewAny(json.Number("+x1.1")), false, nonEmptyErr},
+		{"Bool", NewAny(string("0")), false, nil},
+		{"Bool", NewAny(string("t")), true, nil},
+		{"Bool", NewAny([]byte{0}), false, nonEmptyErr},
+		{"Bool", NewRaw("true"), true, nil},
+		{"Bool", NewRaw("false"), false, nil},
+		{"Bool", NewRaw("null"), false, nil},
+		{"Bool", NewString(`true`), true, nil},
+		{"Bool", NewString(`false`), false, nil},
+		{"Bool", NewString(``), false, nonEmptyErr},
+		{"Bool", NewNumber("2"), true, nil},
+		{"Bool", NewNumber("-2.1"), true, nil},
+		{"Bool", NewNumber("-x-2.1"), false, nonEmptyErr},
+		{"Int64", NewRaw("true"), int64(1), nil},
+		{"Int64", NewRaw("false"), int64(0), nil},
+		{"Int64", NewRaw("\"1\""), int64(1), nil},
+		{"Int64", NewRaw("\"1.1\""), int64(1), nil},
+		{"Int64", NewRaw("\"1.0\""), int64(1), nil},
+		{"Int64", NewNumber("+x.0"), int64(0), nonEmptyErr},
+		{"Int64", NewAny(false), int64(0), nil},
+		{"Int64", NewAny(true), int64(1), nil},
+		{"Int64", NewAny(int(1)), int64(1), nil},
+		{"Int64", NewAny(int8(1)), int64(1), nil},
+		{"Int64", NewAny(int16(1)), int64(1), nil},
+		{"Int64", NewAny(int32(1)), int64(1), nil},
+		{"Int64", NewAny(int64(1)), int64(1), nil},
+		{"Int64", NewAny(uint(1)), int64(1), nil},
+		{"Int64", NewAny(uint8(1)), int64(1), nil},
+		{"Int64", NewAny(uint32(1)), int64(1), nil},
+		{"Int64", NewAny(uint64(1)), int64(1), nil},
+		{"Int64", NewAny(float32(1)), int64(1), nil},
+		{"Int64", NewAny(float64(1)), int64(1), nil},
+		{"Int64", NewAny("1"), int64(1), nil},
+		{"Int64", NewAny("1.1"), int64(1), nil},
+		{"Int64", NewAny("+1x.1"), int64(0), nonEmptyErr},
+		{"Int64", NewAny(json.Number("1")), int64(1), nil},
+		{"Int64", NewAny(json.Number("1.1")), int64(1), nil},
+		{"Int64", NewAny(json.Number("+1x.1")), int64(0), nonEmptyErr},
+		{"Int64", NewAny([]byte{0}), int64(0), ErrUnsupportType},
+		{"Int64", Node{}, int64(0), ErrUnsupportType},
+		{"Int64", NewRaw("0"), int64(0), nil},
+		{"Int64", NewRaw("null"), int64(0), nil},
+		{"StrictInt64", NewRaw("true"), int64(0), ErrUnsupportType},
+		{"StrictInt64", NewRaw("false"), int64(0), ErrUnsupportType},
+		{"StrictInt64", NewAny(int(0)), int64(0), nil},
+		{"StrictInt64", NewAny(int8(0)), int64(0), nil},
+		{"StrictInt64", NewAny(int16(0)), int64(0), nil},
+		{"StrictInt64", NewAny(int32(0)), int64(0), nil},
+		{"StrictInt64", NewAny(int64(0)), int64(0), nil},
+		{"StrictInt64", NewAny(uint(0)), int64(0), nil},
+		{"StrictInt64", NewAny(uint8(0)), int64(0), nil},
+		{"StrictInt64", NewAny(uint32(0)), int64(0), nil},
+		{"StrictInt64", NewAny(uint64(0)), int64(0), nil},
+		{"StrictInt64", Node{}, int64(0), ErrUnsupportType},
+		{"StrictInt64", NewRaw("0"), int64(0), nil},
+		{"StrictInt64", NewRaw("null"), int64(0), ErrUnsupportType},
+		{"Float64", NewRaw("true"), float64(1), nil},
+		{"Float64", NewRaw("false"), float64(0), nil},
+		{"Float64", NewRaw("\"1.0\""), float64(1.0), nil},
+		{"Float64", NewRaw("\"xx\""), float64(0), nonEmptyErr},
+		{"Float64", Node{}, float64(0), ErrUnsupportType},
+		{"Float64", NewAny(false), float64(0), nil},
+		{"Float64", NewAny(true), float64(1), nil},
+		{"Float64", NewAny(int(1)), float64(1), nil},
+		{"Float64", NewAny(int8(1)), float64(1), nil},
+		{"Float64", NewAny(int16(1)), float64(1), nil},
+		{"Float64", NewAny(int32(1)), float64(1), nil},
+		{"Float64", NewAny(int64(1)), float64(1), nil},
+		{"Float64", NewAny(uint(1)), float64(1), nil},
+		{"Float64", NewAny(uint8(1)), float64(1), nil},
+		{"Float64", NewAny(uint32(1)), float64(1), nil},
+		{"Float64", NewAny(uint64(1)), float64(1), nil},
+		{"Float64", NewAny(float32(1)), float64(1), nil},
+		{"Float64", NewAny(float64(1)), float64(1), nil},
+		{"Float64", NewAny("1.1"), float64(1.1), nil},
+		{"Float64", NewAny("+1x.1"), float64(0), nonEmptyErr},
+		{"Float64", NewAny(json.Number("0")), float64(0), nil},
+		{"Float64", NewAny(json.Number("x")), float64(0), nonEmptyErr},
+		{"Float64", NewAny([]byte{0}), float64(0), ErrUnsupportType},
+		{"Float64", NewRaw("0.0"), float64(0.0), nil},
+		{"Float64", NewRaw("1"), float64(1.0), nil},
+		{"Float64", NewRaw("null"), float64(0.0), nil},
+		{"StrictFloat64", NewRaw("true"), float64(0), ErrUnsupportType},
+		{"StrictFloat64", NewRaw("false"), float64(0), ErrUnsupportType},
+		{"StrictFloat64", Node{}, float64(0), ErrUnsupportType},
+		{"StrictFloat64", NewAny(float32(0)), float64(0), nil},
+		{"StrictFloat64", NewAny(float64(0)), float64(0), nil},
+		{"StrictFloat64", NewRaw("0.0"), float64(0.0), nil},
+		{"StrictFloat64", NewRaw("null"), float64(0.0), ErrUnsupportType},
+		{"Number", Node{}, json.Number(""), ErrUnsupportType},
+		{"Number", NewAny(false), json.Number("0"), nil},
+		{"Number", NewAny(true), json.Number("1"), nil},
+		{"Number", NewAny(int(1)), json.Number("1"), nil},
+		{"Number", NewAny(int8(1)), json.Number("1"), nil},
+		{"Number", NewAny(int16(1)), json.Number("1"), nil},
+		{"Number", NewAny(int32(1)), json.Number("1"), nil},
+		{"Number", NewAny(int64(1)), json.Number("1"), nil},
+		{"Number", NewAny(uint(1)), json.Number("1"), nil},
+		{"Number", NewAny(uint8(1)), json.Number("1"), nil},
+		{"Number", NewAny(uint32(1)), json.Number("1"), nil},
+		{"Number", NewAny(uint64(1)), json.Number("1"), nil},
+		{"Number", NewAny(float32(1)), json.Number("1"), nil},
+		{"Number", NewAny(float64(1)), json.Number("1"), nil},
+		{"Number", NewAny("1.1"), json.Number("1.1"), nil},
+		{"Number", NewAny("+1x.1"), json.Number(""), nonEmptyErr},
+		{"Number", NewAny(json.Number("0")), json.Number("0"), nil},
+		{"Number", NewAny(json.Number("x")), json.Number("x"), nil},
+		{"Number", NewAny(json.Number("+1x.1")), json.Number("+1x.1"), nil},
+		{"Number", NewAny([]byte{0}), json.Number(""), ErrUnsupportType},
+		{"Number", NewRaw("x"), json.Number(""), nonEmptyErr},
+		{"Number", NewRaw("0.0"), json.Number("0.0"), nil},
+		{"Number", NewRaw("\"1\""), json.Number("1"), nil},
+		{"Number", NewRaw("\"1.1\""), json.Number("1.1"), nil},
+		{"Number", NewRaw("\"0.x0\""), json.Number(""), nonEmptyErr},
+		{"Number", NewRaw("{]"), json.Number(""), nonEmptyErr},
+		{"Number", NewRaw("true"), json.Number("1"), nil},
+		{"Number", NewRaw("false"), json.Number("0"), nil},
+		{"Number", NewRaw("null"), json.Number("0"), nil},
+		{"StrictNumber", NewRaw("true"), json.Number(""), ErrUnsupportType},
+		{"StrictNumber", NewRaw("false"), json.Number(""), ErrUnsupportType},
+		{"StrictNumber", Node{}, json.Number(""), ErrUnsupportType},
+		{"StrictNumber", NewAny(json.Number("0")), json.Number("0"), nil},
+		{"StrictNumber", NewRaw("0.0"), json.Number("0.0"), nil},
+		{"StrictNumber", NewRaw("null"), json.Number(""), ErrUnsupportType},
+		{"String", Node{}, "", ErrUnsupportType},
+		{"String", NewAny(`\u263a`), `\u263a`, nil},
+		{"String", NewRaw(`"\u263a"`), `☺`, nil},
+		{"String", NewString(`\u263a`), `\u263a`, nil},
+		{"String", NewRaw(`0.0`), "0.0", nil},
+		{"String", NewRaw(`true`), "true", nil},
+		{"String", NewRaw(`false`), "false", nil},
+		{"String", NewRaw(`null`), "", nil},
+		{"String", NewAny(false), "false", nil},
+		{"String", NewAny(true), "true", nil},
+		{"String", NewAny(int(1)), "1", nil},
+		{"String", NewAny(int8(1)), "1", nil},
+		{"String", NewAny(int16(1)), "1", nil},
+		{"String", NewAny(int32(1)), "1", nil},
+		{"String", NewAny(int64(1)), "1", nil},
+		{"String", NewAny(uint(1)), "1", nil},
+		{"String", NewAny(uint8(1)), "1", nil},
+		{"String", NewAny(uint32(1)), "1", nil},
+		{"String", NewAny(uint64(1)), "1", nil},
+		{"String", NewAny(float32(1)), "1", nil},
+		{"String", NewAny(float64(1)), "1", nil},
+		{"String", NewAny("1.1"), "1.1", nil},
+		{"String", NewAny("+1x.1"), "+1x.1", nil},
+		{"String", NewAny(json.Number("0")), ("0"), nil},
+		{"String", NewAny(json.Number("x")), ("x"), nil},
+		{"String", NewAny([]byte{0}), (""), ErrUnsupportType},
+		{"StrictString", Node{}, "", ErrUnsupportType},
+		{"StrictString", NewAny(`\u263a`), `\u263a`, nil},
+		{"StrictString", NewRaw(`"\u263a"`), `☺`, nil},
+		{"StrictString", NewString(`\u263a`), `\u263a`, nil},
+		{"StrictString", NewRaw(`0.0`), "", ErrUnsupportType},
+		{"StrictString", NewRaw(`true`), "", ErrUnsupportType},
+		{"StrictString", NewRaw(`false`), "", ErrUnsupportType},
+		{"StrictString", NewRaw(`null`), "", ErrUnsupportType},
+		{"Len", Node{}, 0, nil},
+		{"Len", NewAny(0), 0, ErrUnsupportType},
+		{"Len", NewNull(), 0, nil},
+		{"Len", NewRaw(`"1"`), 1, nil},
+		{"Len", NewRaw(`[1]`), 0, nil},
+		{"Len", NewArray([]Node{NewNull()}), 1, nil},
+		{"Len", lazyArray, 0, nil},
+		{"Len", NewRaw(`{"a":1}`), 0, nil},
+		{"Len", lazyObject, 0, nil},
+		{"Cap", Node{}, 0, nil},
+		{"Cap", NewAny(0), 0, ErrUnsupportType},
+		{"Cap", NewNull(), 0, nil},
+		{"Cap", NewRaw(`[1]`), _DEFAULT_NODE_CAP, nil},
+		{"Cap", NewObject([]Pair{{"", NewNull()}}), _DEFAULT_NODE_CAP, nil},
+		{"Cap", NewRaw(`{"a":1}`), _DEFAULT_NODE_CAP, nil},
+	}
+	lazyArray.skipAllIndex()
+	lazyObject.skipAllKey()
+	cases = append(cases,
+		tcase{"Len", lazyArray, 17, nil},
+		tcase{"Len", lazyObject, 17, nil},
+		tcase{"Cap", lazyArray, _DEFAULT_NODE_CAP * 3, nil},
+		tcase{"Cap", lazyObject, _DEFAULT_NODE_CAP * 3, nil},
+	)
 
-    for i, c := range cases {
-        fmt.Println(i, c)
-        rt := reflect.ValueOf(&c.node)
-        m := rt.MethodByName(c.method)
-        rets := m.Call([]reflect.Value{})
-        if len(rets) != 2 {
-            t.Error(i, rets)
-        }
-        if !reflect.DeepEqual(rets[0].Interface(), c.exp) {
-            t.Error(i, rets[0].Interface(), c.exp)
-        }
-        v := rets[1].Interface();
-        if c.err == nonEmptyErr {
-            if reflect.ValueOf(v).IsNil() {
-                t.Error(i, v)
-            }
-        } else if  v != c.err {
-            t.Error(i, v)
-        }
-    }
+	for i, c := range cases {
+		fmt.Println(i, c)
+		rt := reflect.ValueOf(&c.node)
+		m := rt.MethodByName(c.method)
+		rets := m.Call([]reflect.Value{})
+		if len(rets) != 2 {
+			t.Error(i, rets)
+		}
+		if !reflect.DeepEqual(rets[0].Interface(), c.exp) {
+			t.Error(i, rets[0].Interface(), c.exp)
+		}
+		v := rets[1].Interface()
+		if c.err == nonEmptyErr {
+			if reflect.ValueOf(v).IsNil() {
+				t.Error(i, v)
+			}
+		} else if v != c.err {
+			t.Error(i, v)
+		}
+	}
 }
 
 func TestCheckError_Nil(t *testing.T) {
-    nill := (*Node)(nil)
-    if nill.Valid() || nill.Check() == nil {
-        t.Fail()
-    }
-    if nill.Get("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.GetByPath("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.Index(1).Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexOrGet(1, "a").Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexPair(1) != nil {
-        t.Fatal()
-    }
-    if _, err := nill.Set("", Node{}); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetByIndex(1, Node{}); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetAny("", 1); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.Unset(""); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.UnsetByIndex(1); err == nil {
-        t.Fatal()
-    }
-    if err := nill.Add(Node{}); err == nil {
-        t.Fatal()
-    }
-    if err := nill.AddAny(1); err == nil {
-        t.Fatal()
-    }
+	nill := (*Node)(nil)
+	if nill.Valid() || nill.Check() == nil {
+		t.Fail()
+	}
+	if nill.Get("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.GetByPath("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.Index(1).Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexOrGet(1, "a").Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexPair(1) != nil {
+		t.Fatal()
+	}
+	if _, err := nill.Set("", Node{}); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetByIndex(1, Node{}); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetAny("", 1); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.Unset(""); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.UnsetByIndex(1); err == nil {
+		t.Fatal()
+	}
+	if err := nill.Add(Node{}); err == nil {
+		t.Fatal()
+	}
+	if err := nill.AddAny(1); err == nil {
+		t.Fatal()
+	}
 }
 
 func TestCheckError_None(t *testing.T) {
-    nill := Node{}
-    if !nill.Valid() || nill.Check() != nil {
-        t.Fail()
-    }
-    if nill.Get("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.GetByPath("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.Index(1).Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexOrGet(1, "a").Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexPair(1) != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.Set("a", Node{}); err != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.SetByIndex(0, Node{}); err != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.SetByIndex(1, Node{}); err == nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.SetAny("a", 1); err != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.SetAnyByIndex(0, 1); err != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.Unset(""); err == nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if _, err := nill.UnsetByIndex(1); err == nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if err := nill.Add(Node{}); err != nil {
-        t.Fatal()
-    }
-    nill = Node{}
-    if err := nill.AddAny(1); err != nil {
-        t.Fatal()
-    }
+	nill := Node{}
+	if !nill.Valid() || nill.Check() != nil {
+		t.Fail()
+	}
+	if nill.Get("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.GetByPath("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.Index(1).Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexOrGet(1, "a").Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexPair(1) != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.Set("a", Node{}); err != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.SetByIndex(0, Node{}); err != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.SetByIndex(1, Node{}); err == nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.SetAny("a", 1); err != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.SetAnyByIndex(0, 1); err != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.Unset(""); err == nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if _, err := nill.UnsetByIndex(1); err == nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if err := nill.Add(Node{}); err != nil {
+		t.Fatal()
+	}
+	nill = Node{}
+	if err := nill.AddAny(1); err != nil {
+		t.Fatal()
+	}
 }
 
 func TestCheckError_Error(t *testing.T) {
-    nill := newError(types.ERR_EOF, "")
-    if nill.Valid() || nill.Check() == nil {
-        t.Fail()
-    }
-    if nill.Get("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.GetByPath("").Check() == nil {
-        t.Fatal()
-    }
-    if nill.Index(1).Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexOrGet(1, "a").Check() == nil {
-        t.Fatal()
-    }
-    if nill.IndexPair(1) != nil {
-        t.Fatal()
-    }
-    if _, err := nill.Set("", Node{}); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetByIndex(1, Node{}); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetAny("", 1); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.Unset(""); err == nil {
-        t.Fatal()
-    }
-    if _, err := nill.UnsetByIndex(1); err == nil {
-        t.Fatal()
-    }
-    if err := nill.Add(Node{}); err == nil {
-        t.Fatal()
-    }
-    if err := nill.AddAny(1); err == nil {
-        t.Fatal()
-    }
+	nill := newError(types.ERR_EOF, "")
+	if nill.Valid() || nill.Check() == nil {
+		t.Fail()
+	}
+	if nill.Get("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.GetByPath("").Check() == nil {
+		t.Fatal()
+	}
+	if nill.Index(1).Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexOrGet(1, "a").Check() == nil {
+		t.Fatal()
+	}
+	if nill.IndexPair(1) != nil {
+		t.Fatal()
+	}
+	if _, err := nill.Set("", Node{}); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetByIndex(1, Node{}); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetAny("", 1); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.Unset(""); err == nil {
+		t.Fatal()
+	}
+	if _, err := nill.UnsetByIndex(1); err == nil {
+		t.Fatal()
+	}
+	if err := nill.Add(Node{}); err == nil {
+		t.Fatal()
+	}
+	if err := nill.AddAny(1); err == nil {
+		t.Fatal()
+	}
 }
 
 func TestCheckError_Empty(t *testing.T) {
-    empty := Node{}
-    if !empty.Valid() || empty.Check() != nil || empty.Error() != "" {
-        t.Fatal()
-    }
- 
-    n := newRawNode("[hello]", types.V_ARRAY)
-    n.parseRaw(false)
-    if n.Check() != nil {
-        t.Fatal(n.Check())
-    }
-    n = newRawNode("[hello]", types.V_ARRAY)
-    n.parseRaw(true)
-    p := NewParser("[hello]")
-    p.noLazy = true
-    p.skipValue = false
-    _, x := p.Parse()
-    if n.Error() != newSyntaxError(p.syntaxError(x)).Error() {
-        t.Fatal(n.Check())
-    }
+	empty := Node{}
+	if !empty.Valid() || empty.Check() != nil || empty.Error() != "" {
+		t.Fatal()
+	}
 
+	n := newRawNode("[hello]", types.V_ARRAY)
+	n.parseRaw(false)
+	if n.Check() != nil {
+		t.Fatal(n.Check())
+	}
+	n = newRawNode("[hello]", types.V_ARRAY)
+	n.parseRaw(true)
+	p := NewParser("[hello]")
+	p.noLazy = true
+	p.skipValue = false
+	_, x := p.Parse()
+	if n.Error() != newSyntaxError(p.syntaxError(x)).Error() {
+		t.Fatal(n.Check())
+	}
 
-    s, err := NewParser(`{"a":{}, "b":talse, "c":{}}`).Parse()
-    if err != 0 {
-        t.Fatal(err)
-    }
+	s, err := NewParser(`{"a":{}, "b":talse, "c":{}}`).Parse()
+	if err != 0 {
+		t.Fatal(err)
+	}
 
-    root := s.GetByPath()
-    // fmt.Println(root.Check())
-    a := root.Get("a")
-    if a.Check() != nil {
-        t.Fatal(a.Check())
-    }
-    c := root.Get("c")
-    if c.Check() == nil {
-        t.Fatal()
-    }
-    fmt.Println(c.Check())
+	root := s.GetByPath()
+	// fmt.Println(root.Check())
+	a := root.Get("a")
+	if a.Check() != nil {
+		t.Fatal(a.Check())
+	}
+	c := root.Get("c")
+	if c.Check() == nil {
+		t.Fatal()
+	}
+	fmt.Println(c.Check())
 
-    _, e := a.Properties()
-    if e != nil {
-        t.Fatal(e)
-    }
-    exist, e := a.Set("d", newRawNode("x", types.V_OBJECT))
-    if exist || e != nil {
-        t.Fatal(err)
-    }
-    if a.len() != 1 {
-        t.Fail()
-    }
-    d := a.Get("d").Get("")
-    if d.Check() == nil {
-        t.Fatal(d) 
-    }
-    exist, e = a.Set("e", newRawNode("[}", types.V_ARRAY))
-    if e != nil {
-        t.Fatal(e)
-    }
-    if a.len() != 2 {
-        t.Fail()
-    }
-    d = a.Index(1).Index(0)
-    if d.Check() == nil {
-        t.Fatal(d)
-    }
+	_, e := a.Properties()
+	if e != nil {
+		t.Fatal(e)
+	}
+	exist, e := a.Set("d", newRawNode("x", types.V_OBJECT))
+	if exist || e != nil {
+		t.Fatal(err)
+	}
+	if a.len() != 1 {
+		t.Fail()
+	}
+	d := a.Get("d").Get("")
+	if d.Check() == nil {
+		t.Fatal(d)
+	}
+	exist, e = a.Set("e", newRawNode("[}", types.V_ARRAY))
+	if e != nil {
+		t.Fatal(e)
+	}
+	if a.len() != 2 {
+		t.Fail()
+	}
+	d = a.Index(1).Index(0)
+	if d.Check() == nil {
+		t.Fatal(d)
+	}
 
-
-    it, e := root.Interface()
-    if e == nil {
-        t.Fatal(it)
-    }
-    fmt.Println(e)
+	it, e := root.Interface()
+	if e == nil {
+		t.Fatal(it)
+	}
+	fmt.Println(e)
 }
 
 func TestIndex(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    status := root.GetByPath("statuses", 0)
-    x, _ := status.Index(4).String()
-    y, _ := status.Get("id_str").String()
-    if x != y {
-        t.Fail()
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	status := root.GetByPath("statuses", 0)
+	x, _ := status.Index(4).String()
+	y, _ := status.Get("id_str").String()
+	if x != y {
+		t.Fail()
+	}
 }
 
 func TestUnset(t *testing.T) {
@@ -912,7 +909,7 @@ func TestUnset(t *testing.T) {
 //             t.Fatalf("exp:%v, got:%v", i, x)
 //         }
 //     }
-    
+
 //     root, err = NewSearcher(str).GetByPath("object")
 //     if err != nil {
 //         t.Fatal(err)
@@ -934,176 +931,176 @@ func TestUnset(t *testing.T) {
 // }
 
 func TestUseNode(t *testing.T) {
-    str, loop := getTestIteratorSample(_DEFAULT_NODE_CAP)
-    root, e := NewParser(str).Parse()
-    if e != 0 {
-        t.Fatal(e)
-    }
-    _, er := root.InterfaceUseNode()
-    if er != nil {
-        t.Fatal(er)
-    }
+	str, loop := getTestIteratorSample(_DEFAULT_NODE_CAP)
+	root, e := NewParser(str).Parse()
+	if e != 0 {
+		t.Fatal(e)
+	}
+	_, er := root.InterfaceUseNode()
+	if er != nil {
+		t.Fatal(er)
+	}
 
-    root, err := NewSearcher(str).GetByPath("array")
-    if err != nil {
-        t.Fatal(err)
-    }
-    a, _ := root.ArrayUseNode()
-    if len(a) != loop {
-        t.Fatalf("exp:%v, got:%v", loop, len(a))
-    }
-    for i := int64(0); i<int64(loop); i++{
-        in := a[i]
-        a, _ := in.Int64()
-        if a != i {
-            t.Fatalf("exp:%v, got:%v", i, a)
-        }
-    }
+	root, err := NewSearcher(str).GetByPath("array")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := root.ArrayUseNode()
+	if len(a) != loop {
+		t.Fatalf("exp:%v, got:%v", loop, len(a))
+	}
+	for i := int64(0); i < int64(loop); i++ {
+		in := a[i]
+		a, _ := in.Int64()
+		if a != i {
+			t.Fatalf("exp:%v, got:%v", i, a)
+		}
+	}
 
-    root, err = NewSearcher(str).GetByPath("array")
-    if err != nil {
-        t.Fatal(err)
-    }
-    x, _ := root.InterfaceUseNode()
-    a = x.([]Node)
-    if len(a) != loop {
-        t.Fatalf("exp:%v, got:%v", loop, len(a))
-    }
-    for i := int64(0); i<int64(loop); i++{
-        in := a[i]
-        a, _ := in.Int64()
-        if a != i {
-            t.Fatalf("exp:%v, got:%v", i, a)
-        }
-    }
-    
-    root, err = NewSearcher(str).GetByPath("object")
-    if err != nil {
-        t.Fatal(err)
-    }
-    b, _ := root.MapUseNode()
-    if len(b) != loop {
-        t.Fatalf("exp:%v, got:%v", loop, len(b))
-    }
-    for i := int64(0); i<int64(loop); i++ {
-        k := `k`+strconv.Itoa(int(i))
-        xn, ok := b[k]
-        if !ok {
-            t.Fatalf("unexpected element: %#v", xn)
-        }
-        a, _ := xn.Int64()
-        if a != i {
-            t.Fatalf("exp:%v, got:%v", i, a)
-        }
-    }
-    
-    root, err = NewSearcher(str).GetByPath("object")
-    if err != nil {
-        t.Fatal(err)
-    }
-    x, _ = root.InterfaceUseNode()
-    b = x.(map[string]Node)
-    if len(b) != loop {
-        t.Fatalf("exp:%v, got:%v", loop, len(b))
-    }
-    for i := int64(0); i<int64(loop); i++ {
-        k := `k`+strconv.Itoa(int(i))
-        xn, ok := b[k]
-        if !ok {
-            t.Fatalf("unexpected element: %#v", xn)
-        }
-        a, _ := xn.Int64()
-        if a != i {
-            t.Fatalf("exp:%v, got:%v", i, a)
-        }
-    }
+	root, err = NewSearcher(str).GetByPath("array")
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, _ := root.InterfaceUseNode()
+	a = x.([]Node)
+	if len(a) != loop {
+		t.Fatalf("exp:%v, got:%v", loop, len(a))
+	}
+	for i := int64(0); i < int64(loop); i++ {
+		in := a[i]
+		a, _ := in.Int64()
+		if a != i {
+			t.Fatalf("exp:%v, got:%v", i, a)
+		}
+	}
+
+	root, err = NewSearcher(str).GetByPath("object")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := root.MapUseNode()
+	if len(b) != loop {
+		t.Fatalf("exp:%v, got:%v", loop, len(b))
+	}
+	for i := int64(0); i < int64(loop); i++ {
+		k := `k` + strconv.Itoa(int(i))
+		xn, ok := b[k]
+		if !ok {
+			t.Fatalf("unexpected element: %#v", xn)
+		}
+		a, _ := xn.Int64()
+		if a != i {
+			t.Fatalf("exp:%v, got:%v", i, a)
+		}
+	}
+
+	root, err = NewSearcher(str).GetByPath("object")
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, _ = root.InterfaceUseNode()
+	b = x.(map[string]Node)
+	if len(b) != loop {
+		t.Fatalf("exp:%v, got:%v", loop, len(b))
+	}
+	for i := int64(0); i < int64(loop); i++ {
+		k := `k` + strconv.Itoa(int(i))
+		xn, ok := b[k]
+		if !ok {
+			t.Fatalf("unexpected element: %#v", xn)
+		}
+		a, _ := xn.Int64()
+		if a != i {
+			t.Fatalf("exp:%v, got:%v", i, a)
+		}
+	}
 }
 
 func TestUseNumber(t *testing.T) {
-    str, _ := getTestIteratorSample(_DEFAULT_NODE_CAP)
-    root, e := NewParser(str).Parse()
-    if e != 0 {
-        t.Fatal(e)
-    }
-    _, er := root.InterfaceUseNumber()
-    if er != nil {
-        t.Fatal(er)
-    }
+	str, _ := getTestIteratorSample(_DEFAULT_NODE_CAP)
+	root, e := NewParser(str).Parse()
+	if e != 0 {
+		t.Fatal(e)
+	}
+	_, er := root.InterfaceUseNumber()
+	if er != nil {
+		t.Fatal(er)
+	}
 
-    node, err := NewParser("1061346755812312312313").Parse()
-    if err != 0 {
-        t.Fatal(err)
-    }
-    if node.Type() != V_NUMBER {
-        t.Fatalf("wrong type: %v", node.Type())
-    }
-    x, _ := node.InterfaceUseNumber()
-    iv := x.(json.Number)
-    if iv.String() != "1061346755812312312313" {
-        t.Fatalf("exp:%#v, got:%#v", "1061346755812312312313", iv.String())
-    }
-    x, _ = node.Interface()
-    ix := x.(float64)
-    if ix != float64(1061346755812312312313) {
-        t.Fatalf("exp:%#v, got:%#v", float64(1061346755812312312313), ix)
-    }
-    xj, _ := node.Number()
-    ij, _ := xj.Int64()
-    jj, _ := json.Number("1061346755812312312313").Int64()
-    if ij != jj {
-        t.Fatalf("exp:%#v, got:%#v", jj, ij)
-    }
+	node, err := NewParser("1061346755812312312313").Parse()
+	if err != 0 {
+		t.Fatal(err)
+	}
+	if node.Type() != V_NUMBER {
+		t.Fatalf("wrong type: %v", node.Type())
+	}
+	x, _ := node.InterfaceUseNumber()
+	iv := x.(json.Number)
+	if iv.String() != "1061346755812312312313" {
+		t.Fatalf("exp:%#v, got:%#v", "1061346755812312312313", iv.String())
+	}
+	x, _ = node.Interface()
+	ix := x.(float64)
+	if ix != float64(1061346755812312312313) {
+		t.Fatalf("exp:%#v, got:%#v", float64(1061346755812312312313), ix)
+	}
+	xj, _ := node.Number()
+	ij, _ := xj.Int64()
+	jj, _ := json.Number("1061346755812312312313").Int64()
+	if ij != jj {
+		t.Fatalf("exp:%#v, got:%#v", jj, ij)
+	}
 }
 
 func TestMap(t *testing.T) {
-    node, err := NewParser(`{"a":-0, "b":1, "c":-1.2, "d":-1.2e-10}`).Parse()
-    if err != 0 {
-        t.Fatal(err)
-    }
-    m, _ := node.Map()
-    assert.Equal(t, m, map[string]interface{}{
-        "a": float64(0),    
-        "b": float64(1),    
-        "c": -1.2,
-        "d": -1.2e-10,
-    })
-    m1, _ := node.MapUseNumber()
-    assert.Equal(t, m1, map[string]interface{}{
-        "a": json.Number("-0"),    
-        "b": json.Number("1"),    
-        "c": json.Number("-1.2"),    
-        "d": json.Number("-1.2e-10"),    
-    })
+	node, err := NewParser(`{"a":-0, "b":1, "c":-1.2, "d":-1.2e-10}`).Parse()
+	if err != 0 {
+		t.Fatal(err)
+	}
+	m, _ := node.Map()
+	assert.Equal(t, m, map[string]interface{}{
+		"a": float64(0),
+		"b": float64(1),
+		"c": -1.2,
+		"d": -1.2e-10,
+	})
+	m1, _ := node.MapUseNumber()
+	assert.Equal(t, m1, map[string]interface{}{
+		"a": json.Number("-0"),
+		"b": json.Number("1"),
+		"c": json.Number("-1.2"),
+		"d": json.Number("-1.2e-10"),
+	})
 }
 
 func TestArray(t *testing.T) {
-    node, err := NewParser(`[-0, 1, -1.2, -1.2e-10]`).Parse()
-    if err != 0 {
-        t.Fatal(err)
-    }
-    m, _ := node.Array()
-    assert.Equal(t, m, []interface{}{
-        float64(0),    
-        float64(1),
-        -1.2,
-        -1.2e-10,
-    })
-    m1, _ := node.ArrayUseNumber()
-    assert.Equal(t, m1, []interface{}{
-        json.Number("-0"),    
-        json.Number("1"),    
-        json.Number("-1.2"),    
-        json.Number("-1.2e-10"),    
-    })
+	node, err := NewParser(`[-0, 1, -1.2, -1.2e-10]`).Parse()
+	if err != 0 {
+		t.Fatal(err)
+	}
+	m, _ := node.Array()
+	assert.Equal(t, m, []interface{}{
+		float64(0),
+		float64(1),
+		-1.2,
+		-1.2e-10,
+	})
+	m1, _ := node.ArrayUseNumber()
+	assert.Equal(t, m1, []interface{}{
+		json.Number("-0"),
+		json.Number("1"),
+		json.Number("-1.2"),
+		json.Number("-1.2e-10"),
+	})
 }
 
 func TestNodeRaw(t *testing.T) {
-    root, derr := NewSearcher(_TwitterJson).GetByPath("search_metadata")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ := root.Raw()
-    var comp = `{
+	root, derr := NewSearcher(_TwitterJson).GetByPath("search_metadata")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ := root.Raw()
+	var comp = `{
     "max_id": 250126199840518145,
     "since_id": 24012619984051000,
     "refresh_url": "?since_id=250126199840518145&q=%23freebandnames&result_type=mixed&include_entities=1",
@@ -1114,16 +1111,16 @@ func TestNodeRaw(t *testing.T) {
     "query": "%23freebandnames",
     "max_id_str": "250126199840518145"
   }`
-    if val != comp {
-        t.Fatalf("exp: %+v, got: %+v", comp, val)
-    }
+	if val != comp {
+		t.Fatalf("exp: %+v, got: %+v", comp, val)
+	}
 
-    root, derr = NewSearcher(_TwitterJson).GetByPath("statuses", 0, "entities", "hashtags")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ = root.Raw()
-    comp = `[
+	root, derr = NewSearcher(_TwitterJson).GetByPath("statuses", 0, "entities", "hashtags")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ = root.Raw()
+	comp = `[
           {
             "text": "freebandnames",
             "indices": [
@@ -1132,688 +1129,742 @@ func TestNodeRaw(t *testing.T) {
             ]
           }
         ]`
-    if val != comp {
-        t.Fatalf("exp: \n%s\n, got: \n%s\n", comp, val)
-    }
+	if val != comp {
+		t.Fatalf("exp: \n%s\n, got: \n%s\n", comp, val)
+	}
 
-    var data = `{"k1" :   { "a" : "bc"} , "k2" : [1,2 ] , "k3":{} , "k4":[]}`
-    root, derr = NewSearcher(data).GetByPath("k1")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ = root.Raw()
-    comp = `{ "a" : "bc"}`
-    if val != comp {
-        t.Fatalf("exp: %+v, got: %+v", comp, val)
-    }
+	var data = `{"k1" :   { "a" : "bc"} , "k2" : [1,2 ] , "k3":{} , "k4":[]}`
+	root, derr = NewSearcher(data).GetByPath("k1")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ = root.Raw()
+	comp = `{ "a" : "bc"}`
+	if val != comp {
+		t.Fatalf("exp: %+v, got: %+v", comp, val)
+	}
 
-    root, derr = NewSearcher(data).GetByPath("k2")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ = root.Raw()
-    comp = `[1,2 ]`
-    if val != comp {
-        t.Fatalf("exp: %+v, got: %+v", comp, val)
-    }
+	root, derr = NewSearcher(data).GetByPath("k2")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ = root.Raw()
+	comp = `[1,2 ]`
+	if val != comp {
+		t.Fatalf("exp: %+v, got: %+v", comp, val)
+	}
 
-    root, derr = NewSearcher(data).GetByPath("k3")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ = root.Raw()
-    comp = `{}`
-    if val != comp {
-        t.Fatalf("exp: %+v, got: %+v", comp, val)
-    }
+	root, derr = NewSearcher(data).GetByPath("k3")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ = root.Raw()
+	comp = `{}`
+	if val != comp {
+		t.Fatalf("exp: %+v, got: %+v", comp, val)
+	}
 
-    root, derr = NewSearcher(data).GetByPath("k4")
-    if derr != nil {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ = root.Raw()
-    comp = `[]`
-    if val != comp {
-        t.Fatalf("exp: %+v, got: %+v", comp, val)
-    }
+	root, derr = NewSearcher(data).GetByPath("k4")
+	if derr != nil {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ = root.Raw()
+	comp = `[]`
+	if val != comp {
+		t.Fatalf("exp: %+v, got: %+v", comp, val)
+	}
 }
 
 func TestNodeGet(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ := root.Get("search_metadata").Get("max_id").Int64()
-    if val != int64(250126199840518145) {
-        t.Fatalf("exp: %+v, got: %+v", 250126199840518145, val)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ := root.Get("search_metadata").Get("max_id").Int64()
+	if val != int64(250126199840518145) {
+		t.Fatalf("exp: %+v, got: %+v", 250126199840518145, val)
+	}
 }
 
 func TestNodeIndex(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ := root.Get("statuses").Index(3).Get("id_str").String()
-    if val != "249279667666817024" {
-        t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ := root.Get("statuses").Index(3).Get("id_str").String()
+	if val != "249279667666817024" {
+		t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
+	}
 }
 
 func TestNodeGetByPath(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    val, _ := root.GetByPath("statuses", 3, "id_str").String()
-    if val != "249279667666817024" {
-        t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	val, _ := root.GetByPath("statuses", 3, "id_str").String()
+	if val != "249279667666817024" {
+		t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
+	}
 }
 
 func TestNodeSet(t *testing.T) {
-    arr := NewRaw(`[]`)
-    ex, ee := arr.Set("a", NewNumber("-1"))
-    if ex || ee == nil {
-        t.Fatal()
-    }
-    empty := Node{}
-    err := empty.Add(Node{})
-    if err != nil {
-        t.Fatal(err)
-    }
-    empty2 := empty.Index(0)
-    if empty2.Check() != nil {
-        t.Fatal(err)
-    }
-    exist, err := empty2.SetByIndex(1, Node{})
-    if exist || err == nil {
-        t.Fatal(exist, err)
-    }
-    empty3 := empty.Index(0)
-    if empty3.Check() != nil {
-        t.Fatal(err)
-    }
-    exist, err = empty3.Set("a", NewNumber("-1"))
-    if exist || err != nil {
-        t.Fatal(exist, err)
-    }
-    if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
-        t.Fatal(n, e)
-    }
+	arr := NewRaw(`[]`)
+	ex, ee := arr.Set("a", NewNumber("-1"))
+	if ex || ee == nil {
+		t.Fatal()
+	}
+	empty := Node{}
+	err := empty.Add(Node{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty2 := empty.Index(0)
+	if empty2.Check() != nil {
+		t.Fatal(err)
+	}
+	exist, err := empty2.SetByIndex(1, Node{})
+	if exist || err == nil {
+		t.Fatal(exist, err)
+	}
+	empty3 := empty.Index(0)
+	if empty3.Check() != nil {
+		t.Fatal(err)
+	}
+	exist, err = empty3.Set("a", NewNumber("-1"))
+	if exist || err != nil {
+		t.Fatal(exist, err)
+	}
+	if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
+		t.Fatal(n, e)
+	}
 
-    empty = NewNull()
-    err = empty.Add(NewNull())
-    if err != nil {
-        t.Fatal(err)
-    }
-    empty2 = empty.Index(0)
-    if empty2.Check() != nil {
-        t.Fatal(err)
-    }
-    exist, err = empty2.SetByIndex(1, NewNull())
-    if exist || err == nil {
-        t.Fatal(exist, err)
-    }
-    empty3 = empty.Index(0)
-    if empty3.Check() != nil {
-        t.Fatal(err)
-    }
-    exist, err = empty3.Set("a", NewNumber("-1"))
-    if exist || err != nil {
-        t.Fatal(exist, err)
-    }
-    if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
-        t.Fatal(n, e)
-    }
-    
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    app,_ := NewParser("111").Parse()
-    root.GetByPath("statuses", 3).Set("id_str", app)
-    val, _ := root.GetByPath("statuses", 3, "id_str").Int64()
-    if val != 111 {
-        t.Fatalf("exp: %+v, got: %+v", 111, val)
-    }
-    for i, _ := root.GetByPath("statuses", 3).Cap(); i >= 0; i-- {
-        root.GetByPath("statuses", 3).Set("id_str"+strconv.Itoa(i), app)
-    }
-    val, _ = root.GetByPath("statuses", 3, "id_str0").Int64()
-    if val != 111 {
-        t.Fatalf("exp: %+v, got: %+v", 111, val)
-    }
+	empty = NewNull()
+	err = empty.Add(NewNull())
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty2 = empty.Index(0)
+	if empty2.Check() != nil {
+		t.Fatal(err)
+	}
+	exist, err = empty2.SetByIndex(1, NewNull())
+	if exist || err == nil {
+		t.Fatal(exist, err)
+	}
+	empty3 = empty.Index(0)
+	if empty3.Check() != nil {
+		t.Fatal(err)
+	}
+	exist, err = empty3.Set("a", NewNumber("-1"))
+	if exist || err != nil {
+		t.Fatal(exist, err)
+	}
+	if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
+		t.Fatal(n, e)
+	}
 
-    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    root.GetByPath("statuses", 3).Set("id_str2", nroot)
-    val2, _ := root.GetByPath("statuses", 3, "id_str2", "a", 4, "b").String()
-    if val2 != "c" {
-        t.Fatalf("exp:%+v, got:%+v", "c", val2)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	app, _ := NewParser("111").Parse()
+	root.GetByPath("statuses", 3).Set("id_str", app)
+	val, _ := root.GetByPath("statuses", 3, "id_str").Int64()
+	if val != 111 {
+		t.Fatalf("exp: %+v, got: %+v", 111, val)
+	}
+	for i, _ := root.GetByPath("statuses", 3).Cap(); i >= 0; i-- {
+		root.GetByPath("statuses", 3).Set("id_str"+strconv.Itoa(i), app)
+	}
+	val, _ = root.GetByPath("statuses", 3, "id_str0").Int64()
+	if val != 111 {
+		t.Fatalf("exp: %+v, got: %+v", 111, val)
+	}
+
+	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	root.GetByPath("statuses", 3).Set("id_str2", nroot)
+	val2, _ := root.GetByPath("statuses", 3, "id_str2", "a", 4, "b").String()
+	if val2 != "c" {
+		t.Fatalf("exp:%+v, got:%+v", "c", val2)
+	}
 }
 
 func TestNodeAny(t *testing.T) {
-    empty := Node{}
-    _,err := empty.SetAny("any", map[string]interface{}{"a": []int{0}})
-    if err != nil {
-        t.Fatal(err)
-    }
-    if m, err := empty.Get("any").Interface(); err != nil {
-        t.Fatal(err)
-    } else if v, ok := m.(map[string]interface{}); !ok {
-        t.Fatal(v)
-    }
-    if buf, err := empty.MarshalJSON(); err != nil {
-        t.Fatal(err)
-    } else if string(buf) != `{"any":{"a":[0]}}` {
-        t.Fatal(string(buf))
-    }
-    if _, err := empty.Set("any2", Node{}); err != nil {
-        t.Fatal(err)
-    }
-    if err := empty.Get("any2").AddAny(nil); err != nil {
-        t.Fatal(err)
-    }
-    if buf, err := empty.MarshalJSON(); err != nil {
-        t.Fatal(err)
-    } else if string(buf) != `{"any":{"a":[0]},"any2":[null]}` {
-        t.Fatal(string(buf))
-    }
-    if _, err := empty.Get("any2").SetAnyByIndex(0, NewNumber("-0.0")); err != nil {
-        t.Fatal(err)
-    }
-    if buf, err := empty.MarshalJSON(); err != nil {
-        t.Fatal(err)
-    } else if string(buf) != `{"any":{"a":[0]},"any2":[-0.0]}` {
-        t.Fatal(string(buf))
-    }
+	empty := Node{}
+	_, err := empty.SetAny("any", map[string]interface{}{"a": []int{0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m, err := empty.Get("any").Interface(); err != nil {
+		t.Fatal(err)
+	} else if v, ok := m.(map[string]interface{}); !ok {
+		t.Fatal(v)
+	}
+	if buf, err := empty.MarshalJSON(); err != nil {
+		t.Fatal(err)
+	} else if string(buf) != `{"any":{"a":[0]}}` {
+		t.Fatal(string(buf))
+	}
+	if _, err := empty.Set("any2", Node{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := empty.Get("any2").AddAny(nil); err != nil {
+		t.Fatal(err)
+	}
+	if buf, err := empty.MarshalJSON(); err != nil {
+		t.Fatal(err)
+	} else if string(buf) != `{"any":{"a":[0]},"any2":[null]}` {
+		t.Fatal(string(buf))
+	}
+	if _, err := empty.Get("any2").SetAnyByIndex(0, NewNumber("-0.0")); err != nil {
+		t.Fatal(err)
+	}
+	if buf, err := empty.MarshalJSON(); err != nil {
+		t.Fatal(err)
+	} else if string(buf) != `{"any":{"a":[0]},"any2":[-0.0]}` {
+		t.Fatal(string(buf))
+	}
 }
 
 func TestNodeSetByIndex(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    app, _ := NewParser("111").Parse()
-    st := root.GetByPath("statuses")
-    st.SetByIndex(0, app)
-    st = root.GetByPath("statuses") 
-    val := st.Index(0)
-    x, _ := val.Int64()
-    if x != 111 {
-        t.Fatalf("exp: %+v, got: %+v", 111, val)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	app, _ := NewParser("111").Parse()
+	st := root.GetByPath("statuses")
+	st.SetByIndex(0, app)
+	st = root.GetByPath("statuses")
+	val := st.Index(0)
+	x, _ := val.Int64()
+	if x != 111 {
+		t.Fatalf("exp: %+v, got: %+v", 111, val)
+	}
 
-    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    root.GetByPath("statuses").SetByIndex(0, nroot)
-    val2, _ := root.GetByPath("statuses", 0, "a", 4, "b").String()
-    if val2 != "c" {
-        t.Fatalf("exp:%+v, got:%+v", "c", val2)
-    }
+	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	root.GetByPath("statuses").SetByIndex(0, nroot)
+	val2, _ := root.GetByPath("statuses", 0, "a", 4, "b").String()
+	if val2 != "c" {
+		t.Fatalf("exp:%+v, got:%+v", "c", val2)
+	}
 }
 
 func TestNodeAdd(t *testing.T) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    app, _ := NewParser("111").Parse()
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	app, _ := NewParser("111").Parse()
 
-    for i, _ := root.GetByPath("statuses").Cap(); i >= 0; i-- {
-        root.GetByPath("statuses").Add(app)
-    }
-    val, _ := root.GetByPath("statuses", 4).Int64()
-    if val != 111 {
-        t.Fatalf("exp: %+v, got: %+v", 111, val)
-    }
-    val, _ = root.GetByPath("statuses", root.GetByPath("statuses").len()-1).Int64()
-    if val != 111 {
-        t.Fatalf("exp: %+v, got: %+v", 111, val)
-    }
+	for i, _ := root.GetByPath("statuses").Cap(); i >= 0; i-- {
+		root.GetByPath("statuses").Add(app)
+	}
+	val, _ := root.GetByPath("statuses", 4).Int64()
+	if val != 111 {
+		t.Fatalf("exp: %+v, got: %+v", 111, val)
+	}
+	val, _ = root.GetByPath("statuses", root.GetByPath("statuses").len()-1).Int64()
+	if val != 111 {
+		t.Fatalf("exp: %+v, got: %+v", 111, val)
+	}
 
-    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-    if derr != 0 {
-        t.Fatalf("decode failed: %v", derr.Error())
-    }
-    root.GetByPath("statuses").Add(nroot)
-    val2, _ := root.GetByPath("statuses", root.GetByPath("statuses").len()-1, "a", 4, "b").String()
-    if val2 != "c" {
-        t.Fatalf("exp:%+v, got:%+v", "c", val2)
-    }
+	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+	if derr != 0 {
+		t.Fatalf("decode failed: %v", derr.Error())
+	}
+	root.GetByPath("statuses").Add(nroot)
+	val2, _ := root.GetByPath("statuses", root.GetByPath("statuses").len()-1, "a", 4, "b").String()
+	if val2 != "c" {
+		t.Fatalf("exp:%+v, got:%+v", "c", val2)
+	}
 }
 
 func BenchmarkLoadNode(b *testing.B) {
-    b.Run("Interface()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-            if err != nil {
-                b.Fatal(err)
-            }
-            _, _ = root.Interface()
-        }
-    })
+	b.Run("Interface()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, _ = root.Interface()
+		}
+	})
 
-    b.Run("LoadAll()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-            if err != nil {
-                b.Fatal(err)
-            }
-            _ = root.LoadAll()
-        }
-    })
+	b.Run("LoadAll()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = root.LoadAll()
+		}
+	})
 
-    b.Run("InterfaceUseNode()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-            if err != nil {
-                b.Fatal(err)
-            }
-            _, _ = root.InterfaceUseNode()
-        }
-    })
+	b.Run("InterfaceUseNode()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_, _ = root.InterfaceUseNode()
+		}
+	})
 
-    b.Run("Load()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        for i:=0; i<b.N; i++ {
-            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-            if err != nil {
-                b.Fatal(err)
-            }
-            _ = root.Load()
-        }
-    })
+	b.Run("Load()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = root.Load()
+		}
+	})
 }
 
 func BenchmarkLoadNode_Parallel(b *testing.B) {
-    b.Run("Interface()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        b.RunParallel(func(pb *testing.PB) {
-            for pb.Next() {
-                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-                if err != nil {
-                    b.Fatal(err)
-                }
-                _, _ = root.Interface()
-            }
-        })
-    })
+	b.Run("Interface()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, _ = root.Interface()
+			}
+		})
+	})
 
-    b.Run("LoadAll()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        b.RunParallel(func(pb *testing.PB) {
-            for pb.Next() {
-                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-                if err != nil {
-                    b.Fatal(err)
-                }
-                _ = root.LoadAll()
-            }
-        })
-    })
+	b.Run("LoadAll()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = root.LoadAll()
+			}
+		})
+	})
 
-    b.Run("InterfaceUseNode()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        b.RunParallel(func(pb *testing.PB) {
-            for pb.Next() {
-                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-                if err != nil {
-                    b.Fatal(err)
-                }
-                _, _ = root.InterfaceUseNode()
-            }
-        })
-    })
+	b.Run("InterfaceUseNode()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, _ = root.InterfaceUseNode()
+			}
+		})
+	})
 
-    b.Run("Load()", func(b *testing.B) {
-        b.SetBytes(int64(len(_TwitterJson)))
-        b.ResetTimer()
-        b.RunParallel(func(pb *testing.PB) {
-            for pb.Next() {
-                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-                if err != nil {
-                    b.Fatal(err)
-                }
-                _ = root.Load()
-            }
-        })
-    })
+	b.Run("Load()", func(b *testing.B) {
+		b.SetBytes(int64(len(_TwitterJson)))
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = root.Load()
+			}
+		})
+	})
 }
 
 func BenchmarkNodeGetByPath(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    _, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
-    b.ResetTimer()
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	_, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
+	b.ResetTimer()
 
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
-        }
-    })
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
+		}
+	})
 }
 
 func BenchmarkStructGetByPath(b *testing.B) {
-    var root = _TwitterStruct{}
-    err := json.Unmarshal([]byte(_TwitterJson), &root)
-    if err != nil {
-        b.Fatalf("unmarshal failed: %v", err)
-    }
+	var root = _TwitterStruct{}
+	err := json.Unmarshal([]byte(_TwitterJson), &root)
+	if err != nil {
+		b.Fatalf("unmarshal failed: %v", err)
+	}
 
-    b.ResetTimer()
+	b.ResetTimer()
 
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            _ = root.Statuses[3].Entities.Hashtags[0].Text
-        }
-    })
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = root.Statuses[3].Entities.Hashtags[0].Text
+		}
+	})
 }
 
 func BenchmarkNodeIndex(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node.Index(2)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node.Index(2)
+	}
 }
 
 func BenchmarkStructIndex(b *testing.B) {
-    type T struct {
-        A Node
-        B Node
-        C Node
-        D Node
-        E Node
-    }
-    var obj = new(T)
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _ = obj.C
-    }
+	type T struct {
+		A Node
+		B Node
+		C Node
+		D Node
+		E Node
+	}
+	var obj = new(T)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = obj.C
+	}
 }
 
 func BenchmarkSliceIndex(b *testing.B) {
-    var obj = []Node{Node{},Node{},Node{},Node{},Node{}}
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _ = obj[2]
-    }
+	var obj = []Node{Node{}, Node{}, Node{}, Node{}, Node{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = obj[2]
+	}
 }
 
 func BenchmarkMapIndex(b *testing.B) {
-    var obj = map[string]interface{}{"test1":Node{}, "test2":Node{}, "test3":Node{}, "test4":Node{}, "test5":Node{}}
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        for k := range obj {
-            if k == "test3" {
-                break 
-            }
-        }
-    }
+	var obj = map[string]interface{}{"test1": Node{}, "test2": Node{}, "test3": Node{}, "test4": Node{}, "test5": Node{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for k := range obj {
+			if k == "test3" {
+				break
+			}
+		}
+	}
 }
 
 func BenchmarkNodeGet(b *testing.B) {
-    var N = 5
-    var half = "test" + strconv.Itoa(N/2+1)
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    for i:=0; i<N; i++ {
-        node.Set("test"+strconv.Itoa(i), NewNumber(strconv.Itoa(i)))
-    }
+	var N = 5
+	var half = "test" + strconv.Itoa(N/2+1)
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	for i := 0; i < N; i++ {
+		node.Set("test"+strconv.Itoa(i), NewNumber(strconv.Itoa(i)))
+	}
 
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _ = node.Get(half)
-    }
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = node.Get(half)
+	}
 }
 
 func BenchmarkSliceGet(b *testing.B) {
-    var obj = []string{"test1", "test2", "test3", "test4", "test5"}
-    str := "test3"
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        for _, k := range obj {
-            if k == str {
-                break 
-            }
-        }
-    }
+	var obj = []string{"test1", "test2", "test3", "test4", "test5"}
+	str := "test3"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, k := range obj {
+			if k == str {
+				break
+			}
+		}
+	}
 }
 
 func BenchmarkMapGet(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    m, _ := node.Map()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        _ = m["test3"]
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	m, _ := node.Map()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m["test3"]
+	}
 }
 
 func BenchmarkNodeSet(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    n := NewNull()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node.Set("test3", n)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	n := NewNull()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node.Set("test3", n)
+	}
 }
 
 func BenchmarkMapSet(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    m, _ := node.Map()
-    n := NewNull()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        m["test3"] = n
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	m, _ := node.Map()
+	n := NewNull()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m["test3"] = n
+	}
 }
 
 func BenchmarkNodeSetByIndex(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-    node.Add(NewNumber("1"))
-    node.Add(NewNumber("2"))
-    node.Add(NewNumber("3"))
-    node.Add(NewNumber("4"))
-    node.Add(NewNumber("5"))
-    n := NewNull()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node.SetByIndex(2, n)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+	node.Add(NewNumber("1"))
+	node.Add(NewNumber("2"))
+	node.Add(NewNumber("3"))
+	node.Add(NewNumber("4"))
+	node.Add(NewNumber("5"))
+	n := NewNull()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node.SetByIndex(2, n)
+	}
 }
 
 func BenchmarkSliceSetByIndex(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-    node.Add(NewNumber("1"))
-    node.Add(NewNumber("2"))
-    node.Add(NewNumber("3"))
-    node.Add(NewNumber("4"))
-    node.Add(NewNumber("5"))
-    m, _ := node.Array()
-    n := NewNull()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        m[2] = n
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+	node.Add(NewNumber("1"))
+	node.Add(NewNumber("2"))
+	node.Add(NewNumber("3"))
+	node.Add(NewNumber("4"))
+	node.Add(NewNumber("5"))
+	m, _ := node.Array()
+	n := NewNull()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m[2] = n
+	}
 }
 
 func BenchmarkStructSetByIndex(b *testing.B) {
-    type T struct {
-        A Node
-        B Node
-        C Node
-        D Node
-        E Node
-    }
-    var obj = new(T)
-    n := NewNull()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        obj.C = n
-    }
+	type T struct {
+		A Node
+		B Node
+		C Node
+		D Node
+		E Node
+	}
+	var obj = new(T)
+	n := NewNull()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		obj.C = n
+	}
 }
 
 func BenchmarkNodeUnset(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node.Unset("test3")
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node.Unset("test3")
+	}
 }
 
 func BenchmarkMapUnset(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-    node.Set("test1", NewNumber("1"))
-    node.Set("test2", NewNumber("2"))
-    node.Set("test3", NewNumber("3"))
-    node.Set("test4", NewNumber("4"))
-    node.Set("test5", NewNumber("5"))
-    m, _ := node.Map()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        delete(m, "test3")
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+	node.Set("test1", NewNumber("1"))
+	node.Set("test2", NewNumber("2"))
+	node.Set("test3", NewNumber("3"))
+	node.Set("test4", NewNumber("4"))
+	node.Set("test5", NewNumber("5"))
+	m, _ := node.Map()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		delete(m, "test3")
+	}
 }
 
 func BenchmarkNodUnsetByIndex(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-    node.Add(NewNumber("1"))
-    node.Add(NewNumber("2"))
-    node.Add(NewNumber("3"))
-    node.Add(NewNumber("4"))
-    node.Add(NewNumber("5"))
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node.UnsetByIndex(2)
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+	node.Add(NewNumber("1"))
+	node.Add(NewNumber("2"))
+	node.Add(NewNumber("3"))
+	node.Add(NewNumber("4"))
+	node.Add(NewNumber("5"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node.UnsetByIndex(2)
+	}
 }
 
 func BenchmarkSliceUnsetByIndex(b *testing.B) {
-    root, derr := NewParser(_TwitterJson).Parse()
-    if derr != 0 {
-        b.Fatalf("decode failed: %v", derr.Error())
-    }
-    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-    node.Add(NewNumber("1"))
-    node.Add(NewNumber("2"))
-    node.Add(NewNumber("3"))
-    node.Add(NewNumber("4"))
-    node.Add(NewNumber("5"))
-    m, _ := node.Array()
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        for i:=3; i<5; i++ {
-            m[i-1] = m[i]
-        }
-    }
+	root, derr := NewParser(_TwitterJson).Parse()
+	if derr != 0 {
+		b.Fatalf("decode failed: %v", derr.Error())
+	}
+	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+	node.Add(NewNumber("1"))
+	node.Add(NewNumber("2"))
+	node.Add(NewNumber("3"))
+	node.Add(NewNumber("4"))
+	node.Add(NewNumber("5"))
+	m, _ := node.Array()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for i := 3; i < 5; i++ {
+			m[i-1] = m[i]
+		}
+	}
 }
 
 func BenchmarkNodeAdd(b *testing.B) {
-    n := NewObject([]Pair{{"test", NewNumber("1")}})
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node := NewArray([]Node{})
-        node.Add(n)
-    }
+	n := NewObject([]Pair{{"test", NewNumber("1")}})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node := NewArray([]Node{})
+		node.Add(n)
+	}
 }
 
 func BenchmarkSliceAdd(b *testing.B) {
-    n := NewObject([]Pair{{"test", NewNumber("1")}})
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node := []Node{}
-        node = append(node, n)
-    }
+	n := NewObject([]Pair{{"test", NewNumber("1")}})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node := []Node{}
+		node = append(node, n)
+	}
 }
 
 func BenchmarkMapAdd(b *testing.B) {
-    n := NewObject([]Pair{{"test", NewNumber("1")}})
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        node := map[string]Node{}
-        node["test3"] = n
-    }
+	n := NewObject([]Pair{{"test", NewNumber("1")}})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		node := map[string]Node{}
+		node["test3"] = n
+	}
+}
+
+func TestNode_Move(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      Node 
+        src int
+        dst int
+        out     Node
+		wantErr bool
+	}{
+		{
+            name:    "over index",
+            in:      NewArray([]Node{}),
+            src: 0,
+            dst: 1,
+            out:     NewArray([]Node{}),
+            wantErr: false,
+        },
+        {
+            name:    "equal index",
+            in:      NewArray([]Node{NewBool(true)}),
+            src: 0,
+            dst: 0,
+            out:     NewArray([]Node{NewBool(true)}),
+            wantErr: false,
+        },
+        {
+            name:    "forward",
+            in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
+            src: 0,
+            dst: 2,
+            out:     NewArray([]Node{NewString("b"), NewString("c"), NewString("a")}),
+            wantErr: false,
+        },
+        {
+            name:    "backward",
+            in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
+            src: 2,
+            dst: 0,
+            out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
+            wantErr: false,
+        },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.in.Move(tt.src, tt.dst)
+            require.NoError(t, err)
+            ej, _ := tt.out.MarshalJSON()
+            aj, _ := tt.in.MarshalJSON()
+            require.Equal(t, string(ej), string(aj))
+		})
+	}
+
 }

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -17,876 +17,876 @@
 package ast
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"reflect"
-	"runtime"
-	"runtime/debug"
-	"strconv"
-	"testing"
+    `bytes`
+    `encoding/json`
+    `errors`
+    `fmt`
+    `reflect`
+    `runtime`
+    `runtime/debug`
+    `strconv`
+    `testing`
 
-	"github.com/bytedance/sonic/internal/native/types"
-	"github.com/bytedance/sonic/internal/rt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+    `github.com/bytedance/sonic/internal/native/types`
+    `github.com/bytedance/sonic/internal/rt`
+    `github.com/stretchr/testify/assert`
+    `github.com/stretchr/testify/require`
 )
 
 func TestNodeSortKeys(t *testing.T) {
-	var src = `{"b":1,"a":2,"c":3}`
-	root, err := NewSearcher(src).GetByPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	obj, err := root.MapUseNumber()
-	if err != nil {
-		t.Fatal(err)
-	}
-	exp, err := json.Marshal(obj)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := root.SortKeys(true); err != nil {
-		t.Fatal(err)
-	}
-	act, err := root.MarshalJSON()
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, len(exp), len(act))
-	assert.Equal(t, string(exp), string(act))
+    var src = `{"b":1,"a":2,"c":3}`
+    root, err := NewSearcher(src).GetByPath()
+    if err != nil {
+        t.Fatal(err)
+    }
+    obj, err := root.MapUseNumber()
+    if err != nil {
+        t.Fatal(err)
+    }
+    exp, err := json.Marshal(obj)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := root.SortKeys(true); err != nil {
+        t.Fatal(err)
+    }
+    act, err := root.MarshalJSON()
+    if err != nil {
+        t.Fatal(err)
+    }
+    assert.Equal(t, len(exp), len(act))
+    assert.Equal(t, string(exp), string(act))
 
-	src = `[[1], {"b":1,"a":2,"c":3}, [], {}, [{"b":1,"a":2,"c":3,"d":[],"e":{}}]]`
-	root, err = NewSearcher(src).GetByPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	vv, err := root.Interface()
-	if err != nil {
-		t.Fatal(err)
-	}
-	exp, err = json.Marshal(vv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := root.SortKeys(true); err != nil {
-		t.Fatal(err)
-	}
-	act, err = root.MarshalJSON()
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, string(exp), string(act))
+    src = `[[1], {"b":1,"a":2,"c":3}, [], {}, [{"b":1,"a":2,"c":3,"d":[],"e":{}}]]`
+    root, err = NewSearcher(src).GetByPath()
+    if err != nil {
+        t.Fatal(err)
+    }
+    vv, err := root.Interface()
+    if err != nil {
+        t.Fatal(err)
+    }
+    exp, err = json.Marshal(vv)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := root.SortKeys(true); err != nil {
+        t.Fatal(err)
+    }
+    act, err = root.MarshalJSON()
+    if err != nil {
+        t.Fatal(err)
+    }
+    assert.Equal(t, string(exp), string(act))
 
 }
 
 func BenchmarkNodeSortKeys(b *testing.B) {
-	root, err := NewSearcher(_TwitterJson).GetByPath()
-	if err != nil {
-		b.Fatal(err)
-	}
-	if err := root.LoadAll(); err != nil {
-		b.Fatal(err)
-	}
+    root, err := NewSearcher(_TwitterJson).GetByPath()
+    if err != nil {
+        b.Fatal(err)
+    }
+    if err := root.LoadAll(); err != nil {
+        b.Fatal(err)
+    }
 
-	b.Run("single", func(b *testing.B) {
-		r := root.Get("statuses")
-		if r.Check() != nil {
-			b.Fatal(r.Error())
-		}
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_ = root.SortKeys(false)
-		}
-	})
-	b.Run("recurse", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_ = root.SortKeys(true)
-		}
-	})
+    b.Run("single", func(b *testing.B) {
+        r := root.Get("statuses")
+        if r.Check() != nil {
+            b.Fatal(r.Error())
+        }
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            _ = root.SortKeys(false)
+        }
+    })
+    b.Run("recurse", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            _ = root.SortKeys(true)
+        }
+    })
 }
 
 //go:noinline
 func stackObj() interface{} {
-	var a int = 1
-	return rt.UnpackEface(a).Pack()
+    var a int = 1
+    return rt.UnpackEface(a).Pack()
 }
 
 func TestStackAny(t *testing.T) {
-	var obj = stackObj()
-	any := NewAny(obj)
-	fmt.Printf("any: %#v\n", any)
-	runtime.GC()
-	debug.FreeOSMemory()
-	println("finish GC")
-	buf, err := any.MarshalJSON()
-	println("finish marshal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(buf) != `1` {
-		t.Fatal(string(buf))
-	}
+    var obj = stackObj()
+    any := NewAny(obj)
+    fmt.Printf("any: %#v\n", any)
+    runtime.GC()
+    debug.FreeOSMemory()
+    println("finish GC")
+    buf, err := any.MarshalJSON()
+    println("finish marshal")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if string(buf) != `1` {
+        t.Fatal(string(buf))
+    }
 }
 
 func TestLoadAll(t *testing.T) {
-	e := Node{}
-	err := e.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = e.LoadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
+    e := Node{}
+    err := e.Load()
+    if err != nil {
+        t.Fatal(err)
+    }
+    err = e.LoadAll()
+    if err != nil {
+        t.Fatal(err)
+    }
 
-	root, err := NewSearcher(`{"a":{"1":[1],"2":2},"b":[{"1":1},2],"c":[1,2]}`).GetByPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = root.Load(); err != nil {
-		t.Fatal(err)
-	}
-	if root.len() != 3 {
-		t.Fatal(root.len())
-	}
+    root, err := NewSearcher(`{"a":{"1":[1],"2":2},"b":[{"1":1},2],"c":[1,2]}`).GetByPath()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err = root.Load(); err != nil {
+        t.Fatal(err)
+    }
+    if root.len() != 3 {
+        t.Fatal(root.len())
+    }
 
-	c := root.Get("c")
-	if !c.IsRaw() {
-		t.Fatal(err)
-	}
-	err = c.LoadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c.len() != 2 {
-		t.Fatal(c.len())
-	}
-	c1 := c.nodeAt(0)
-	if n, err := c1.Int64(); err != nil || n != 1 {
-		t.Fatal(n, err)
-	}
+    c := root.Get("c")
+    if !c.IsRaw() {
+        t.Fatal(err)
+    }
+    err = c.LoadAll()
+    if err != nil {
+        t.Fatal(err)
+    }
+    if c.len() != 2 {
+        t.Fatal(c.len())
+    }
+    c1 := c.nodeAt(0)
+    if n, err := c1.Int64(); err != nil || n != 1 {
+        t.Fatal(n, err)
+    }
 
-	a := root.pairAt(0)
-	if a.Key != "a" {
-		t.Fatal(a.Key)
-	} else if !a.Value.IsRaw() {
-		t.Fatal(a.Value.itype())
-	} else if n, err := a.Value.Len(); n != 0 || err != nil {
-		t.Fatal(n, err)
-	}
-	if err := a.Value.Load(); err != nil {
-		t.Fatal(err)
-	}
-	if a.Value.len() != 2 {
-		t.Fatal(a.Value.len())
-	}
-	a1 := a.Value.Get("1")
-	if !a1.IsRaw() {
-		t.Fatal(a1)
-	}
-	a.Value.LoadAll()
-	if a1.t != types.V_ARRAY || a1.len() != 1 {
-		t.Fatal(a1.t, a1.len())
-	}
+    a := root.pairAt(0)
+    if a.Key != "a" {
+        t.Fatal(a.Key)
+    } else if !a.Value.IsRaw() {
+        t.Fatal(a.Value.itype())
+    } else if n, err := a.Value.Len(); n != 0 || err != nil {
+        t.Fatal(n, err)
+    }
+    if err := a.Value.Load(); err != nil {
+        t.Fatal(err)
+    }
+    if a.Value.len() != 2 {
+        t.Fatal(a.Value.len())
+    }
+    a1 := a.Value.Get("1")
+    if !a1.IsRaw() {
+        t.Fatal(a1)
+    }
+    a.Value.LoadAll()
+    if a1.t != types.V_ARRAY || a1.len() != 1 {
+        t.Fatal(a1.t, a1.len())
+    }
 
-	b := root.pairAt(1)
-	if b.Key != "b" {
-		t.Fatal(b.Key)
-	} else if !b.Value.IsRaw() {
-		t.Fatal(b.Value.itype())
-	} else if n, err := b.Value.Len(); n != 0 || err != nil {
-		t.Fatal(n, err)
-	}
-	if err := b.Value.Load(); err != nil {
-		t.Fatal(err)
-	}
-	if b.Value.len() != 2 {
-		t.Fatal(b.Value.len())
-	}
-	b1 := b.Value.Index(0)
-	if !b1.IsRaw() {
-		t.Fatal(b1)
-	}
-	b.Value.LoadAll()
-	if b1.t != types.V_OBJECT || b1.len() != 1 {
-		t.Fatal(a1.t, a1.len())
-	}
+    b := root.pairAt(1)
+    if b.Key != "b" {
+        t.Fatal(b.Key)
+    } else if !b.Value.IsRaw() {
+        t.Fatal(b.Value.itype())
+    } else if n, err := b.Value.Len(); n != 0 || err != nil {
+        t.Fatal(n, err)
+    }
+    if err := b.Value.Load(); err != nil {
+        t.Fatal(err)
+    }
+    if b.Value.len() != 2 {
+        t.Fatal(b.Value.len())
+    }
+    b1 := b.Value.Index(0)
+    if !b1.IsRaw() {
+        t.Fatal(b1)
+    }
+    b.Value.LoadAll()
+    if b1.t != types.V_OBJECT || b1.len() != 1 {
+        t.Fatal(a1.t, a1.len())
+    }
 }
 
 func TestIndexPair(t *testing.T) {
-	root, _ := NewParser(`{"a":1,"b":2}`).Parse()
-	a := root.IndexPair(0)
-	if a == nil || a.Key != "a" {
-		t.Fatal(a)
-	}
-	b := root.IndexPair(1)
-	if b == nil || b.Key != "b" {
-		t.Fatal(b)
-	}
-	c := root.IndexPair(2)
-	if c != nil {
-		t.Fatal(c)
-	}
+    root, _ := NewParser(`{"a":1,"b":2}`).Parse()
+    a := root.IndexPair(0)
+    if a == nil || a.Key != "a" {
+        t.Fatal(a)
+    }
+    b := root.IndexPair(1)
+    if b == nil || b.Key != "b" {
+        t.Fatal(b)
+    }
+    c := root.IndexPair(2)
+    if c != nil {
+        t.Fatal(c)
+    }
 }
 
 func TestIndexOrGet(t *testing.T) {
-	root, _ := NewParser(`{"a":1,"b":2}`).Parse()
-	a := root.IndexOrGet(0, "a")
-	if v, err := a.Int64(); err != nil || v != int64(1) {
-		t.Fatal(a)
-	}
-	a = root.IndexOrGet(0, "b")
-	if v, err := a.Int64(); err != nil || v != int64(2) {
-		t.Fatal(a)
-	}
-	a = root.IndexOrGet(0, "c")
-	if a.Valid() {
-		t.Fatal(a)
-	}
+    root, _ := NewParser(`{"a":1,"b":2}`).Parse()
+    a := root.IndexOrGet(0, "a")
+    if v, err := a.Int64(); err != nil || v != int64(1) {
+        t.Fatal(a)
+    }
+    a = root.IndexOrGet(0, "b")
+    if v, err := a.Int64(); err != nil || v != int64(2) {
+        t.Fatal(a)
+    }
+    a = root.IndexOrGet(0, "c")
+    if a.Valid() {
+        t.Fatal(a)
+    }
 }
 
 func TestTypeCast(t *testing.T) {
-	type tcase struct {
-		method string
-		node   Node
-		exp    interface{}
-		err    error
-	}
-	var nonEmptyErr error = errors.New("")
-	a1 := NewAny(1)
-	lazyArray, _ := NewParser("[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]").Parse()
-	lazyObject, _ := NewParser(`{"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12,"13":13,"14":14,"15":15,"16":16}`).Parse()
-	var cases = []tcase{
-		{"Interface", Node{}, interface{}(nil), ErrUnsupportType},
-		{"Interface", NewAny(NewNumber("1")), float64(1), nil},
-		{"Interface", NewAny(int64(1)), int64(1), nil},
-		{"Interface", NewNumber("1"), float64(1), nil},
-		{"InterfaceUseNode", Node{}, Node{}, nil},
-		{"InterfaceUseNode", a1, a1, nil},
-		{"InterfaceUseNode", NewNumber("1"), NewNumber("1"), nil},
-		{"InterfaceUseNumber", Node{}, interface{}(nil), ErrUnsupportType},
-		{"InterfaceUseNumber", NewAny(1), 1, nil},
-		{"InterfaceUseNumber", NewNumber("1"), json.Number("1"), nil},
-		{"Map", Node{}, map[string]interface{}(nil), ErrUnsupportType},
-		{"Map", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]interface{}(nil), ErrUnsupportType},
-		{"Map", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
-		{"Map", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": float64(1.0)}, nil},
-		{"MapUseNode", Node{}, map[string]Node(nil), ErrUnsupportType},
-		{"MapUseNode", NewAny(map[string]interface{}{"a": 1}), map[string]Node(nil), ErrUnsupportType},
-		{"MapUseNode", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]Node{"a": NewNumber("1")}, nil},
-		{"MapUseNode", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]Node{"a": NewNumber("1")}, nil},
-		{"MapUseNumber", Node{}, map[string]interface{}(nil), ErrUnsupportType},
-		{"MapUseNumber", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
-		{"MapUseNumber", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": json.Number("1")}, nil},
-		{"Array", Node{}, []interface{}(nil), ErrUnsupportType},
-		{"Array", NewAny([]interface{}{1}), []interface{}{1}, nil},
-		{"Array", NewArray([]Node{NewNumber("1")}), []interface{}{float64(1.0)}, nil},
-		{"ArrayUseNode", Node{}, []Node(nil), ErrUnsupportType},
-		{"ArrayUseNode", NewAny([]interface{}{1}), []Node(nil), ErrUnsupportType},
-		{"ArrayUseNode", NewAny([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
-		{"ArrayUseNode", NewArray([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
-		{"ArrayUseNumber", Node{}, []interface{}(nil), ErrUnsupportType},
-		{"ArrayUseNumber", NewAny([]interface{}{1}), []interface{}{1}, nil},
-		{"ArrayUseNumber", NewAny([]Node{NewNumber("1")}), []interface{}(nil), ErrUnsupportType},
-		{"ArrayUseNumber", NewArray([]Node{NewNumber("1")}), []interface{}{json.Number("1")}, nil},
-		{"Raw", Node{}, "", ErrNotExist},
-		{"Raw", NewAny(""), `""`, nil},
-		{"Raw", NewRaw(" "), "", nonEmptyErr},
-		{"Raw", NewRaw(" [ ] "), "[ ]", nil},
-		{"Raw", NewRaw("[ ]"), "[ ]", nil},
-		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] } `), `{ "a" : [ true, -1.2e34 ] }`, nil},
-		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] `), "", nonEmptyErr},
-		{"Raw", NewRaw(` { "a" : [ true, -1.2e34 }`), "", nonEmptyErr},
-		{"Raw", NewBool(true), "true", nil},
-		{"Raw", NewNumber("-0.0"), "-0.0", nil},
-		{"Raw", NewString(""), `""`, nil},
-		{"Raw", NewBytes([]byte("hello, world")), `"aGVsbG8sIHdvcmxk"`, nil},
-		{"Bool", Node{}, false, ErrUnsupportType},
-		{"Bool", NewAny(true), true, nil},
-		{"Bool", NewAny(false), false, nil},
-		{"Bool", NewAny(int(0)), false, nil},
-		{"Bool", NewAny(int8(1)), true, nil},
-		{"Bool", NewAny(int16(1)), true, nil},
-		{"Bool", NewAny(int32(1)), true, nil},
-		{"Bool", NewAny(int64(1)), true, nil},
-		{"Bool", NewAny(uint(1)), true, nil},
-		{"Bool", NewAny(uint16(1)), true, nil},
-		{"Bool", NewAny(uint32(1)), true, nil},
-		{"Bool", NewAny(uint64(1)), true, nil},
-		{"Bool", NewAny(float64(0)), false, nil},
-		{"Bool", NewAny(float32(1)), true, nil},
-		{"Bool", NewAny(float64(1)), true, nil},
-		{"Bool", NewAny(json.Number("0")), false, nil},
-		{"Bool", NewAny(json.Number("1")), true, nil},
-		{"Bool", NewAny(json.Number("1.1")), true, nil},
-		{"Bool", NewAny(json.Number("+x1.1")), false, nonEmptyErr},
-		{"Bool", NewAny(string("0")), false, nil},
-		{"Bool", NewAny(string("t")), true, nil},
-		{"Bool", NewAny([]byte{0}), false, nonEmptyErr},
-		{"Bool", NewRaw("true"), true, nil},
-		{"Bool", NewRaw("false"), false, nil},
-		{"Bool", NewRaw("null"), false, nil},
-		{"Bool", NewString(`true`), true, nil},
-		{"Bool", NewString(`false`), false, nil},
-		{"Bool", NewString(``), false, nonEmptyErr},
-		{"Bool", NewNumber("2"), true, nil},
-		{"Bool", NewNumber("-2.1"), true, nil},
-		{"Bool", NewNumber("-x-2.1"), false, nonEmptyErr},
-		{"Int64", NewRaw("true"), int64(1), nil},
-		{"Int64", NewRaw("false"), int64(0), nil},
-		{"Int64", NewRaw("\"1\""), int64(1), nil},
-		{"Int64", NewRaw("\"1.1\""), int64(1), nil},
-		{"Int64", NewRaw("\"1.0\""), int64(1), nil},
-		{"Int64", NewNumber("+x.0"), int64(0), nonEmptyErr},
-		{"Int64", NewAny(false), int64(0), nil},
-		{"Int64", NewAny(true), int64(1), nil},
-		{"Int64", NewAny(int(1)), int64(1), nil},
-		{"Int64", NewAny(int8(1)), int64(1), nil},
-		{"Int64", NewAny(int16(1)), int64(1), nil},
-		{"Int64", NewAny(int32(1)), int64(1), nil},
-		{"Int64", NewAny(int64(1)), int64(1), nil},
-		{"Int64", NewAny(uint(1)), int64(1), nil},
-		{"Int64", NewAny(uint8(1)), int64(1), nil},
-		{"Int64", NewAny(uint32(1)), int64(1), nil},
-		{"Int64", NewAny(uint64(1)), int64(1), nil},
-		{"Int64", NewAny(float32(1)), int64(1), nil},
-		{"Int64", NewAny(float64(1)), int64(1), nil},
-		{"Int64", NewAny("1"), int64(1), nil},
-		{"Int64", NewAny("1.1"), int64(1), nil},
-		{"Int64", NewAny("+1x.1"), int64(0), nonEmptyErr},
-		{"Int64", NewAny(json.Number("1")), int64(1), nil},
-		{"Int64", NewAny(json.Number("1.1")), int64(1), nil},
-		{"Int64", NewAny(json.Number("+1x.1")), int64(0), nonEmptyErr},
-		{"Int64", NewAny([]byte{0}), int64(0), ErrUnsupportType},
-		{"Int64", Node{}, int64(0), ErrUnsupportType},
-		{"Int64", NewRaw("0"), int64(0), nil},
-		{"Int64", NewRaw("null"), int64(0), nil},
-		{"StrictInt64", NewRaw("true"), int64(0), ErrUnsupportType},
-		{"StrictInt64", NewRaw("false"), int64(0), ErrUnsupportType},
-		{"StrictInt64", NewAny(int(0)), int64(0), nil},
-		{"StrictInt64", NewAny(int8(0)), int64(0), nil},
-		{"StrictInt64", NewAny(int16(0)), int64(0), nil},
-		{"StrictInt64", NewAny(int32(0)), int64(0), nil},
-		{"StrictInt64", NewAny(int64(0)), int64(0), nil},
-		{"StrictInt64", NewAny(uint(0)), int64(0), nil},
-		{"StrictInt64", NewAny(uint8(0)), int64(0), nil},
-		{"StrictInt64", NewAny(uint32(0)), int64(0), nil},
-		{"StrictInt64", NewAny(uint64(0)), int64(0), nil},
-		{"StrictInt64", Node{}, int64(0), ErrUnsupportType},
-		{"StrictInt64", NewRaw("0"), int64(0), nil},
-		{"StrictInt64", NewRaw("null"), int64(0), ErrUnsupportType},
-		{"Float64", NewRaw("true"), float64(1), nil},
-		{"Float64", NewRaw("false"), float64(0), nil},
-		{"Float64", NewRaw("\"1.0\""), float64(1.0), nil},
-		{"Float64", NewRaw("\"xx\""), float64(0), nonEmptyErr},
-		{"Float64", Node{}, float64(0), ErrUnsupportType},
-		{"Float64", NewAny(false), float64(0), nil},
-		{"Float64", NewAny(true), float64(1), nil},
-		{"Float64", NewAny(int(1)), float64(1), nil},
-		{"Float64", NewAny(int8(1)), float64(1), nil},
-		{"Float64", NewAny(int16(1)), float64(1), nil},
-		{"Float64", NewAny(int32(1)), float64(1), nil},
-		{"Float64", NewAny(int64(1)), float64(1), nil},
-		{"Float64", NewAny(uint(1)), float64(1), nil},
-		{"Float64", NewAny(uint8(1)), float64(1), nil},
-		{"Float64", NewAny(uint32(1)), float64(1), nil},
-		{"Float64", NewAny(uint64(1)), float64(1), nil},
-		{"Float64", NewAny(float32(1)), float64(1), nil},
-		{"Float64", NewAny(float64(1)), float64(1), nil},
-		{"Float64", NewAny("1.1"), float64(1.1), nil},
-		{"Float64", NewAny("+1x.1"), float64(0), nonEmptyErr},
-		{"Float64", NewAny(json.Number("0")), float64(0), nil},
-		{"Float64", NewAny(json.Number("x")), float64(0), nonEmptyErr},
-		{"Float64", NewAny([]byte{0}), float64(0), ErrUnsupportType},
-		{"Float64", NewRaw("0.0"), float64(0.0), nil},
-		{"Float64", NewRaw("1"), float64(1.0), nil},
-		{"Float64", NewRaw("null"), float64(0.0), nil},
-		{"StrictFloat64", NewRaw("true"), float64(0), ErrUnsupportType},
-		{"StrictFloat64", NewRaw("false"), float64(0), ErrUnsupportType},
-		{"StrictFloat64", Node{}, float64(0), ErrUnsupportType},
-		{"StrictFloat64", NewAny(float32(0)), float64(0), nil},
-		{"StrictFloat64", NewAny(float64(0)), float64(0), nil},
-		{"StrictFloat64", NewRaw("0.0"), float64(0.0), nil},
-		{"StrictFloat64", NewRaw("null"), float64(0.0), ErrUnsupportType},
-		{"Number", Node{}, json.Number(""), ErrUnsupportType},
-		{"Number", NewAny(false), json.Number("0"), nil},
-		{"Number", NewAny(true), json.Number("1"), nil},
-		{"Number", NewAny(int(1)), json.Number("1"), nil},
-		{"Number", NewAny(int8(1)), json.Number("1"), nil},
-		{"Number", NewAny(int16(1)), json.Number("1"), nil},
-		{"Number", NewAny(int32(1)), json.Number("1"), nil},
-		{"Number", NewAny(int64(1)), json.Number("1"), nil},
-		{"Number", NewAny(uint(1)), json.Number("1"), nil},
-		{"Number", NewAny(uint8(1)), json.Number("1"), nil},
-		{"Number", NewAny(uint32(1)), json.Number("1"), nil},
-		{"Number", NewAny(uint64(1)), json.Number("1"), nil},
-		{"Number", NewAny(float32(1)), json.Number("1"), nil},
-		{"Number", NewAny(float64(1)), json.Number("1"), nil},
-		{"Number", NewAny("1.1"), json.Number("1.1"), nil},
-		{"Number", NewAny("+1x.1"), json.Number(""), nonEmptyErr},
-		{"Number", NewAny(json.Number("0")), json.Number("0"), nil},
-		{"Number", NewAny(json.Number("x")), json.Number("x"), nil},
-		{"Number", NewAny(json.Number("+1x.1")), json.Number("+1x.1"), nil},
-		{"Number", NewAny([]byte{0}), json.Number(""), ErrUnsupportType},
-		{"Number", NewRaw("x"), json.Number(""), nonEmptyErr},
-		{"Number", NewRaw("0.0"), json.Number("0.0"), nil},
-		{"Number", NewRaw("\"1\""), json.Number("1"), nil},
-		{"Number", NewRaw("\"1.1\""), json.Number("1.1"), nil},
-		{"Number", NewRaw("\"0.x0\""), json.Number(""), nonEmptyErr},
-		{"Number", NewRaw("{]"), json.Number(""), nonEmptyErr},
-		{"Number", NewRaw("true"), json.Number("1"), nil},
-		{"Number", NewRaw("false"), json.Number("0"), nil},
-		{"Number", NewRaw("null"), json.Number("0"), nil},
-		{"StrictNumber", NewRaw("true"), json.Number(""), ErrUnsupportType},
-		{"StrictNumber", NewRaw("false"), json.Number(""), ErrUnsupportType},
-		{"StrictNumber", Node{}, json.Number(""), ErrUnsupportType},
-		{"StrictNumber", NewAny(json.Number("0")), json.Number("0"), nil},
-		{"StrictNumber", NewRaw("0.0"), json.Number("0.0"), nil},
-		{"StrictNumber", NewRaw("null"), json.Number(""), ErrUnsupportType},
-		{"String", Node{}, "", ErrUnsupportType},
-		{"String", NewAny(`\u263a`), `\u263a`, nil},
-		{"String", NewRaw(`"\u263a"`), `☺`, nil},
-		{"String", NewString(`\u263a`), `\u263a`, nil},
-		{"String", NewRaw(`0.0`), "0.0", nil},
-		{"String", NewRaw(`true`), "true", nil},
-		{"String", NewRaw(`false`), "false", nil},
-		{"String", NewRaw(`null`), "", nil},
-		{"String", NewAny(false), "false", nil},
-		{"String", NewAny(true), "true", nil},
-		{"String", NewAny(int(1)), "1", nil},
-		{"String", NewAny(int8(1)), "1", nil},
-		{"String", NewAny(int16(1)), "1", nil},
-		{"String", NewAny(int32(1)), "1", nil},
-		{"String", NewAny(int64(1)), "1", nil},
-		{"String", NewAny(uint(1)), "1", nil},
-		{"String", NewAny(uint8(1)), "1", nil},
-		{"String", NewAny(uint32(1)), "1", nil},
-		{"String", NewAny(uint64(1)), "1", nil},
-		{"String", NewAny(float32(1)), "1", nil},
-		{"String", NewAny(float64(1)), "1", nil},
-		{"String", NewAny("1.1"), "1.1", nil},
-		{"String", NewAny("+1x.1"), "+1x.1", nil},
-		{"String", NewAny(json.Number("0")), ("0"), nil},
-		{"String", NewAny(json.Number("x")), ("x"), nil},
-		{"String", NewAny([]byte{0}), (""), ErrUnsupportType},
-		{"StrictString", Node{}, "", ErrUnsupportType},
-		{"StrictString", NewAny(`\u263a`), `\u263a`, nil},
-		{"StrictString", NewRaw(`"\u263a"`), `☺`, nil},
-		{"StrictString", NewString(`\u263a`), `\u263a`, nil},
-		{"StrictString", NewRaw(`0.0`), "", ErrUnsupportType},
-		{"StrictString", NewRaw(`true`), "", ErrUnsupportType},
-		{"StrictString", NewRaw(`false`), "", ErrUnsupportType},
-		{"StrictString", NewRaw(`null`), "", ErrUnsupportType},
-		{"Len", Node{}, 0, nil},
-		{"Len", NewAny(0), 0, ErrUnsupportType},
-		{"Len", NewNull(), 0, nil},
-		{"Len", NewRaw(`"1"`), 1, nil},
-		{"Len", NewRaw(`[1]`), 0, nil},
-		{"Len", NewArray([]Node{NewNull()}), 1, nil},
-		{"Len", lazyArray, 0, nil},
-		{"Len", NewRaw(`{"a":1}`), 0, nil},
-		{"Len", lazyObject, 0, nil},
-		{"Cap", Node{}, 0, nil},
-		{"Cap", NewAny(0), 0, ErrUnsupportType},
-		{"Cap", NewNull(), 0, nil},
-		{"Cap", NewRaw(`[1]`), _DEFAULT_NODE_CAP, nil},
-		{"Cap", NewObject([]Pair{{"", NewNull()}}), _DEFAULT_NODE_CAP, nil},
-		{"Cap", NewRaw(`{"a":1}`), _DEFAULT_NODE_CAP, nil},
-	}
-	lazyArray.skipAllIndex()
-	lazyObject.skipAllKey()
-	cases = append(cases,
-		tcase{"Len", lazyArray, 17, nil},
-		tcase{"Len", lazyObject, 17, nil},
-		tcase{"Cap", lazyArray, _DEFAULT_NODE_CAP * 3, nil},
-		tcase{"Cap", lazyObject, _DEFAULT_NODE_CAP * 3, nil},
-	)
+    type tcase struct {
+        method string
+        node   Node
+        exp    interface{}
+        err    error
+    }
+    var nonEmptyErr error = errors.New("")
+    a1 := NewAny(1)
+    lazyArray, _ := NewParser("[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]").Parse()
+    lazyObject, _ := NewParser(`{"0":0,"1":1,"2":2,"3":3,"4":4,"5":5,"6":6,"7":7,"8":8,"9":9,"10":10,"11":11,"12":12,"13":13,"14":14,"15":15,"16":16}`).Parse()
+    var cases = []tcase{
+        {"Interface", Node{}, interface{}(nil), ErrUnsupportType},
+        {"Interface", NewAny(NewNumber("1")), float64(1), nil},
+        {"Interface", NewAny(int64(1)), int64(1), nil},
+        {"Interface", NewNumber("1"), float64(1), nil},
+        {"InterfaceUseNode", Node{}, Node{}, nil},
+        {"InterfaceUseNode", a1, a1, nil},
+        {"InterfaceUseNode", NewNumber("1"), NewNumber("1"), nil},
+        {"InterfaceUseNumber", Node{}, interface{}(nil), ErrUnsupportType},
+        {"InterfaceUseNumber", NewAny(1), 1, nil},
+        {"InterfaceUseNumber", NewNumber("1"), json.Number("1"), nil},
+        {"Map", Node{}, map[string]interface{}(nil), ErrUnsupportType},
+        {"Map", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]interface{}(nil), ErrUnsupportType},
+        {"Map", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
+        {"Map", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": float64(1.0)}, nil},
+        {"MapUseNode", Node{}, map[string]Node(nil), ErrUnsupportType},
+        {"MapUseNode", NewAny(map[string]interface{}{"a": 1}), map[string]Node(nil), ErrUnsupportType},
+        {"MapUseNode", NewAny(map[string]Node{"a": NewNumber("1")}), map[string]Node{"a": NewNumber("1")}, nil},
+        {"MapUseNode", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]Node{"a": NewNumber("1")}, nil},
+        {"MapUseNumber", Node{}, map[string]interface{}(nil), ErrUnsupportType},
+        {"MapUseNumber", NewAny(map[string]interface{}{"a": 1}), map[string]interface{}{"a": 1}, nil},
+        {"MapUseNumber", NewObject([]Pair{{"a", NewNumber("1")}}), map[string]interface{}{"a": json.Number("1")}, nil},
+        {"Array", Node{}, []interface{}(nil), ErrUnsupportType},
+        {"Array", NewAny([]interface{}{1}), []interface{}{1}, nil},
+        {"Array", NewArray([]Node{NewNumber("1")}), []interface{}{float64(1.0)}, nil},
+        {"ArrayUseNode", Node{}, []Node(nil), ErrUnsupportType},
+        {"ArrayUseNode", NewAny([]interface{}{1}), []Node(nil), ErrUnsupportType},
+        {"ArrayUseNode", NewAny([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
+        {"ArrayUseNode", NewArray([]Node{NewNumber("1")}), []Node{NewNumber("1")}, nil},
+        {"ArrayUseNumber", Node{}, []interface{}(nil), ErrUnsupportType},
+        {"ArrayUseNumber", NewAny([]interface{}{1}), []interface{}{1}, nil},
+        {"ArrayUseNumber", NewAny([]Node{NewNumber("1")}), []interface{}(nil), ErrUnsupportType},
+        {"ArrayUseNumber", NewArray([]Node{NewNumber("1")}), []interface{}{json.Number("1")}, nil},
+        {"Raw", Node{}, "", ErrNotExist},
+        {"Raw", NewAny(""), `""`, nil},
+        {"Raw", NewRaw(" "), "", nonEmptyErr},
+        {"Raw", NewRaw(" [ ] "), "[ ]", nil},
+        {"Raw", NewRaw("[ ]"), "[ ]", nil},
+        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] } `), `{ "a" : [ true, -1.2e34 ] }`, nil},
+        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 ] `), "", nonEmptyErr},
+        {"Raw", NewRaw(` { "a" : [ true, -1.2e34 }`), "", nonEmptyErr},
+        {"Raw", NewBool(true), "true", nil},
+        {"Raw", NewNumber("-0.0"), "-0.0", nil},
+        {"Raw", NewString(""), `""`, nil},
+        {"Raw", NewBytes([]byte("hello, world")), `"aGVsbG8sIHdvcmxk"`, nil},
+        {"Bool", Node{}, false, ErrUnsupportType},
+        {"Bool", NewAny(true), true, nil},
+        {"Bool", NewAny(false), false, nil},
+        {"Bool", NewAny(int(0)), false, nil},
+        {"Bool", NewAny(int8(1)), true, nil},
+        {"Bool", NewAny(int16(1)), true, nil},
+        {"Bool", NewAny(int32(1)), true, nil},
+        {"Bool", NewAny(int64(1)), true, nil},
+        {"Bool", NewAny(uint(1)), true, nil},
+        {"Bool", NewAny(uint16(1)), true, nil},
+        {"Bool", NewAny(uint32(1)), true, nil},
+        {"Bool", NewAny(uint64(1)), true, nil},
+        {"Bool", NewAny(float64(0)), false, nil},
+        {"Bool", NewAny(float32(1)), true, nil},
+        {"Bool", NewAny(float64(1)), true, nil},
+        {"Bool", NewAny(json.Number("0")), false, nil},
+        {"Bool", NewAny(json.Number("1")), true, nil},
+        {"Bool", NewAny(json.Number("1.1")), true, nil},
+        {"Bool", NewAny(json.Number("+x1.1")), false, nonEmptyErr},
+        {"Bool", NewAny(string("0")), false, nil},
+        {"Bool", NewAny(string("t")), true, nil},
+        {"Bool", NewAny([]byte{0}), false, nonEmptyErr},
+        {"Bool", NewRaw("true"), true, nil},
+        {"Bool", NewRaw("false"), false, nil},
+        {"Bool", NewRaw("null"), false, nil},
+        {"Bool", NewString(`true`), true, nil},
+        {"Bool", NewString(`false`), false, nil},
+        {"Bool", NewString(``), false, nonEmptyErr},
+        {"Bool", NewNumber("2"), true, nil},
+        {"Bool", NewNumber("-2.1"), true, nil},
+        {"Bool", NewNumber("-x-2.1"), false, nonEmptyErr},
+        {"Int64", NewRaw("true"), int64(1), nil},
+        {"Int64", NewRaw("false"), int64(0), nil},
+        {"Int64", NewRaw("\"1\""), int64(1), nil},
+        {"Int64", NewRaw("\"1.1\""), int64(1), nil},
+        {"Int64", NewRaw("\"1.0\""), int64(1), nil},
+        {"Int64", NewNumber("+x.0"), int64(0), nonEmptyErr},
+        {"Int64", NewAny(false), int64(0), nil},
+        {"Int64", NewAny(true), int64(1), nil},
+        {"Int64", NewAny(int(1)), int64(1), nil},
+        {"Int64", NewAny(int8(1)), int64(1), nil},
+        {"Int64", NewAny(int16(1)), int64(1), nil},
+        {"Int64", NewAny(int32(1)), int64(1), nil},
+        {"Int64", NewAny(int64(1)), int64(1), nil},
+        {"Int64", NewAny(uint(1)), int64(1), nil},
+        {"Int64", NewAny(uint8(1)), int64(1), nil},
+        {"Int64", NewAny(uint32(1)), int64(1), nil},
+        {"Int64", NewAny(uint64(1)), int64(1), nil},
+        {"Int64", NewAny(float32(1)), int64(1), nil},
+        {"Int64", NewAny(float64(1)), int64(1), nil},
+        {"Int64", NewAny("1"), int64(1), nil},
+        {"Int64", NewAny("1.1"), int64(1), nil},
+        {"Int64", NewAny("+1x.1"), int64(0), nonEmptyErr},
+        {"Int64", NewAny(json.Number("1")), int64(1), nil},
+        {"Int64", NewAny(json.Number("1.1")), int64(1), nil},
+        {"Int64", NewAny(json.Number("+1x.1")), int64(0), nonEmptyErr},
+        {"Int64", NewAny([]byte{0}), int64(0), ErrUnsupportType},
+        {"Int64", Node{}, int64(0), ErrUnsupportType},
+        {"Int64", NewRaw("0"), int64(0), nil},
+        {"Int64", NewRaw("null"), int64(0), nil},
+        {"StrictInt64", NewRaw("true"), int64(0), ErrUnsupportType},
+        {"StrictInt64", NewRaw("false"), int64(0), ErrUnsupportType},
+        {"StrictInt64", NewAny(int(0)), int64(0), nil},
+        {"StrictInt64", NewAny(int8(0)), int64(0), nil},
+        {"StrictInt64", NewAny(int16(0)), int64(0), nil},
+        {"StrictInt64", NewAny(int32(0)), int64(0), nil},
+        {"StrictInt64", NewAny(int64(0)), int64(0), nil},
+        {"StrictInt64", NewAny(uint(0)), int64(0), nil},
+        {"StrictInt64", NewAny(uint8(0)), int64(0), nil},
+        {"StrictInt64", NewAny(uint32(0)), int64(0), nil},
+        {"StrictInt64", NewAny(uint64(0)), int64(0), nil},
+        {"StrictInt64", Node{}, int64(0), ErrUnsupportType},
+        {"StrictInt64", NewRaw("0"), int64(0), nil},
+        {"StrictInt64", NewRaw("null"), int64(0), ErrUnsupportType},
+        {"Float64", NewRaw("true"), float64(1), nil},
+        {"Float64", NewRaw("false"), float64(0), nil},
+        {"Float64", NewRaw("\"1.0\""), float64(1.0), nil},
+        {"Float64", NewRaw("\"xx\""), float64(0), nonEmptyErr},
+        {"Float64", Node{}, float64(0), ErrUnsupportType},
+        {"Float64", NewAny(false), float64(0), nil},
+        {"Float64", NewAny(true), float64(1), nil},
+        {"Float64", NewAny(int(1)), float64(1), nil},
+        {"Float64", NewAny(int8(1)), float64(1), nil},
+        {"Float64", NewAny(int16(1)), float64(1), nil},
+        {"Float64", NewAny(int32(1)), float64(1), nil},
+        {"Float64", NewAny(int64(1)), float64(1), nil},
+        {"Float64", NewAny(uint(1)), float64(1), nil},
+        {"Float64", NewAny(uint8(1)), float64(1), nil},
+        {"Float64", NewAny(uint32(1)), float64(1), nil},
+        {"Float64", NewAny(uint64(1)), float64(1), nil},
+        {"Float64", NewAny(float32(1)), float64(1), nil},
+        {"Float64", NewAny(float64(1)), float64(1), nil},
+        {"Float64", NewAny("1.1"), float64(1.1), nil},
+        {"Float64", NewAny("+1x.1"), float64(0), nonEmptyErr},
+        {"Float64", NewAny(json.Number("0")), float64(0), nil},
+        {"Float64", NewAny(json.Number("x")), float64(0), nonEmptyErr},
+        {"Float64", NewAny([]byte{0}), float64(0), ErrUnsupportType},
+        {"Float64", NewRaw("0.0"), float64(0.0), nil},
+        {"Float64", NewRaw("1"), float64(1.0), nil},
+        {"Float64", NewRaw("null"), float64(0.0), nil},
+        {"StrictFloat64", NewRaw("true"), float64(0), ErrUnsupportType},
+        {"StrictFloat64", NewRaw("false"), float64(0), ErrUnsupportType},
+        {"StrictFloat64", Node{}, float64(0), ErrUnsupportType},
+        {"StrictFloat64", NewAny(float32(0)), float64(0), nil},
+        {"StrictFloat64", NewAny(float64(0)), float64(0), nil},
+        {"StrictFloat64", NewRaw("0.0"), float64(0.0), nil},
+        {"StrictFloat64", NewRaw("null"), float64(0.0), ErrUnsupportType},
+        {"Number", Node{}, json.Number(""), ErrUnsupportType},
+        {"Number", NewAny(false), json.Number("0"), nil},
+        {"Number", NewAny(true), json.Number("1"), nil},
+        {"Number", NewAny(int(1)), json.Number("1"), nil},
+        {"Number", NewAny(int8(1)), json.Number("1"), nil},
+        {"Number", NewAny(int16(1)), json.Number("1"), nil},
+        {"Number", NewAny(int32(1)), json.Number("1"), nil},
+        {"Number", NewAny(int64(1)), json.Number("1"), nil},
+        {"Number", NewAny(uint(1)), json.Number("1"), nil},
+        {"Number", NewAny(uint8(1)), json.Number("1"), nil},
+        {"Number", NewAny(uint32(1)), json.Number("1"), nil},
+        {"Number", NewAny(uint64(1)), json.Number("1"), nil},
+        {"Number", NewAny(float32(1)), json.Number("1"), nil},
+        {"Number", NewAny(float64(1)), json.Number("1"), nil},
+        {"Number", NewAny("1.1"), json.Number("1.1"), nil},
+        {"Number", NewAny("+1x.1"), json.Number(""), nonEmptyErr},
+        {"Number", NewAny(json.Number("0")), json.Number("0"), nil},
+        {"Number", NewAny(json.Number("x")), json.Number("x"), nil},
+        {"Number", NewAny(json.Number("+1x.1")), json.Number("+1x.1"), nil},
+        {"Number", NewAny([]byte{0}), json.Number(""), ErrUnsupportType},
+        {"Number", NewRaw("x"), json.Number(""), nonEmptyErr},
+        {"Number", NewRaw("0.0"), json.Number("0.0"), nil},
+        {"Number", NewRaw("\"1\""), json.Number("1"), nil},
+        {"Number", NewRaw("\"1.1\""), json.Number("1.1"), nil},
+        {"Number", NewRaw("\"0.x0\""), json.Number(""), nonEmptyErr},
+        {"Number", NewRaw("{]"), json.Number(""), nonEmptyErr},
+        {"Number", NewRaw("true"), json.Number("1"), nil},
+        {"Number", NewRaw("false"), json.Number("0"), nil},
+        {"Number", NewRaw("null"), json.Number("0"), nil},
+        {"StrictNumber", NewRaw("true"), json.Number(""), ErrUnsupportType},
+        {"StrictNumber", NewRaw("false"), json.Number(""), ErrUnsupportType},
+        {"StrictNumber", Node{}, json.Number(""), ErrUnsupportType},
+        {"StrictNumber", NewAny(json.Number("0")), json.Number("0"), nil},
+        {"StrictNumber", NewRaw("0.0"), json.Number("0.0"), nil},
+        {"StrictNumber", NewRaw("null"), json.Number(""), ErrUnsupportType},
+        {"String", Node{}, "", ErrUnsupportType},
+        {"String", NewAny(`\u263a`), `\u263a`, nil},
+        {"String", NewRaw(`"\u263a"`), `☺`, nil},
+        {"String", NewString(`\u263a`), `\u263a`, nil},
+        {"String", NewRaw(`0.0`), "0.0", nil},
+        {"String", NewRaw(`true`), "true", nil},
+        {"String", NewRaw(`false`), "false", nil},
+        {"String", NewRaw(`null`), "", nil},
+        {"String", NewAny(false), "false", nil},
+        {"String", NewAny(true), "true", nil},
+        {"String", NewAny(int(1)), "1", nil},
+        {"String", NewAny(int8(1)), "1", nil},
+        {"String", NewAny(int16(1)), "1", nil},
+        {"String", NewAny(int32(1)), "1", nil},
+        {"String", NewAny(int64(1)), "1", nil},
+        {"String", NewAny(uint(1)), "1", nil},
+        {"String", NewAny(uint8(1)), "1", nil},
+        {"String", NewAny(uint32(1)), "1", nil},
+        {"String", NewAny(uint64(1)), "1", nil},
+        {"String", NewAny(float32(1)), "1", nil},
+        {"String", NewAny(float64(1)), "1", nil},
+        {"String", NewAny("1.1"), "1.1", nil},
+        {"String", NewAny("+1x.1"), "+1x.1", nil},
+        {"String", NewAny(json.Number("0")), ("0"), nil},
+        {"String", NewAny(json.Number("x")), ("x"), nil},
+        {"String", NewAny([]byte{0}), (""), ErrUnsupportType},
+        {"StrictString", Node{}, "", ErrUnsupportType},
+        {"StrictString", NewAny(`\u263a`), `\u263a`, nil},
+        {"StrictString", NewRaw(`"\u263a"`), `☺`, nil},
+        {"StrictString", NewString(`\u263a`), `\u263a`, nil},
+        {"StrictString", NewRaw(`0.0`), "", ErrUnsupportType},
+        {"StrictString", NewRaw(`true`), "", ErrUnsupportType},
+        {"StrictString", NewRaw(`false`), "", ErrUnsupportType},
+        {"StrictString", NewRaw(`null`), "", ErrUnsupportType},
+        {"Len", Node{}, 0, nil},
+        {"Len", NewAny(0), 0, ErrUnsupportType},
+        {"Len", NewNull(), 0, nil},
+        {"Len", NewRaw(`"1"`), 1, nil},
+        {"Len", NewRaw(`[1]`), 0, nil},
+        {"Len", NewArray([]Node{NewNull()}), 1, nil},
+        {"Len", lazyArray, 0, nil},
+        {"Len", NewRaw(`{"a":1}`), 0, nil},
+        {"Len", lazyObject, 0, nil},
+        {"Cap", Node{}, 0, nil},
+        {"Cap", NewAny(0), 0, ErrUnsupportType},
+        {"Cap", NewNull(), 0, nil},
+        {"Cap", NewRaw(`[1]`), _DEFAULT_NODE_CAP, nil},
+        {"Cap", NewObject([]Pair{{"", NewNull()}}), _DEFAULT_NODE_CAP, nil},
+        {"Cap", NewRaw(`{"a":1}`), _DEFAULT_NODE_CAP, nil},
+    }
+    lazyArray.skipAllIndex()
+    lazyObject.skipAllKey()
+    cases = append(cases,
+        tcase{"Len", lazyArray, 17, nil},
+        tcase{"Len", lazyObject, 17, nil},
+        tcase{"Cap", lazyArray, _DEFAULT_NODE_CAP * 3, nil},
+        tcase{"Cap", lazyObject, _DEFAULT_NODE_CAP * 3, nil},
+    )
 
-	for i, c := range cases {
-		fmt.Println(i, c)
-		rt := reflect.ValueOf(&c.node)
-		m := rt.MethodByName(c.method)
-		rets := m.Call([]reflect.Value{})
-		if len(rets) != 2 {
-			t.Error(i, rets)
-		}
-		if !reflect.DeepEqual(rets[0].Interface(), c.exp) {
-			t.Error(i, rets[0].Interface(), c.exp)
-		}
-		v := rets[1].Interface()
-		if c.err == nonEmptyErr {
-			if reflect.ValueOf(v).IsNil() {
-				t.Error(i, v)
-			}
-		} else if v != c.err {
-			t.Error(i, v)
-		}
-	}
+    for i, c := range cases {
+        fmt.Println(i, c)
+        rt := reflect.ValueOf(&c.node)
+        m := rt.MethodByName(c.method)
+        rets := m.Call([]reflect.Value{})
+        if len(rets) != 2 {
+            t.Error(i, rets)
+        }
+        if !reflect.DeepEqual(rets[0].Interface(), c.exp) {
+            t.Error(i, rets[0].Interface(), c.exp)
+        }
+        v := rets[1].Interface()
+        if c.err == nonEmptyErr {
+            if reflect.ValueOf(v).IsNil() {
+                t.Error(i, v)
+            }
+        } else if v != c.err {
+            t.Error(i, v)
+        }
+    }
 }
 
 func TestCheckError_Nil(t *testing.T) {
-	nill := (*Node)(nil)
-	if nill.Valid() || nill.Check() == nil {
-		t.Fail()
-	}
-	if nill.Get("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.GetByPath("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.Index(1).Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexOrGet(1, "a").Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexPair(1) != nil {
-		t.Fatal()
-	}
-	if _, err := nill.Set("", Node{}); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetByIndex(1, Node{}); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetAny("", 1); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.Unset(""); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.UnsetByIndex(1); err == nil {
-		t.Fatal()
-	}
-	if err := nill.Add(Node{}); err == nil {
-		t.Fatal()
-	}
-	if err := nill.AddAny(1); err == nil {
-		t.Fatal()
-	}
+    nill := (*Node)(nil)
+    if nill.Valid() || nill.Check() == nil {
+        t.Fail()
+    }
+    if nill.Get("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.GetByPath("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.Index(1).Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexOrGet(1, "a").Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexPair(1) != nil {
+        t.Fatal()
+    }
+    if _, err := nill.Set("", Node{}); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetByIndex(1, Node{}); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetAny("", 1); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.Unset(""); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.UnsetByIndex(1); err == nil {
+        t.Fatal()
+    }
+    if err := nill.Add(Node{}); err == nil {
+        t.Fatal()
+    }
+    if err := nill.AddAny(1); err == nil {
+        t.Fatal()
+    }
 }
 
 func TestCheckError_None(t *testing.T) {
-	nill := Node{}
-	if !nill.Valid() || nill.Check() != nil {
-		t.Fail()
-	}
-	if nill.Get("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.GetByPath("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.Index(1).Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexOrGet(1, "a").Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexPair(1) != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.Set("a", Node{}); err != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.SetByIndex(0, Node{}); err != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.SetByIndex(1, Node{}); err == nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.SetAny("a", 1); err != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.SetAnyByIndex(0, 1); err != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.Unset(""); err == nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if _, err := nill.UnsetByIndex(1); err == nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if err := nill.Add(Node{}); err != nil {
-		t.Fatal()
-	}
-	nill = Node{}
-	if err := nill.AddAny(1); err != nil {
-		t.Fatal()
-	}
+    nill := Node{}
+    if !nill.Valid() || nill.Check() != nil {
+        t.Fail()
+    }
+    if nill.Get("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.GetByPath("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.Index(1).Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexOrGet(1, "a").Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexPair(1) != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.Set("a", Node{}); err != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.SetByIndex(0, Node{}); err != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.SetByIndex(1, Node{}); err == nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.SetAny("a", 1); err != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.SetAnyByIndex(0, 1); err != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.Unset(""); err == nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if _, err := nill.UnsetByIndex(1); err == nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if err := nill.Add(Node{}); err != nil {
+        t.Fatal()
+    }
+    nill = Node{}
+    if err := nill.AddAny(1); err != nil {
+        t.Fatal()
+    }
 }
 
 func TestCheckError_Error(t *testing.T) {
-	nill := newError(types.ERR_EOF, "")
-	if nill.Valid() || nill.Check() == nil {
-		t.Fail()
-	}
-	if nill.Get("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.GetByPath("").Check() == nil {
-		t.Fatal()
-	}
-	if nill.Index(1).Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexOrGet(1, "a").Check() == nil {
-		t.Fatal()
-	}
-	if nill.IndexPair(1) != nil {
-		t.Fatal()
-	}
-	if _, err := nill.Set("", Node{}); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetByIndex(1, Node{}); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetAny("", 1); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.SetAnyByIndex(1, 1); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.Unset(""); err == nil {
-		t.Fatal()
-	}
-	if _, err := nill.UnsetByIndex(1); err == nil {
-		t.Fatal()
-	}
-	if err := nill.Add(Node{}); err == nil {
-		t.Fatal()
-	}
-	if err := nill.AddAny(1); err == nil {
-		t.Fatal()
-	}
+    nill := newError(types.ERR_EOF, "")
+    if nill.Valid() || nill.Check() == nil {
+        t.Fail()
+    }
+    if nill.Get("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.GetByPath("").Check() == nil {
+        t.Fatal()
+    }
+    if nill.Index(1).Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexOrGet(1, "a").Check() == nil {
+        t.Fatal()
+    }
+    if nill.IndexPair(1) != nil {
+        t.Fatal()
+    }
+    if _, err := nill.Set("", Node{}); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetByIndex(1, Node{}); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetAny("", 1); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.SetAnyByIndex(1, 1); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.Unset(""); err == nil {
+        t.Fatal()
+    }
+    if _, err := nill.UnsetByIndex(1); err == nil {
+        t.Fatal()
+    }
+    if err := nill.Add(Node{}); err == nil {
+        t.Fatal()
+    }
+    if err := nill.AddAny(1); err == nil {
+        t.Fatal()
+    }
 }
 
 func TestCheckError_Empty(t *testing.T) {
-	empty := Node{}
-	if !empty.Valid() || empty.Check() != nil || empty.Error() != "" {
-		t.Fatal()
-	}
+    empty := Node{}
+    if !empty.Valid() || empty.Check() != nil || empty.Error() != "" {
+        t.Fatal()
+    }
 
-	n := newRawNode("[hello]", types.V_ARRAY)
-	n.parseRaw(false)
-	if n.Check() != nil {
-		t.Fatal(n.Check())
-	}
-	n = newRawNode("[hello]", types.V_ARRAY)
-	n.parseRaw(true)
-	p := NewParser("[hello]")
-	p.noLazy = true
-	p.skipValue = false
-	_, x := p.Parse()
-	if n.Error() != newSyntaxError(p.syntaxError(x)).Error() {
-		t.Fatal(n.Check())
-	}
+    n := newRawNode("[hello]", types.V_ARRAY)
+    n.parseRaw(false)
+    if n.Check() != nil {
+        t.Fatal(n.Check())
+    }
+    n = newRawNode("[hello]", types.V_ARRAY)
+    n.parseRaw(true)
+    p := NewParser("[hello]")
+    p.noLazy = true
+    p.skipValue = false
+    _, x := p.Parse()
+    if n.Error() != newSyntaxError(p.syntaxError(x)).Error() {
+        t.Fatal(n.Check())
+    }
 
-	s, err := NewParser(`{"a":{}, "b":talse, "c":{}}`).Parse()
-	if err != 0 {
-		t.Fatal(err)
-	}
+    s, err := NewParser(`{"a":{}, "b":talse, "c":{}}`).Parse()
+    if err != 0 {
+        t.Fatal(err)
+    }
 
-	root := s.GetByPath()
-	// fmt.Println(root.Check())
-	a := root.Get("a")
-	if a.Check() != nil {
-		t.Fatal(a.Check())
-	}
-	c := root.Get("c")
-	if c.Check() == nil {
-		t.Fatal()
-	}
-	fmt.Println(c.Check())
+    root := s.GetByPath()
+    // fmt.Println(root.Check())
+    a := root.Get("a")
+    if a.Check() != nil {
+        t.Fatal(a.Check())
+    }
+    c := root.Get("c")
+    if c.Check() == nil {
+        t.Fatal()
+    }
+    fmt.Println(c.Check())
 
-	_, e := a.Properties()
-	if e != nil {
-		t.Fatal(e)
-	}
-	exist, e := a.Set("d", newRawNode("x", types.V_OBJECT))
-	if exist || e != nil {
-		t.Fatal(err)
-	}
-	if a.len() != 1 {
-		t.Fail()
-	}
-	d := a.Get("d").Get("")
-	if d.Check() == nil {
-		t.Fatal(d)
-	}
-	exist, e = a.Set("e", newRawNode("[}", types.V_ARRAY))
-	if e != nil {
-		t.Fatal(e)
-	}
-	if a.len() != 2 {
-		t.Fail()
-	}
-	d = a.Index(1).Index(0)
-	if d.Check() == nil {
-		t.Fatal(d)
-	}
+    _, e := a.Properties()
+    if e != nil {
+        t.Fatal(e)
+    }
+    exist, e := a.Set("d", newRawNode("x", types.V_OBJECT))
+    if exist || e != nil {
+        t.Fatal(err)
+    }
+    if a.len() != 1 {
+        t.Fail()
+    }
+    d := a.Get("d").Get("")
+    if d.Check() == nil {
+        t.Fatal(d)
+    }
+    exist, e = a.Set("e", newRawNode("[}", types.V_ARRAY))
+    if e != nil {
+        t.Fatal(e)
+    }
+    if a.len() != 2 {
+        t.Fail()
+    }
+    d = a.Index(1).Index(0)
+    if d.Check() == nil {
+        t.Fatal(d)
+    }
 
-	it, e := root.Interface()
-	if e == nil {
-		t.Fatal(it)
-	}
-	fmt.Println(e)
+    it, e := root.Interface()
+    if e == nil {
+        t.Fatal(it)
+    }
+    fmt.Println(e)
 }
 
 func TestIndex(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	status := root.GetByPath("statuses", 0)
-	x, _ := status.Index(4).String()
-	y, _ := status.Get("id_str").String()
-	if x != y {
-		t.Fail()
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    status := root.GetByPath("statuses", 0)
+    x, _ := status.Index(4).String()
+    y, _ := status.Get("id_str").String()
+    if x != y {
+        t.Fail()
+    }
 }
 
 func TestUnset(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	entities := root.GetByPath("statuses", 0, "entities")
-	if !entities.Exists() || entities.Check() != nil {
-		t.Fatal(entities.Check().Error())
-	}
-	exist, err := entities.Unset("urls")
-	if !exist || err != nil {
-		t.Fatal()
-	}
-	e := entities.Get("urls")
-	if e.Exists() {
-		t.Fatal()
-	}
-	if entities.len() != 2 {
-		t.Fatal(entities.len())
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    entities := root.GetByPath("statuses", 0, "entities")
+    if !entities.Exists() || entities.Check() != nil {
+        t.Fatal(entities.Check().Error())
+    }
+    exist, err := entities.Unset("urls")
+    if !exist || err != nil {
+        t.Fatal()
+    }
+    e := entities.Get("urls")
+    if e.Exists() {
+        t.Fatal()
+    }
+    if entities.len() != 2 {
+        t.Fatal(entities.len())
+    }
 
-	es, err := entities.Interface()
-	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
-		"hashtags": []interface{}{
-			map[string]interface{}{
-				"text": "freebandnames",
-				"indices": []interface{}{
-					float64(20), float64(34),
-				},
-			},
-		},
-		"user_mentions": []interface{}{},
-	}, es)
+    es, err := entities.Interface()
+    require.NoError(t, err)
+    require.Equal(t, map[string]interface{}{
+        "hashtags": []interface{}{
+            map[string]interface{}{
+                "text": "freebandnames",
+                "indices": []interface{}{
+                    float64(20), float64(34),
+                },
+            },
+        },
+        "user_mentions": []interface{}{},
+    }, es)
 
-	out, err := entities.MarshalJSON()
-	require.NoError(t, err)
-	println(string(out))
-	buf := bytes.NewBuffer(nil)
-	require.NoError(t, json.Compact(buf, out))
-	require.Equal(t,
-		`{"hashtags":[{"text":"freebandnames","indices":[20,34]}],"user_mentions":[]}`, buf.String())
+    out, err := entities.MarshalJSON()
+    require.NoError(t, err)
+    println(string(out))
+    buf := bytes.NewBuffer(nil)
+    require.NoError(t, json.Compact(buf, out))
+    require.Equal(t,
+        `{"hashtags":[{"text":"freebandnames","indices":[20,34]}],"user_mentions":[]}`, buf.String())
 
-	entities.Set("urls", NewString("a"))
-	e = entities.Get("urls")
-	x, _ := e.String()
-	if !e.Exists() || x != "a" {
-		t.Fatal()
-	}
+    entities.Set("urls", NewString("a"))
+    e = entities.Get("urls")
+    x, _ := e.String()
+    if !e.Exists() || x != "a" {
+        t.Fatal()
+    }
 
-	out, err = entities.MarshalJSON()
-	require.NoError(t, err)
-	buf = bytes.NewBuffer(nil)
-	json.Compact(buf, out)
-	require.Equal(t,
-		`{"hashtags":[{"text":"freebandnames","indices":[20,34]}],"user_mentions":[],"urls":"a"}`, buf.String())
+    out, err = entities.MarshalJSON()
+    require.NoError(t, err)
+    buf = bytes.NewBuffer(nil)
+    json.Compact(buf, out)
+    require.Equal(t,
+        `{"hashtags":[{"text":"freebandnames","indices":[20,34]}],"user_mentions":[],"urls":"a"}`, buf.String())
 
-	// reload entities
-	*entities = NewRaw(string(out))
+    // reload entities
+    *entities = NewRaw(string(out))
 
-	hashtags := entities.Get("hashtags").Index(0)
-	hashtags.Set("text2", newRawNode(`{}`, types.V_OBJECT))
-	exist, err = hashtags.Unset("indices") // NOTICE: Unset() won't change node.Len() here
-	if !exist || err != nil || hashtags.len() != 2 {
-		t.Fatal(hashtags.len())
-	}
-	y, _ := hashtags.Get("text").String()
-	if y != "freebandnames" {
-		t.Fatal()
-	}
-	if hashtags.Get("text2").Type() != V_OBJECT {
-		t.Fatal()
-	}
+    hashtags := entities.Get("hashtags").Index(0)
+    hashtags.Set("text2", newRawNode(`{}`, types.V_OBJECT))
+    exist, err = hashtags.Unset("indices") // NOTICE: Unset() won't change node.Len() here
+    if !exist || err != nil || hashtags.len() != 2 {
+        t.Fatal(hashtags.len())
+    }
+    y, _ := hashtags.Get("text").String()
+    if y != "freebandnames" {
+        t.Fatal()
+    }
+    if hashtags.Get("text2").Type() != V_OBJECT {
+        t.Fatal()
+    }
 
-	entities.Load()
-	exist, err = entities.UnsetByIndex(entities.len() - 1)
-	if !exist || err != nil {
-		t.Fatal()
-	}
-	if entities.len() != 2 {
-		t.Fatal(entities.len())
-	}
-	e = entities.Index(entities.len())
-	if e.Exists() {
-		t.Fatal()
-	}
+    entities.Load()
+    exist, err = entities.UnsetByIndex(entities.len() - 1)
+    if !exist || err != nil {
+        t.Fatal()
+    }
+    if entities.len() != 2 {
+        t.Fatal(entities.len())
+    }
+    e = entities.Index(entities.len())
+    if e.Exists() {
+        t.Fatal()
+    }
 
-	ums := entities.Get("user_mentions")
-	ums.Add(NewNull())
-	ums.Add(NewBool(false))
-	ums.Add(NewBool(true))
-	if ums.len() != 3 {
-		t.Fatal()
-	}
-	exist, err = ums.UnsetByIndex(1)
-	if !exist || err != nil {
-		t.Fatal()
-	}
-	require.Equal(t, 2, ums.len())
-	umses, err := ums.Interface()
-	require.NoError(t, err)
-	require.Equal(t, []interface{}{interface{}(nil), true}, umses)
+    ums := entities.Get("user_mentions")
+    ums.Add(NewNull())
+    ums.Add(NewBool(false))
+    ums.Add(NewBool(true))
+    if ums.len() != 3 {
+        t.Fatal()
+    }
+    exist, err = ums.UnsetByIndex(1)
+    if !exist || err != nil {
+        t.Fatal()
+    }
+    require.Equal(t, 2, ums.len())
+    umses, err := ums.Interface()
+    require.NoError(t, err)
+    require.Equal(t, []interface{}{interface{}(nil), true}, umses)
 
-	v1, _ := ums.Index(0).Interface()
-	v2, _ := ums.Index(1).Interface() // NOTICE: unseted index 1 still can be find here
-	v3, _ := ums.Index(2).Interface()
-	if v1 != nil {
-		t.Fatal()
-	}
-	if v2 != true {
-		t.Fatal()
-	}
-	if v3 != nil {
-		t.Fatal()
-	}
-	out, err = entities.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t,
-		`{"hashtags":[{"text":"freebandnames","text2":{}}],"user_mentions":[null,true]}`, string(out))
+    v1, _ := ums.Index(0).Interface()
+    v2, _ := ums.Index(1).Interface() // NOTICE: unseted index 1 still can be find here
+    v3, _ := ums.Index(2).Interface()
+    if v1 != nil {
+        t.Fatal()
+    }
+    if v2 != true {
+        t.Fatal()
+    }
+    if v3 != nil {
+        t.Fatal()
+    }
+    out, err = entities.MarshalJSON()
+    require.NoError(t, err)
+    require.Equal(t,
+        `{"hashtags":[{"text":"freebandnames","text2":{}}],"user_mentions":[null,true]}`, string(out))
 
 }
 
@@ -930,176 +930,176 @@ func TestUnset(t *testing.T) {
 // }
 
 func TestUseNode(t *testing.T) {
-	str, loop := getTestIteratorSample(_DEFAULT_NODE_CAP)
-	root, e := NewParser(str).Parse()
-	if e != 0 {
-		t.Fatal(e)
-	}
-	_, er := root.InterfaceUseNode()
-	if er != nil {
-		t.Fatal(er)
-	}
+    str, loop := getTestIteratorSample(_DEFAULT_NODE_CAP)
+    root, e := NewParser(str).Parse()
+    if e != 0 {
+        t.Fatal(e)
+    }
+    _, er := root.InterfaceUseNode()
+    if er != nil {
+        t.Fatal(er)
+    }
 
-	root, err := NewSearcher(str).GetByPath("array")
-	if err != nil {
-		t.Fatal(err)
-	}
-	a, _ := root.ArrayUseNode()
-	if len(a) != loop {
-		t.Fatalf("exp:%v, got:%v", loop, len(a))
-	}
-	for i := int64(0); i < int64(loop); i++ {
-		in := a[i]
-		a, _ := in.Int64()
-		if a != i {
-			t.Fatalf("exp:%v, got:%v", i, a)
-		}
-	}
+    root, err := NewSearcher(str).GetByPath("array")
+    if err != nil {
+        t.Fatal(err)
+    }
+    a, _ := root.ArrayUseNode()
+    if len(a) != loop {
+        t.Fatalf("exp:%v, got:%v", loop, len(a))
+    }
+    for i := int64(0); i < int64(loop); i++ {
+        in := a[i]
+        a, _ := in.Int64()
+        if a != i {
+            t.Fatalf("exp:%v, got:%v", i, a)
+        }
+    }
 
-	root, err = NewSearcher(str).GetByPath("array")
-	if err != nil {
-		t.Fatal(err)
-	}
-	x, _ := root.InterfaceUseNode()
-	a = x.([]Node)
-	if len(a) != loop {
-		t.Fatalf("exp:%v, got:%v", loop, len(a))
-	}
-	for i := int64(0); i < int64(loop); i++ {
-		in := a[i]
-		a, _ := in.Int64()
-		if a != i {
-			t.Fatalf("exp:%v, got:%v", i, a)
-		}
-	}
+    root, err = NewSearcher(str).GetByPath("array")
+    if err != nil {
+        t.Fatal(err)
+    }
+    x, _ := root.InterfaceUseNode()
+    a = x.([]Node)
+    if len(a) != loop {
+        t.Fatalf("exp:%v, got:%v", loop, len(a))
+    }
+    for i := int64(0); i < int64(loop); i++ {
+        in := a[i]
+        a, _ := in.Int64()
+        if a != i {
+            t.Fatalf("exp:%v, got:%v", i, a)
+        }
+    }
 
-	root, err = NewSearcher(str).GetByPath("object")
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, _ := root.MapUseNode()
-	if len(b) != loop {
-		t.Fatalf("exp:%v, got:%v", loop, len(b))
-	}
-	for i := int64(0); i < int64(loop); i++ {
-		k := `k` + strconv.Itoa(int(i))
-		xn, ok := b[k]
-		if !ok {
-			t.Fatalf("unexpected element: %#v", xn)
-		}
-		a, _ := xn.Int64()
-		if a != i {
-			t.Fatalf("exp:%v, got:%v", i, a)
-		}
-	}
+    root, err = NewSearcher(str).GetByPath("object")
+    if err != nil {
+        t.Fatal(err)
+    }
+    b, _ := root.MapUseNode()
+    if len(b) != loop {
+        t.Fatalf("exp:%v, got:%v", loop, len(b))
+    }
+    for i := int64(0); i < int64(loop); i++ {
+        k := `k` + strconv.Itoa(int(i))
+        xn, ok := b[k]
+        if !ok {
+            t.Fatalf("unexpected element: %#v", xn)
+        }
+        a, _ := xn.Int64()
+        if a != i {
+            t.Fatalf("exp:%v, got:%v", i, a)
+        }
+    }
 
-	root, err = NewSearcher(str).GetByPath("object")
-	if err != nil {
-		t.Fatal(err)
-	}
-	x, _ = root.InterfaceUseNode()
-	b = x.(map[string]Node)
-	if len(b) != loop {
-		t.Fatalf("exp:%v, got:%v", loop, len(b))
-	}
-	for i := int64(0); i < int64(loop); i++ {
-		k := `k` + strconv.Itoa(int(i))
-		xn, ok := b[k]
-		if !ok {
-			t.Fatalf("unexpected element: %#v", xn)
-		}
-		a, _ := xn.Int64()
-		if a != i {
-			t.Fatalf("exp:%v, got:%v", i, a)
-		}
-	}
+    root, err = NewSearcher(str).GetByPath("object")
+    if err != nil {
+        t.Fatal(err)
+    }
+    x, _ = root.InterfaceUseNode()
+    b = x.(map[string]Node)
+    if len(b) != loop {
+        t.Fatalf("exp:%v, got:%v", loop, len(b))
+    }
+    for i := int64(0); i < int64(loop); i++ {
+        k := `k` + strconv.Itoa(int(i))
+        xn, ok := b[k]
+        if !ok {
+            t.Fatalf("unexpected element: %#v", xn)
+        }
+        a, _ := xn.Int64()
+        if a != i {
+            t.Fatalf("exp:%v, got:%v", i, a)
+        }
+    }
 }
 
 func TestUseNumber(t *testing.T) {
-	str, _ := getTestIteratorSample(_DEFAULT_NODE_CAP)
-	root, e := NewParser(str).Parse()
-	if e != 0 {
-		t.Fatal(e)
-	}
-	_, er := root.InterfaceUseNumber()
-	if er != nil {
-		t.Fatal(er)
-	}
+    str, _ := getTestIteratorSample(_DEFAULT_NODE_CAP)
+    root, e := NewParser(str).Parse()
+    if e != 0 {
+        t.Fatal(e)
+    }
+    _, er := root.InterfaceUseNumber()
+    if er != nil {
+        t.Fatal(er)
+    }
 
-	node, err := NewParser("1061346755812312312313").Parse()
-	if err != 0 {
-		t.Fatal(err)
-	}
-	if node.Type() != V_NUMBER {
-		t.Fatalf("wrong type: %v", node.Type())
-	}
-	x, _ := node.InterfaceUseNumber()
-	iv := x.(json.Number)
-	if iv.String() != "1061346755812312312313" {
-		t.Fatalf("exp:%#v, got:%#v", "1061346755812312312313", iv.String())
-	}
-	x, _ = node.Interface()
-	ix := x.(float64)
-	if ix != float64(1061346755812312312313) {
-		t.Fatalf("exp:%#v, got:%#v", float64(1061346755812312312313), ix)
-	}
-	xj, _ := node.Number()
-	ij, _ := xj.Int64()
-	jj, _ := json.Number("1061346755812312312313").Int64()
-	if ij != jj {
-		t.Fatalf("exp:%#v, got:%#v", jj, ij)
-	}
+    node, err := NewParser("1061346755812312312313").Parse()
+    if err != 0 {
+        t.Fatal(err)
+    }
+    if node.Type() != V_NUMBER {
+        t.Fatalf("wrong type: %v", node.Type())
+    }
+    x, _ := node.InterfaceUseNumber()
+    iv := x.(json.Number)
+    if iv.String() != "1061346755812312312313" {
+        t.Fatalf("exp:%#v, got:%#v", "1061346755812312312313", iv.String())
+    }
+    x, _ = node.Interface()
+    ix := x.(float64)
+    if ix != float64(1061346755812312312313) {
+        t.Fatalf("exp:%#v, got:%#v", float64(1061346755812312312313), ix)
+    }
+    xj, _ := node.Number()
+    ij, _ := xj.Int64()
+    jj, _ := json.Number("1061346755812312312313").Int64()
+    if ij != jj {
+        t.Fatalf("exp:%#v, got:%#v", jj, ij)
+    }
 }
 
 func TestMap(t *testing.T) {
-	node, err := NewParser(`{"a":-0, "b":1, "c":-1.2, "d":-1.2e-10}`).Parse()
-	if err != 0 {
-		t.Fatal(err)
-	}
-	m, _ := node.Map()
-	assert.Equal(t, m, map[string]interface{}{
-		"a": float64(0),
-		"b": float64(1),
-		"c": -1.2,
-		"d": -1.2e-10,
-	})
-	m1, _ := node.MapUseNumber()
-	assert.Equal(t, m1, map[string]interface{}{
-		"a": json.Number("-0"),
-		"b": json.Number("1"),
-		"c": json.Number("-1.2"),
-		"d": json.Number("-1.2e-10"),
-	})
+    node, err := NewParser(`{"a":-0, "b":1, "c":-1.2, "d":-1.2e-10}`).Parse()
+    if err != 0 {
+        t.Fatal(err)
+    }
+    m, _ := node.Map()
+    assert.Equal(t, m, map[string]interface{}{
+        "a": float64(0),
+        "b": float64(1),
+        "c": -1.2,
+        "d": -1.2e-10,
+    })
+    m1, _ := node.MapUseNumber()
+    assert.Equal(t, m1, map[string]interface{}{
+        "a": json.Number("-0"),
+        "b": json.Number("1"),
+        "c": json.Number("-1.2"),
+        "d": json.Number("-1.2e-10"),
+    })
 }
 
 func TestArray(t *testing.T) {
-	node, err := NewParser(`[-0, 1, -1.2, -1.2e-10]`).Parse()
-	if err != 0 {
-		t.Fatal(err)
-	}
-	m, _ := node.Array()
-	assert.Equal(t, m, []interface{}{
-		float64(0),
-		float64(1),
-		-1.2,
-		-1.2e-10,
-	})
-	m1, _ := node.ArrayUseNumber()
-	assert.Equal(t, m1, []interface{}{
-		json.Number("-0"),
-		json.Number("1"),
-		json.Number("-1.2"),
-		json.Number("-1.2e-10"),
-	})
+    node, err := NewParser(`[-0, 1, -1.2, -1.2e-10]`).Parse()
+    if err != 0 {
+        t.Fatal(err)
+    }
+    m, _ := node.Array()
+    assert.Equal(t, m, []interface{}{
+        float64(0),
+        float64(1),
+        -1.2,
+        -1.2e-10,
+    })
+    m1, _ := node.ArrayUseNumber()
+    assert.Equal(t, m1, []interface{}{
+        json.Number("-0"),
+        json.Number("1"),
+        json.Number("-1.2"),
+        json.Number("-1.2e-10"),
+    })
 }
 
 func TestNodeRaw(t *testing.T) {
-	root, derr := NewSearcher(_TwitterJson).GetByPath("search_metadata")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ := root.Raw()
-	var comp = `{
+    root, derr := NewSearcher(_TwitterJson).GetByPath("search_metadata")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ := root.Raw()
+    var comp = `{
     "max_id": 250126199840518145,
     "since_id": 24012619984051000,
     "refresh_url": "?since_id=250126199840518145&q=%23freebandnames&result_type=mixed&include_entities=1",
@@ -1110,16 +1110,16 @@ func TestNodeRaw(t *testing.T) {
     "query": "%23freebandnames",
     "max_id_str": "250126199840518145"
   }`
-	if val != comp {
-		t.Fatalf("exp: %+v, got: %+v", comp, val)
-	}
+    if val != comp {
+        t.Fatalf("exp: %+v, got: %+v", comp, val)
+    }
 
-	root, derr = NewSearcher(_TwitterJson).GetByPath("statuses", 0, "entities", "hashtags")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ = root.Raw()
-	comp = `[
+    root, derr = NewSearcher(_TwitterJson).GetByPath("statuses", 0, "entities", "hashtags")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ = root.Raw()
+    comp = `[
           {
             "text": "freebandnames",
             "indices": [
@@ -1128,832 +1128,832 @@ func TestNodeRaw(t *testing.T) {
             ]
           }
         ]`
-	if val != comp {
-		t.Fatalf("exp: \n%s\n, got: \n%s\n", comp, val)
-	}
+    if val != comp {
+        t.Fatalf("exp: \n%s\n, got: \n%s\n", comp, val)
+    }
 
-	var data = `{"k1" :   { "a" : "bc"} , "k2" : [1,2 ] , "k3":{} , "k4":[]}`
-	root, derr = NewSearcher(data).GetByPath("k1")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ = root.Raw()
-	comp = `{ "a" : "bc"}`
-	if val != comp {
-		t.Fatalf("exp: %+v, got: %+v", comp, val)
-	}
+    var data = `{"k1" :   { "a" : "bc"} , "k2" : [1,2 ] , "k3":{} , "k4":[]}`
+    root, derr = NewSearcher(data).GetByPath("k1")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ = root.Raw()
+    comp = `{ "a" : "bc"}`
+    if val != comp {
+        t.Fatalf("exp: %+v, got: %+v", comp, val)
+    }
 
-	root, derr = NewSearcher(data).GetByPath("k2")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ = root.Raw()
-	comp = `[1,2 ]`
-	if val != comp {
-		t.Fatalf("exp: %+v, got: %+v", comp, val)
-	}
+    root, derr = NewSearcher(data).GetByPath("k2")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ = root.Raw()
+    comp = `[1,2 ]`
+    if val != comp {
+        t.Fatalf("exp: %+v, got: %+v", comp, val)
+    }
 
-	root, derr = NewSearcher(data).GetByPath("k3")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ = root.Raw()
-	comp = `{}`
-	if val != comp {
-		t.Fatalf("exp: %+v, got: %+v", comp, val)
-	}
+    root, derr = NewSearcher(data).GetByPath("k3")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ = root.Raw()
+    comp = `{}`
+    if val != comp {
+        t.Fatalf("exp: %+v, got: %+v", comp, val)
+    }
 
-	root, derr = NewSearcher(data).GetByPath("k4")
-	if derr != nil {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ = root.Raw()
-	comp = `[]`
-	if val != comp {
-		t.Fatalf("exp: %+v, got: %+v", comp, val)
-	}
+    root, derr = NewSearcher(data).GetByPath("k4")
+    if derr != nil {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ = root.Raw()
+    comp = `[]`
+    if val != comp {
+        t.Fatalf("exp: %+v, got: %+v", comp, val)
+    }
 }
 
 func TestNodeGet(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ := root.Get("search_metadata").Get("max_id").Int64()
-	if val != int64(250126199840518145) {
-		t.Fatalf("exp: %+v, got: %+v", 250126199840518145, val)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ := root.Get("search_metadata").Get("max_id").Int64()
+    if val != int64(250126199840518145) {
+        t.Fatalf("exp: %+v, got: %+v", 250126199840518145, val)
+    }
 }
 
 func TestNodeIndex(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ := root.Get("statuses").Index(3).Get("id_str").String()
-	if val != "249279667666817024" {
-		t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ := root.Get("statuses").Index(3).Get("id_str").String()
+    if val != "249279667666817024" {
+        t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
+    }
 }
 
 func TestNodeGetByPath(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	val, _ := root.GetByPath("statuses", 3, "id_str").String()
-	if val != "249279667666817024" {
-		t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    val, _ := root.GetByPath("statuses", 3, "id_str").String()
+    if val != "249279667666817024" {
+        t.Fatalf("exp: %+v, got: %+v", "249279667666817024", val)
+    }
 }
 
 func TestNodeSet(t *testing.T) {
-	arr := NewRaw(`[]`)
-	ex, ee := arr.Set("a", NewNumber("-1"))
-	if ex || ee == nil {
-		t.Fatal()
-	}
-	empty := Node{}
-	err := empty.Add(Node{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	empty2 := empty.Index(0)
-	if empty2.Check() != nil {
-		t.Fatal(err)
-	}
-	exist, err := empty2.SetByIndex(1, Node{})
-	if exist || err == nil {
-		t.Fatal(exist, err)
-	}
-	empty3 := empty.Index(0)
-	if empty3.Check() != nil {
-		t.Fatal(err)
-	}
-	exist, err = empty3.Set("a", NewNumber("-1"))
-	if exist || err != nil {
-		t.Fatal(exist, err)
-	}
-	if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
-		t.Fatal(n, e)
-	}
+    arr := NewRaw(`[]`)
+    ex, ee := arr.Set("a", NewNumber("-1"))
+    if ex || ee == nil {
+        t.Fatal()
+    }
+    empty := Node{}
+    err := empty.Add(Node{})
+    if err != nil {
+        t.Fatal(err)
+    }
+    empty2 := empty.Index(0)
+    if empty2.Check() != nil {
+        t.Fatal(err)
+    }
+    exist, err := empty2.SetByIndex(1, Node{})
+    if exist || err == nil {
+        t.Fatal(exist, err)
+    }
+    empty3 := empty.Index(0)
+    if empty3.Check() != nil {
+        t.Fatal(err)
+    }
+    exist, err = empty3.Set("a", NewNumber("-1"))
+    if exist || err != nil {
+        t.Fatal(exist, err)
+    }
+    if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
+        t.Fatal(n, e)
+    }
 
-	empty = NewNull()
-	err = empty.Add(NewNull())
-	if err != nil {
-		t.Fatal(err)
-	}
-	empty2 = empty.Index(0)
-	if empty2.Check() != nil {
-		t.Fatal(err)
-	}
-	exist, err = empty2.SetByIndex(1, NewNull())
-	if exist || err == nil {
-		t.Fatal(exist, err)
-	}
-	empty3 = empty.Index(0)
-	if empty3.Check() != nil {
-		t.Fatal(err)
-	}
-	exist, err = empty3.Set("a", NewNumber("-1"))
-	if exist || err != nil {
-		t.Fatal(exist, err)
-	}
-	if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
-		t.Fatal(n, e)
-	}
+    empty = NewNull()
+    err = empty.Add(NewNull())
+    if err != nil {
+        t.Fatal(err)
+    }
+    empty2 = empty.Index(0)
+    if empty2.Check() != nil {
+        t.Fatal(err)
+    }
+    exist, err = empty2.SetByIndex(1, NewNull())
+    if exist || err == nil {
+        t.Fatal(exist, err)
+    }
+    empty3 = empty.Index(0)
+    if empty3.Check() != nil {
+        t.Fatal(err)
+    }
+    exist, err = empty3.Set("a", NewNumber("-1"))
+    if exist || err != nil {
+        t.Fatal(exist, err)
+    }
+    if n, e := empty.Index(0).Get("a").Int64(); e != nil || n != -1 {
+        t.Fatal(n, e)
+    }
 
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	app, _ := NewParser("111").Parse()
-	root.GetByPath("statuses", 3).Set("id_str", app)
-	val, _ := root.GetByPath("statuses", 3, "id_str").Int64()
-	if val != 111 {
-		t.Fatalf("exp: %+v, got: %+v", 111, val)
-	}
-	for i, _ := root.GetByPath("statuses", 3).Cap(); i >= 0; i-- {
-		root.GetByPath("statuses", 3).Set("id_str"+strconv.Itoa(i), app)
-	}
-	val, _ = root.GetByPath("statuses", 3, "id_str0").Int64()
-	if val != 111 {
-		t.Fatalf("exp: %+v, got: %+v", 111, val)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    app, _ := NewParser("111").Parse()
+    root.GetByPath("statuses", 3).Set("id_str", app)
+    val, _ := root.GetByPath("statuses", 3, "id_str").Int64()
+    if val != 111 {
+        t.Fatalf("exp: %+v, got: %+v", 111, val)
+    }
+    for i, _ := root.GetByPath("statuses", 3).Cap(); i >= 0; i-- {
+        root.GetByPath("statuses", 3).Set("id_str"+strconv.Itoa(i), app)
+    }
+    val, _ = root.GetByPath("statuses", 3, "id_str0").Int64()
+    if val != 111 {
+        t.Fatalf("exp: %+v, got: %+v", 111, val)
+    }
 
-	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	root.GetByPath("statuses", 3).Set("id_str2", nroot)
-	val2, _ := root.GetByPath("statuses", 3, "id_str2", "a", 4, "b").String()
-	if val2 != "c" {
-		t.Fatalf("exp:%+v, got:%+v", "c", val2)
-	}
+    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    root.GetByPath("statuses", 3).Set("id_str2", nroot)
+    val2, _ := root.GetByPath("statuses", 3, "id_str2", "a", 4, "b").String()
+    if val2 != "c" {
+        t.Fatalf("exp:%+v, got:%+v", "c", val2)
+    }
 }
 
 func TestNodeAny(t *testing.T) {
-	empty := Node{}
-	_, err := empty.SetAny("any", map[string]interface{}{"a": []int{0}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if m, err := empty.Get("any").Interface(); err != nil {
-		t.Fatal(err)
-	} else if v, ok := m.(map[string]interface{}); !ok {
-		t.Fatal(v)
-	}
-	if buf, err := empty.MarshalJSON(); err != nil {
-		t.Fatal(err)
-	} else if string(buf) != `{"any":{"a":[0]}}` {
-		t.Fatal(string(buf))
-	}
-	if _, err := empty.Set("any2", Node{}); err != nil {
-		t.Fatal(err)
-	}
-	if err := empty.Get("any2").AddAny(nil); err != nil {
-		t.Fatal(err)
-	}
-	if buf, err := empty.MarshalJSON(); err != nil {
-		t.Fatal(err)
-	} else if string(buf) != `{"any":{"a":[0]},"any2":[null]}` {
-		t.Fatal(string(buf))
-	}
-	if _, err := empty.Get("any2").SetAnyByIndex(0, NewNumber("-0.0")); err != nil {
-		t.Fatal(err)
-	}
-	if buf, err := empty.MarshalJSON(); err != nil {
-		t.Fatal(err)
-	} else if string(buf) != `{"any":{"a":[0]},"any2":[-0.0]}` {
-		t.Fatal(string(buf))
-	}
+    empty := Node{}
+    _, err := empty.SetAny("any", map[string]interface{}{"a": []int{0}})
+    if err != nil {
+        t.Fatal(err)
+    }
+    if m, err := empty.Get("any").Interface(); err != nil {
+        t.Fatal(err)
+    } else if v, ok := m.(map[string]interface{}); !ok {
+        t.Fatal(v)
+    }
+    if buf, err := empty.MarshalJSON(); err != nil {
+        t.Fatal(err)
+    } else if string(buf) != `{"any":{"a":[0]}}` {
+        t.Fatal(string(buf))
+    }
+    if _, err := empty.Set("any2", Node{}); err != nil {
+        t.Fatal(err)
+    }
+    if err := empty.Get("any2").AddAny(nil); err != nil {
+        t.Fatal(err)
+    }
+    if buf, err := empty.MarshalJSON(); err != nil {
+        t.Fatal(err)
+    } else if string(buf) != `{"any":{"a":[0]},"any2":[null]}` {
+        t.Fatal(string(buf))
+    }
+    if _, err := empty.Get("any2").SetAnyByIndex(0, NewNumber("-0.0")); err != nil {
+        t.Fatal(err)
+    }
+    if buf, err := empty.MarshalJSON(); err != nil {
+        t.Fatal(err)
+    } else if string(buf) != `{"any":{"a":[0]},"any2":[-0.0]}` {
+        t.Fatal(string(buf))
+    }
 }
 
 func TestNodeSetByIndex(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	app, _ := NewParser("111").Parse()
-	st := root.GetByPath("statuses")
-	st.SetByIndex(0, app)
-	st = root.GetByPath("statuses")
-	val := st.Index(0)
-	x, _ := val.Int64()
-	if x != 111 {
-		t.Fatalf("exp: %+v, got: %+v", 111, val)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    app, _ := NewParser("111").Parse()
+    st := root.GetByPath("statuses")
+    st.SetByIndex(0, app)
+    st = root.GetByPath("statuses")
+    val := st.Index(0)
+    x, _ := val.Int64()
+    if x != 111 {
+        t.Fatalf("exp: %+v, got: %+v", 111, val)
+    }
 
-	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	root.GetByPath("statuses").SetByIndex(0, nroot)
-	val2, _ := root.GetByPath("statuses", 0, "a", 4, "b").String()
-	if val2 != "c" {
-		t.Fatalf("exp:%+v, got:%+v", "c", val2)
-	}
+    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    root.GetByPath("statuses").SetByIndex(0, nroot)
+    val2, _ := root.GetByPath("statuses", 0, "a", 4, "b").String()
+    if val2 != "c" {
+        t.Fatalf("exp:%+v, got:%+v", "c", val2)
+    }
 }
 
 func TestNodeAdd(t *testing.T) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	app, _ := NewParser("111").Parse()
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    app, _ := NewParser("111").Parse()
 
-	for i, _ := root.GetByPath("statuses").Cap(); i >= 0; i-- {
-		root.GetByPath("statuses").Add(app)
-	}
-	val, _ := root.GetByPath("statuses", 4).Int64()
-	if val != 111 {
-		t.Fatalf("exp: %+v, got: %+v", 111, val)
-	}
-	val, _ = root.GetByPath("statuses", root.GetByPath("statuses").len()-1).Int64()
-	if val != 111 {
-		t.Fatalf("exp: %+v, got: %+v", 111, val)
-	}
+    for i, _ := root.GetByPath("statuses").Cap(); i >= 0; i-- {
+        root.GetByPath("statuses").Add(app)
+    }
+    val, _ := root.GetByPath("statuses", 4).Int64()
+    if val != 111 {
+        t.Fatalf("exp: %+v, got: %+v", 111, val)
+    }
+    val, _ = root.GetByPath("statuses", root.GetByPath("statuses").len()-1).Int64()
+    if val != 111 {
+        t.Fatalf("exp: %+v, got: %+v", 111, val)
+    }
 
-	nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
-	if derr != 0 {
-		t.Fatalf("decode failed: %v", derr.Error())
-	}
-	root.GetByPath("statuses").Add(nroot)
-	val2, _ := root.GetByPath("statuses", root.GetByPath("statuses").len()-1, "a", 4, "b").String()
-	if val2 != "c" {
-		t.Fatalf("exp:%+v, got:%+v", "c", val2)
-	}
+    nroot, derr := NewParser(`{"a":[0.1,true,0,"name",{"b":"c"}]}`).Parse()
+    if derr != 0 {
+        t.Fatalf("decode failed: %v", derr.Error())
+    }
+    root.GetByPath("statuses").Add(nroot)
+    val2, _ := root.GetByPath("statuses", root.GetByPath("statuses").len()-1, "a", 4, "b").String()
+    if val2 != "c" {
+        t.Fatalf("exp:%+v, got:%+v", "c", val2)
+    }
 }
 
 func BenchmarkLoadNode(b *testing.B) {
-	b.Run("Interface()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			_, _ = root.Interface()
-		}
-	})
+    b.Run("Interface()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _, _ = root.Interface()
+        }
+    })
 
-	b.Run("LoadAll()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			_ = root.LoadAll()
-		}
-	})
+    b.Run("LoadAll()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _ = root.LoadAll()
+        }
+    })
 
-	b.Run("InterfaceUseNode()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			_, _ = root.InterfaceUseNode()
-		}
-	})
+    b.Run("InterfaceUseNode()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _, _ = root.InterfaceUseNode()
+        }
+    })
 
-	b.Run("Load()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-			if err != nil {
-				b.Fatal(err)
-			}
-			_ = root.Load()
-		}
-	})
+    b.Run("Load()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+            root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+            if err != nil {
+                b.Fatal(err)
+            }
+            _ = root.Load()
+        }
+    })
 }
 
 func BenchmarkLoadNode_Parallel(b *testing.B) {
-	b.Run("Interface()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-				_, _ = root.Interface()
-			}
-		})
-	})
+    b.Run("Interface()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        b.RunParallel(func(pb *testing.PB) {
+            for pb.Next() {
+                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+                if err != nil {
+                    b.Fatal(err)
+                }
+                _, _ = root.Interface()
+            }
+        })
+    })
 
-	b.Run("LoadAll()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-				_ = root.LoadAll()
-			}
-		})
-	})
+    b.Run("LoadAll()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        b.RunParallel(func(pb *testing.PB) {
+            for pb.Next() {
+                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+                if err != nil {
+                    b.Fatal(err)
+                }
+                _ = root.LoadAll()
+            }
+        })
+    })
 
-	b.Run("InterfaceUseNode()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-				_, _ = root.InterfaceUseNode()
-			}
-		})
-	})
+    b.Run("InterfaceUseNode()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        b.RunParallel(func(pb *testing.PB) {
+            for pb.Next() {
+                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+                if err != nil {
+                    b.Fatal(err)
+                }
+                _, _ = root.InterfaceUseNode()
+            }
+        })
+    })
 
-	b.Run("Load()", func(b *testing.B) {
-		b.SetBytes(int64(len(_TwitterJson)))
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-				_ = root.Load()
-			}
-		})
-	})
+    b.Run("Load()", func(b *testing.B) {
+        b.SetBytes(int64(len(_TwitterJson)))
+        b.ResetTimer()
+        b.RunParallel(func(pb *testing.PB) {
+            for pb.Next() {
+                root, err := NewSearcher(_TwitterJson).GetByPath("statuses", 0)
+                if err != nil {
+                    b.Fatal(err)
+                }
+                _ = root.Load()
+            }
+        })
+    })
 }
 
 func BenchmarkNodeGetByPath(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	_, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
-	b.ResetTimer()
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    _, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
+    b.ResetTimer()
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
-		}
-	})
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            _, _ = root.GetByPath("statuses", 3, "entities", "hashtags", 0, "text").String()
+        }
+    })
 }
 
 func BenchmarkStructGetByPath(b *testing.B) {
-	var root = _TwitterStruct{}
-	err := json.Unmarshal([]byte(_TwitterJson), &root)
-	if err != nil {
-		b.Fatalf("unmarshal failed: %v", err)
-	}
+    var root = _TwitterStruct{}
+    err := json.Unmarshal([]byte(_TwitterJson), &root)
+    if err != nil {
+        b.Fatalf("unmarshal failed: %v", err)
+    }
 
-	b.ResetTimer()
+    b.ResetTimer()
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_ = root.Statuses[3].Entities.Hashtags[0].Text
-		}
-	})
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            _ = root.Statuses[3].Entities.Hashtags[0].Text
+        }
+    })
 }
 
 func BenchmarkNodeIndex(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node.Index(2)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node.Index(2)
+    }
 }
 
 func BenchmarkStructIndex(b *testing.B) {
-	type T struct {
-		A Node
-		B Node
-		C Node
-		D Node
-		E Node
-	}
-	var obj = new(T)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = obj.C
-	}
+    type T struct {
+        A Node
+        B Node
+        C Node
+        D Node
+        E Node
+    }
+    var obj = new(T)
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _ = obj.C
+    }
 }
 
 func BenchmarkSliceIndex(b *testing.B) {
-	var obj = []Node{Node{}, Node{}, Node{}, Node{}, Node{}}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = obj[2]
-	}
+    var obj = []Node{Node{}, Node{}, Node{}, Node{}, Node{}}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _ = obj[2]
+    }
 }
 
 func BenchmarkMapIndex(b *testing.B) {
-	var obj = map[string]interface{}{"test1": Node{}, "test2": Node{}, "test3": Node{}, "test4": Node{}, "test5": Node{}}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for k := range obj {
-			if k == "test3" {
-				break
-			}
-		}
-	}
+    var obj = map[string]interface{}{"test1": Node{}, "test2": Node{}, "test3": Node{}, "test4": Node{}, "test5": Node{}}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        for k := range obj {
+            if k == "test3" {
+                break
+            }
+        }
+    }
 }
 
 func BenchmarkNodeGet(b *testing.B) {
-	var N = 5
-	var half = "test" + strconv.Itoa(N/2+1)
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	for i := 0; i < N; i++ {
-		node.Set("test"+strconv.Itoa(i), NewNumber(strconv.Itoa(i)))
-	}
+    var N = 5
+    var half = "test" + strconv.Itoa(N/2+1)
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    for i := 0; i < N; i++ {
+        node.Set("test"+strconv.Itoa(i), NewNumber(strconv.Itoa(i)))
+    }
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = node.Get(half)
-	}
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _ = node.Get(half)
+    }
 }
 
 func BenchmarkSliceGet(b *testing.B) {
-	var obj = []string{"test1", "test2", "test3", "test4", "test5"}
-	str := "test3"
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for _, k := range obj {
-			if k == str {
-				break
-			}
-		}
-	}
+    var obj = []string{"test1", "test2", "test3", "test4", "test5"}
+    str := "test3"
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        for _, k := range obj {
+            if k == str {
+                break
+            }
+        }
+    }
 }
 
 func BenchmarkMapGet(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	m, _ := node.Map()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = m["test3"]
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    m, _ := node.Map()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        _ = m["test3"]
+    }
 }
 
 func BenchmarkNodeSet(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	n := NewNull()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node.Set("test3", n)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    n := NewNull()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node.Set("test3", n)
+    }
 }
 
 func BenchmarkMapSet(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	m, _ := node.Map()
-	n := NewNull()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		m["test3"] = n
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    m, _ := node.Map()
+    n := NewNull()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        m["test3"] = n
+    }
 }
 
 func BenchmarkNodeSetByIndex(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-	node.Add(NewNumber("1"))
-	node.Add(NewNumber("2"))
-	node.Add(NewNumber("3"))
-	node.Add(NewNumber("4"))
-	node.Add(NewNumber("5"))
-	n := NewNull()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node.SetByIndex(2, n)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+    node.Add(NewNumber("1"))
+    node.Add(NewNumber("2"))
+    node.Add(NewNumber("3"))
+    node.Add(NewNumber("4"))
+    node.Add(NewNumber("5"))
+    n := NewNull()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node.SetByIndex(2, n)
+    }
 }
 
 func BenchmarkSliceSetByIndex(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-	node.Add(NewNumber("1"))
-	node.Add(NewNumber("2"))
-	node.Add(NewNumber("3"))
-	node.Add(NewNumber("4"))
-	node.Add(NewNumber("5"))
-	m, _ := node.Array()
-	n := NewNull()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		m[2] = n
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+    node.Add(NewNumber("1"))
+    node.Add(NewNumber("2"))
+    node.Add(NewNumber("3"))
+    node.Add(NewNumber("4"))
+    node.Add(NewNumber("5"))
+    m, _ := node.Array()
+    n := NewNull()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        m[2] = n
+    }
 }
 
 func BenchmarkStructSetByIndex(b *testing.B) {
-	type T struct {
-		A Node
-		B Node
-		C Node
-		D Node
-		E Node
-	}
-	var obj = new(T)
-	n := NewNull()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		obj.C = n
-	}
+    type T struct {
+        A Node
+        B Node
+        C Node
+        D Node
+        E Node
+    }
+    var obj = new(T)
+    n := NewNull()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        obj.C = n
+    }
 }
 
 func BenchmarkNodeUnset(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node.Unset("test3")
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node.Unset("test3")
+    }
 }
 
 func BenchmarkMapUnset(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
-	node.Set("test1", NewNumber("1"))
-	node.Set("test2", NewNumber("2"))
-	node.Set("test3", NewNumber("3"))
-	node.Set("test4", NewNumber("4"))
-	node.Set("test5", NewNumber("5"))
-	m, _ := node.Map()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		delete(m, "test3")
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags").Index(0)
+    node.Set("test1", NewNumber("1"))
+    node.Set("test2", NewNumber("2"))
+    node.Set("test3", NewNumber("3"))
+    node.Set("test4", NewNumber("4"))
+    node.Set("test5", NewNumber("5"))
+    m, _ := node.Map()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        delete(m, "test3")
+    }
 }
 
 func BenchmarkNodUnsetByIndex(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-	node.Add(NewNumber("1"))
-	node.Add(NewNumber("2"))
-	node.Add(NewNumber("3"))
-	node.Add(NewNumber("4"))
-	node.Add(NewNumber("5"))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node.UnsetByIndex(2)
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+    node.Add(NewNumber("1"))
+    node.Add(NewNumber("2"))
+    node.Add(NewNumber("3"))
+    node.Add(NewNumber("4"))
+    node.Add(NewNumber("5"))
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node.UnsetByIndex(2)
+    }
 }
 
 func BenchmarkSliceUnsetByIndex(b *testing.B) {
-	root, derr := NewParser(_TwitterJson).Parse()
-	if derr != 0 {
-		b.Fatalf("decode failed: %v", derr.Error())
-	}
-	node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
-	node.Add(NewNumber("1"))
-	node.Add(NewNumber("2"))
-	node.Add(NewNumber("3"))
-	node.Add(NewNumber("4"))
-	node.Add(NewNumber("5"))
-	m, _ := node.Array()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for i := 3; i < 5; i++ {
-			m[i-1] = m[i]
-		}
-	}
+    root, derr := NewParser(_TwitterJson).Parse()
+    if derr != 0 {
+        b.Fatalf("decode failed: %v", derr.Error())
+    }
+    node := root.Get("statuses").Index(3).Get("entities").Get("hashtags")
+    node.Add(NewNumber("1"))
+    node.Add(NewNumber("2"))
+    node.Add(NewNumber("3"))
+    node.Add(NewNumber("4"))
+    node.Add(NewNumber("5"))
+    m, _ := node.Array()
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        for i := 3; i < 5; i++ {
+            m[i-1] = m[i]
+        }
+    }
 }
 
 func BenchmarkNodeAdd(b *testing.B) {
-	n := NewObject([]Pair{{"test", NewNumber("1")}})
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node := NewArray([]Node{})
-		node.Add(n)
-	}
+    n := NewObject([]Pair{{"test", NewNumber("1")}})
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node := NewArray([]Node{})
+        node.Add(n)
+    }
 }
 
 func BenchmarkSliceAdd(b *testing.B) {
-	n := NewObject([]Pair{{"test", NewNumber("1")}})
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node := []Node{}
-		node = append(node, n)
-	}
+    n := NewObject([]Pair{{"test", NewNumber("1")}})
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node := []Node{}
+        node = append(node, n)
+    }
 }
 
 func BenchmarkMapAdd(b *testing.B) {
-	n := NewObject([]Pair{{"test", NewNumber("1")}})
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		node := map[string]Node{}
-		node["test3"] = n
-	}
+    n := NewObject([]Pair{{"test", NewNumber("1")}})
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        node := map[string]Node{}
+        node["test3"] = n
+    }
 }
 
 func TestNode_Move(t *testing.T) {
-	var us = NewRaw(`["a","1","b","c"]`)
-	if ex, e := us.UnsetByIndex(1); !ex || e != nil {
-		t.Fail()
-	}
-	var us2 = NewRaw(`["a","b","c","1"]`)
-	if ex, e := us2.UnsetByIndex(3); !ex || e != nil {
-		t.Fail()
-	}
-	tests := []struct {
-		name    string
-		in      Node
-		src     int
-		dst     int
-		out     Node
-		wantErr bool
-	}{
-		{
-			name:    "over index",
-			in:      NewArray([]Node{}),
-			src:     0,
-			dst:     1,
-			out:     NewArray([]Node{}),
-			wantErr: false,
-		},
-		{
-			name:    "equal index",
-			in:      NewArray([]Node{NewBool(true)}),
-			src:     0,
-			dst:     0,
-			out:     NewArray([]Node{NewBool(true)}),
-			wantErr: false,
-		},
-		{
-			name:    "forward",
-			in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
-			src:     0,
-			dst:     2,
-			out:     NewArray([]Node{NewString("b"), NewString("c"), NewString("a")}),
-			wantErr: false,
-		},
-		{
-			name:    "backward",
-			in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
-			src:     2,
-			dst:     0,
-			out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
-			wantErr: false,
-		},
-		{
-			name:    "lazy",
-			in:      NewRaw(`["a","b","c"]`),
-			src:     2,
-			dst:     0,
-			out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
-			wantErr: false,
-		},
-		{
-			name:    "unset back",
-			in:      us,
-			src:     2,
-			dst:     0,
-			out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
-			wantErr: false,
-		},
-		{
-			name:    "unset forward",
-			in:      us2,
-			src:     0,
-			dst:     2,
-			out:     NewArray([]Node{NewString("b"), NewString("c"), NewString("a")}),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.in.Move(tt.dst, tt.src)
-			require.NoError(t, err)
-			ej, _ := tt.out.MarshalJSON()
-			aj, _ := tt.in.MarshalJSON()
-			require.Equal(t, string(ej), string(aj))
-		})
-	}
+    var us = NewRaw(`["a","1","b","c"]`)
+    if ex, e := us.UnsetByIndex(1); !ex || e != nil {
+        t.Fail()
+    }
+    var us2 = NewRaw(`["a","b","c","1"]`)
+    if ex, e := us2.UnsetByIndex(3); !ex || e != nil {
+        t.Fail()
+    }
+    tests := []struct {
+        name    string
+        in      Node
+        src     int
+        dst     int
+        out     Node
+        wantErr bool
+    }{
+        {
+            name:    "over index",
+            in:      NewArray([]Node{}),
+            src:     0,
+            dst:     1,
+            out:     NewArray([]Node{}),
+            wantErr: false,
+        },
+        {
+            name:    "equal index",
+            in:      NewArray([]Node{NewBool(true)}),
+            src:     0,
+            dst:     0,
+            out:     NewArray([]Node{NewBool(true)}),
+            wantErr: false,
+        },
+        {
+            name:    "forward",
+            in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
+            src:     0,
+            dst:     2,
+            out:     NewArray([]Node{NewString("b"), NewString("c"), NewString("a")}),
+            wantErr: false,
+        },
+        {
+            name:    "backward",
+            in:      NewArray([]Node{NewString("a"), NewString("b"), NewString("c")}),
+            src:     2,
+            dst:     0,
+            out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
+            wantErr: false,
+        },
+        {
+            name:    "lazy",
+            in:      NewRaw(`["a","b","c"]`),
+            src:     2,
+            dst:     0,
+            out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
+            wantErr: false,
+        },
+        {
+            name:    "unset back",
+            in:      us,
+            src:     2,
+            dst:     0,
+            out:     NewArray([]Node{NewString("c"), NewString("a"), NewString("b")}),
+            wantErr: false,
+        },
+        {
+            name:    "unset forward",
+            in:      us2,
+            src:     0,
+            dst:     2,
+            out:     NewArray([]Node{NewString("b"), NewString("c"), NewString("a")}),
+            wantErr: false,
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := tt.in.Move(tt.dst, tt.src)
+            require.NoError(t, err)
+            ej, _ := tt.out.MarshalJSON()
+            aj, _ := tt.in.MarshalJSON()
+            require.Equal(t, string(ej), string(aj))
+        })
+    }
 
 }
 
 func TestNode_Pop(t *testing.T) {
-	var us = NewRaw(`[1,2,3]`)
-	if ex, e := us.UnsetByIndex(0); !ex || e != nil {
-		t.Fail()
-	}
-	var us2 = NewRaw(`[1,2,3]`)
-	if ex, e := us2.UnsetByIndex(2); !ex || e != nil {
-		t.Fail()
-	}
-	tests := []struct {
-		name  string
-		in  Node
-		out Node
-		wantErr bool
-	}{
-		{
-			name:  "empty",
-			in:    NewArray([]Node{}),
-			out:   NewArray([]Node{}),
-			wantErr: false,
-		},
-		{
-			name:  "one",
-			in:    NewArray([]Node{NewString("a")}),
-			out:   NewArray([]Node{}),
-			wantErr: false,
-		},
-		{
-			name:  "raw",
-			in:    NewRaw(`[1]`),
-			out:   NewArray([]Node{}),
-			wantErr: false,
-		},
-		{
-			name:  "unset head",
-			in:    us,
-			out:   NewRaw(`[2]`),
-			wantErr: false,
-		},
-		{
-			name:  "unset tail",
-			in:    us2,
-			out:   NewRaw(`[1]`),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.in.Pop(); (err != nil) != tt.wantErr {
-				t.Errorf("Node.Pop() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			ej, _ := tt.out.MarshalJSON()
-			aj, _ := tt.in.MarshalJSON()
-			require.Equal(t, string(ej), string(aj))
-		})
-	}
+    var us = NewRaw(`[1,2,3]`)
+    if ex, e := us.UnsetByIndex(0); !ex || e != nil {
+        t.Fail()
+    }
+    var us2 = NewRaw(`[1,2,3]`)
+    if ex, e := us2.UnsetByIndex(2); !ex || e != nil {
+        t.Fail()
+    }
+    tests := []struct {
+        name  string
+        in  Node
+        out Node
+        wantErr bool
+    }{
+        {
+            name:  "empty",
+            in:    NewArray([]Node{}),
+            out:   NewArray([]Node{}),
+            wantErr: false,
+        },
+        {
+            name:  "one",
+            in:    NewArray([]Node{NewString("a")}),
+            out:   NewArray([]Node{}),
+            wantErr: false,
+        },
+        {
+            name:  "raw",
+            in:    NewRaw(`[1]`),
+            out:   NewArray([]Node{}),
+            wantErr: false,
+        },
+        {
+            name:  "unset head",
+            in:    us,
+            out:   NewRaw(`[2]`),
+            wantErr: false,
+        },
+        {
+            name:  "unset tail",
+            in:    us2,
+            out:   NewRaw(`[1]`),
+            wantErr: false,
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if err := tt.in.Pop(); (err != nil) != tt.wantErr {
+                t.Errorf("Node.Pop() error = %v, wantErr %v", err, tt.wantErr)
+            }
+            ej, _ := tt.out.MarshalJSON()
+            aj, _ := tt.in.MarshalJSON()
+            require.Equal(t, string(ej), string(aj))
+        })
+    }
 }

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -840,7 +840,7 @@ func TestUnset(t *testing.T) {
     hashtags := entities.Get("hashtags").Index(0)
     hashtags.Set("text2", newRawNode(`{}`, types.V_OBJECT))
     exist, err = hashtags.Unset("indices") // NOTICE: Unset() won't change node.Len() here
-    if !exist || err != nil || hashtags.len() != 3 {
+    if !exist || err != nil || hashtags.len() != 2 {
         t.Fatal(hashtags.len())
     }
     y, _ := hashtags.Get("text").String()

--- a/ast/parser.go
+++ b/ast/parser.go
@@ -157,7 +157,7 @@ func (self *Parser) decodeArray(ret *linkedNodes) (Node, types.ParsingError) {
         }
 
         /* add the value to result */
-        ret.Add(val)
+        ret.Push(val)
         self.p = self.lspace(self.p)
 
         /* check for EOF */
@@ -244,7 +244,7 @@ func (self *Parser) decodeObject(ret *linkedPairs) (Node, types.ParsingError) {
 
         /* add the value to result */
         // FIXME: ret's address may change here, thus previous referred node in ret may be invalid !!
-        ret.Add(Pair{Key: key, Value: val})
+        ret.Push(Pair{Key: key, Value: val})
         self.p = self.lspace(self.p)
 
         /* check for EOF */
@@ -475,7 +475,7 @@ func (self *Node) skipNextNode() *Node {
     }
 
     /* add the value to result */
-    ret.Add(val)
+    ret.Push(val)
     self.l++
     parser.p = parser.lspace(parser.p)
 
@@ -558,7 +558,7 @@ func (self *Node) skipNextPair() (*Pair) {
     }
 
     /* add the value to result */
-    ret.Add(Pair{Key: key, Value: val})
+    ret.Push(Pair{Key: key, Value: val})
     self.l++
     parser.p = parser.lspace(parser.p)
 


### PR DESCRIPTION
## Background
- Before v1.9.2, `ast.Node.Unset()` will hard delete child for one node. But since #464 introduced llnked-chunk as storage, the behavior changed: `Unset()` will set an empty node at the index but still count it. This inconsistency disturbs our users, although current behavior sounds more reasonable as`Unset()`. Thus, we decide to be compatible with the old behavior.
- Besides, `UnsetByIndex()` is not a behavior provided by std `slice`, we recommend users to use `Add()` and `Pop()` instead
## Feature
- `Len()` and `Index()` won't count emtpy nodes, as implemenation of `soft-delete`, which comes with overhead of index query O(N)
- Add `Pop()`, `Move()` API as `slice-like` OP
