### PR TITLE
fix: typo in ast/node.go doc comment

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -816,7 +816,7 @@ func (self *Node) Move(dst, src int) error {
     return nil
 }
 
-// SetAny wraps val with V_ANY node, and Add() the node.
+// AddAny wraps val with V_ANY node, and Add() the node.
 func (self *Node) AddAny(val interface{}) error {
     return self.Add(NewAny(val))
 }


### PR DESCRIPTION
A typo in node.go doc comment.
It is small but it is about method name, so I created this PR. 