### PR TITLE
feat: show JSON trace when panic

### DIFF
--- a/internal/encoder/encoder_test.go
+++ b/internal/encoder/encoder_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/bytedance/sonic/internal/encoder/vars"
 	"github.com/bytedance/sonic/internal/rt"
@@ -69,6 +70,24 @@ func TestEncoderMemoryCorruption(t *testing.T) {
 	if err := json.Unmarshal(out, &m); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestEncoderPanicString(t *testing.T) {
+    defer func() {
+        if r := recover(); r != nil {
+            println("recover")
+        } else {
+            t.Fatal("no panic")
+        }
+    }()
+    var s = struct{
+        A string
+        S string
+    }{
+        A: "a",
+    }
+    (*rt.GoString)(unsafe.Pointer(&s.S)).Len = 1
+    Encode(s, 0)
 }
 
 type sample struct {

--- a/internal/encoder/vars/errors.go
+++ b/internal/encoder/vars/errors.go
@@ -17,13 +17,14 @@
 package vars
 
 import (
-    `encoding/json`
-    `fmt`
-    `reflect`
-    `strconv`
-    `unsafe`
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"unsafe"
 
-    `github.com/bytedance/sonic/internal/rt`
+	"github.com/bytedance/sonic/internal/rt"
 )
 
 var ERR_too_deep = &json.UnsupportedValueError {
@@ -59,11 +60,17 @@ const (
     PanicNilPointerOfNonEmptyString int = 1 + iota
 )
 
-func GoPanic(code int, val unsafe.Pointer) {
+func GoPanic(code int, val unsafe.Pointer, buf string) {
+    sb := strings.Builder{}
     switch(code){
     case PanicNilPointerOfNonEmptyString:
-        panic(fmt.Sprintf("val: %#v has nil pointer while its length is not zero!\nThis is a nil pointer exception (NPE) problem. There might be a data race issue. It is recommended to execute the tests related to the code with the `-race` compile flag to detect the problem.", (*rt.GoString)(val)))
+        sb.WriteString(fmt.Sprintf("val: %#v has nil pointer while its length is not zero!\nThis is a nil pointer exception (NPE) problem. There might be a data race issue. It is recommended to execute the tests related to the code with the `-race` compile flag to detect the problem.\n", (*rt.GoString)(val)))
     default:
-        panic("encoder error!")
+        sb.WriteString("encoder error: ")
+        sb.WriteString(strconv.Itoa(code))
+        sb.WriteString("\n")
     }
+    sb.WriteString("JSON: ")
+    sb.WriteString(buf)
+    panic(sb.String())
 }

--- a/internal/encoder/vars/errors.go
+++ b/internal/encoder/vars/errors.go
@@ -19,6 +19,7 @@ package vars
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -71,6 +72,20 @@ func GoPanic(code int, val unsafe.Pointer, buf string) {
         sb.WriteString("\n")
     }
     sb.WriteString("JSON: ")
-    sb.WriteString(buf)
+    if len(buf) > maxJSONLength {
+        sb.WriteString(buf[len(buf)-maxJSONLength:])
+    } else {
+        sb.WriteString(buf)
+    }
     panic(sb.String())
+}
+
+var maxJSONLength = 1024
+
+func init() {
+    if v := os.Getenv("SONIC_PANIC_MAX_JSON_LENGTH"); v != "" {
+        if i, err := strconv.Atoi(v); err == nil {
+            maxJSONLength = i
+        }
+    }
 }

--- a/internal/encoder/x86/assembler_regabi_amd64.go
+++ b/internal/encoder/x86/assembler_regabi_amd64.go
@@ -663,6 +663,8 @@ var (
 func (self *Assembler) go_panic() {
 	self.Link(_LB_panic)
 	self.Emit("MOVQ", _SP_p, _BX)
+	self.Emit("MOVQ", _RP, _CX)
+	self.Emit("MOVQ", _RL, _DI)
 	self.call_go(_F_panic)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->