### PR TITLE
fix: possible oom when encode parallel in go1.16

### DIFF
--- a/internal/encoder/assembler_stkabi_amd64.go
+++ b/internal/encoder/assembler_stkabi_amd64.go
@@ -579,12 +579,12 @@ var (
 
 func (self *_Assembler) more_space() {
     self.Link(_LB_more_space)
-    self.Emit("MOVQ", _T_byte, _AX)                 // MOVQ $_T_byte, _AX
-    self.Emit("MOVQ", _AX, jit.Ptr(_SP, 0))         // MOVQ _AX, (SP)
     self.Emit("MOVQ", _RP, jit.Ptr(_SP, 8))         // MOVQ RP, 8(SP)
     self.Emit("MOVQ", _RL, jit.Ptr(_SP, 16))        // MOVQ RL, 16(SP)
     self.Emit("MOVQ", _RC, jit.Ptr(_SP, 24))        // MOVQ RC, 24(SP)
     self.Emit("MOVQ", _AX, jit.Ptr(_SP, 32))        // MOVQ AX, 32(SP)
+    self.Emit("MOVQ", _T_byte, _AX)                 // MOVQ $_T_byte, _AX
+    self.Emit("MOVQ", _AX, jit.Ptr(_SP, 0))         // MOVQ _AX, (SP)
     self.xsave(_REG_jsr...)                         // SAVE $REG_jsr
     self.call(_F_growslice)                         // CALL $pc
     self.xload(_REG_jsr...)                         // LOAD $REG_jsr

--- a/issue_test/issue634_test.go
+++ b/issue_test/issue634_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package issue_test
+
+import (
+    "strings"
+    "testing"
+
+    "sync"
+
+    "github.com/bytedance/sonic"
+    "github.com/bytedance/sonic/option"
+    "github.com/stretchr/testify/assert"
+)
+
+func marshalSingle() {
+    var m = map[string]interface{}{
+        "1": map[string]interface{} {
+            `"`+strings.Repeat("a", int(option.DefaultEncoderBufferSize) - 38)+`"`: "b",
+            "1": map[string]int32{
+                "b": 1658219785,
+            },
+        },
+    }
+    _, err := sonic.Marshal(&m)
+    if err != nil {
+        panic("err")
+    }
+}
+
+type zoo foo
+
+func (z *zoo) MarshalJSON() ([]byte, error) {
+    marshalSingle()
+    return sonic.Marshal((*foo)(z))
+}
+
+type foo bar
+
+func (f *foo) MarshalJSON() ([]byte, error) {
+    marshalSingle()
+    return sonic.Marshal((*bar)(f))
+}
+
+type bar int
+
+func (b *bar) MarshalJSON() ([]byte, error) {
+    marshalSingle()
+    return sonic.Marshal(int(*b))
+}
+
+ func TestEncodeOOM(t *testing.T) {
+    wg := &sync.WaitGroup{}
+    N := 10000
+    for i:=0; i<N; i++ {
+        wg.Add(1)
+        go func (wg *sync.WaitGroup)  {
+            defer wg.Done()
+            var z zoo
+            _, err := sonic.Marshal(&z)
+            assert.NoError(t, err)
+        }(wg)
+    }
+    wg.Wait()
+ }


### PR DESCRIPTION
Fix issue #634 