### PR TITLE
fix: make encoder pretouch able to recurse

### DIFF
--- a/internal/encoder/compiler.go
+++ b/internal/encoder/compiler.go
@@ -50,12 +50,19 @@ var pretouchType func(_vt reflect.Type, opts option.CompileOptions, v uint8) (ma
 func pretouchTypeVM(_vt reflect.Type, opts option.CompileOptions, v uint8) (map[reflect.Type]uint8, error) {
 	/* compile function */
 	compiler := NewCompiler().apply(opts)
+	encoder := func(vt *rt.GoType, ex ...interface{}) (interface{}, error) {
+		pp, err := compiler.Compile(vt.Pack(), ex[0].(bool))
+		if err != nil {
+			return nil, err
+		}
+		return &pp, nil
+	}
 
 	/* find or compile */
 	vt := rt.UnpackType(_vt)
 	if val := vars.GetProgram(vt); val != nil {
 		return nil, nil
-	} else if _, err := vars.ComputeProgram(vt, makeEncoderVM, v == 1); err == nil {
+	} else if _, err := vars.ComputeProgram(vt, encoder, v == 1); err == nil {
 		return compiler.rec, nil
 	} else {
 		return nil, err
@@ -507,7 +514,7 @@ func (self *Compiler) compileStructBody(p *ir.Program, sp int, vt reflect.Type) 
 
 func (self *Compiler) compileStructFieldStr(p *ir.Program, sp int, vt reflect.Type) {
 	// NOTICE: according to encoding/json, Marshaler type has higher priority than string option
-	// see issue: 
+	// see issue:
 	if self.tryCompileMarshaler(p, vt, self.pv) {
 		return
 	}
@@ -660,7 +667,6 @@ func (self *Compiler) compileUnsupportedType(p *ir.Program, vt reflect.Type) {
 	p.Rtt(ir.OP_unsupported, vt)
 }
 
-
 func (self *Compiler) compileMarshaler(p *ir.Program, op ir.Op, vt reflect.Type, mt reflect.Type) {
 	pc := p.PC()
 	vk := vt.Kind()
@@ -687,7 +693,7 @@ func addMarshalerOp(p *ir.Program, op ir.Op, vt reflect.Type, mt reflect.Type) {
 		itab := rt.GetItab(rt.IfaceType(rt.UnpackType(mt)), rt.UnpackType(vt), true)
 		p.Vtab(op, vt, itab)
 	} else {
-		// OPT: get itab here 
+		// OPT: get itab here
 		p.Rtt(op, vt)
 	}
 }

--- a/internal/encoder/pools_amd64_test.go
+++ b/internal/encoder/pools_amd64_test.go
@@ -1,0 +1,36 @@
+//go:build amd64
+// +build amd64
+
+package encoder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bytedance/sonic/option"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPretouchTypeX86(t *testing.T) {
+	type subA struct{}
+	type subB struct{}
+	type subC struct{}
+	type data struct {
+		SubA subA
+		SubB subB
+		SubC subC
+	}
+
+	sub, err := pretouchTypeX86(
+		reflect.TypeOf(data{}),
+		option.CompileOptions{
+			MaxInlineDepth: 1,
+			RecursiveDepth: 1000,
+		},
+		0,
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, sub, reflect.TypeOf(subA{}))
+	assert.Contains(t, sub, reflect.TypeOf(subB{}))
+	assert.Contains(t, sub, reflect.TypeOf(subC{}))
+}


### PR DESCRIPTION
#### What type of PR is this?

Related to https://github.com/bytedance/sonic/issues/842

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

Make encoder pretouch more similar to decoder

#### (Optional) Which issue(s) this PR fixes:

https://github.com/bytedance/sonic/issues/842

#### (optional) The PR that updates user documentation:

-