### PR TITLE
add APIKind to indicate std-json or sonic

### DIFF
--- a/api.go
+++ b/api.go
@@ -23,6 +23,11 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
+const (
+	UseStdJSON = iota
+	UseSonicJSON
+)
+
 // APIKind is the kind of API, 0 is std json, 1 is sonic.
 const APIKind = apiKind
 

--- a/api.go
+++ b/api.go
@@ -23,6 +23,9 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
+// APIKind is the kind of API, 0 is std json, 1 is sonic.
+const APIKind = apiKind
+
 // Config is a combination of sonic/encoder.Options and sonic/decoder.Options
 type Config struct {
     // EscapeHTML indicates encoder to escape all HTML characters 

--- a/compat.go
+++ b/compat.go
@@ -27,6 +27,8 @@ import (
     `github.com/bytedance/sonic/option`
 )
 
+const apiKind = 0
+
 type frozenConfig struct {
     Config
 }

--- a/compat.go
+++ b/compat.go
@@ -27,7 +27,7 @@ import (
     `github.com/bytedance/sonic/option`
 )
 
-const apiKind = 0
+const apiKind = UseStdJSON
 
 type frozenConfig struct {
     Config

--- a/sonic.go
+++ b/sonic.go
@@ -30,7 +30,7 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
-const apiKind = 1
+const apiKind = UseSonicJSON
 
 type frozenConfig struct {
     Config

--- a/sonic.go
+++ b/sonic.go
@@ -30,6 +30,8 @@ import (
     `github.com/bytedance/sonic/internal/rt`
 )
 
+const apiKind = 1
+
 type frozenConfig struct {
     Config
     encoderOpts encoder.Options


### PR DESCRIPTION
We need to identify the current strategy, whether it is std-json or sonic, to implement a wrapper in our library. This wrapper will issue a warning if upgrading go.mod in a user's project downgrades from sonic to std-json. Our goal is to avoid this situation.