### PR TITLE
fix: better compile error info in 32-bit arch

### DIFF
--- a/ast/decode.go
+++ b/ast/decode.go
@@ -26,7 +26,8 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
-const _blankCharsMask = (1 << ' ') | (1 << '\t') | (1 << '\r') | (1 << '\n')
+// Hack: this is used for both checking space and cause firendly compile errors in 32-bit arch.
+const _Sonic_Not_Support_32Bit_Arch__Checking_32Bit_Arch_Here = (1 << ' ') | (1 << '\t') | (1 << '\r') | (1 << '\n')
 
 const (
     bytesNull   = "null"
@@ -37,7 +38,7 @@ const (
 )
 
 func isSpace(c byte) bool {
-    return (int(1<<c) & _blankCharsMask) != 0
+    return (int(1<<c) & _Sonic_Not_Support_32Bit_Arch__Checking_32Bit_Arch_Here) != 0
 }
 
 //go:nocheckptr


### PR DESCRIPTION
Add a friendly compile error info for  #628 and #631 