### PR TITLE
fix:(ast) SortKeys(true) panic when not loaded-all

### DIFF
--- a/ast/buffer.go
+++ b/ast/buffer.go
@@ -351,7 +351,7 @@ func (self *linkedPairs) Swap(i, j int) {
 }
 
 func (self *linkedPairs) Sort() {
-    sort.Sort(self)
+    sort.Stable(self)
 }
 
 // Compare two strings from the pos d.

--- a/ast/node.go
+++ b/ast/node.go
@@ -971,7 +971,7 @@ func (self *Node) SortKeys(recurse bool) error {
     }
     if self.itype() == types.V_OBJECT {
         return self.sortKeys(recurse)
-    } else {
+    } else if self.itype() == types.V_ARRAY {
         var err error
         err2 := self.ForEach(func(path Sequence, node *Node) bool {
             it := node.itype()
@@ -987,10 +987,16 @@ func (self *Node) SortKeys(recurse bool) error {
             return err
         }
         return err2
+    } else {
+        return nil
     }
 }
 
 func (self *Node) sortKeys(recurse bool) (err error) {
+    // check raw node first
+    if err := self.checkRaw(); err != nil {
+        return err
+    }
     ps, err := self.unsafeMap()
     if err != nil {
         return err

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -86,9 +86,9 @@ func BenchmarkNodeSortKeys(b *testing.B) {
     if err != nil {
         b.Fatal(err)
     }
-    if err := root.LoadAll(); err != nil {
-        b.Fatal(err)
-    }
+    // if err := root.LoadAll(); err != nil {
+    //     b.Fatal(err)
+    // }
 
     b.Run("single", func(b *testing.B) {
         r := root.Get("statuses")
@@ -109,6 +109,28 @@ func BenchmarkNodeSortKeys(b *testing.B) {
         }
     })
 }
+
+func TestNodeSortKeys2(t *testing.T) {
+    root, err := NewSearcher(_TwitterJson).GetByPath()
+    if err != nil {
+        t.Fatal(err)
+    }
+    // if err := root.LoadAll(); err != nil {
+    //     b.Fatal(err)
+    // }
+    t.Run("single", func(t *testing.T) {
+        r := root.Get("statuses")
+        if r.Check() != nil {
+            t.Fatal(r.Error())
+        }
+        require.NoError(t, root.SortKeys(false))
+    })
+    t.Run("recurse", func(t *testing.T) {
+        require.NoError(t, root.SortKeys(true))
+    })
+}
+
+
 
 //go:noinline
 func stackObj() interface{} {


### PR DESCRIPTION
## Reproduce Code
```
func TestNodeSortKeys2(t *testing.T) {
    root, err := NewSearcher(_TwitterJson).GetByPath()
    if err != nil {
        t.Fatal(err)
    }
    t.Run("single", func(t *testing.T) {
        r := root.Get("statuses")
        if r.Check() != nil {
            t.Fatal(r.Error())
        }
        require.NoError(t, root.SortKeys(false))
    })
    t.Run("recurse", func(t *testing.T) {
        require.NoError(t, root.SortKeys(true))
    })
}
```
```
--  runtime error: invalid memory address or nil pointer dereference 
```

## Reason
`sortKey()` use `unsafeMap()` at the beginning , which doesn't consider`V_RAW` type nodes

