### PR TITLE
fix: skip checking linkname when running PCSP test

### DIFF
--- a/.github/workflows/unit_test-linux-x64.yml
+++ b/.github/workflows/unit_test-linux-x64.yml
@@ -34,6 +34,8 @@ jobs:
           ./scripts/test_race.sh
 
       - name: PCSP Test
+        env:
+          GOVERSION: ${{ matrix.go-version }}
         run: python3 ./scripts/test_pcsp.py
     
 


### PR DESCRIPTION
Follow-up: #688 

It shows that `linkname` are used in the PCSP test. This PR disables `linkname` checking under Go 1.23 to make the unit test work again.

It's a hotfix which seems not elegant. Marked as a draft.