### PR TITLE
move StopProf to prof_amd64.go

### DIFF
--- a/internal/rt/gcwb.go
+++ b/internal/rt/gcwb.go
@@ -100,25 +100,3 @@ var (
 
 //go:nosplit
 func MoreStack(size uintptr)
-
-func StopProf()
-
-// func StopProf() {
-//     atomic.AddUint32(&yieldCount, 1)
-//     if runtimeProf.hz != 0 {
-//         oldHz = runtimeProf.hz
-//         runtimeProf.hz = 0
-//     }
-// }
-
-func StartProf()
-
-// func StartProf() {
-//     atomic.AddUint32(&yieldCount, ^uint32(0))
-//     if yieldCount == 0 && runtimeProf.hz == 0 {
-//         if oldHz == 0 {
-//             oldHz = 100
-//         }
-//         runtimeProf.hz = oldHz
-//     }
-// }

--- a/internal/rt/prof_amd64.go
+++ b/internal/rt/prof_amd64.go
@@ -1,0 +1,25 @@
+// +build !noasm,amd64 !appengine,amd64
+
+package rt
+
+func StopProf()
+
+// func StopProf() {
+//     atomic.AddUint32(&yieldCount, 1)
+//     if runtimeProf.hz != 0 {
+//         oldHz = runtimeProf.hz
+//         runtimeProf.hz = 0
+//     }
+// }
+
+func StartProf()
+
+// func StartProf() {
+//     atomic.AddUint32(&yieldCount, ^uint32(0))
+//     if yieldCount == 0 && runtimeProf.hz == 0 {
+//         if oldHz == 0 {
+//             oldHz = 100
+//         }
+//         runtimeProf.hz = oldHz
+//     }
+// }


### PR DESCRIPTION
This PR does not resolve any issue, while somehow addresses https://github.com/bytedance/sonic/issues/648.

It attempts to make the code more self-explained by moving StartProf and StopProf to amd64 files, indicating they are only available in amd64.

This origins from https://github.com/xhd2015/xgo/issues/194#issuecomment-2153663389