### PR TITLE
fix: pcsp for jit functions

### DIFF
--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -31,13 +31,13 @@ jobs:
             ${{ github.workspace }}/go.sum
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-      - name: Disable checklinkname in Go 1.25
-        if: matrix.go-version == '1.25.x'
-        run: echo "GODEBUG=checklinkname=0" >> $GITHUB_ENV
-
       - name: Unit Test JIT
         run: |
           GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+
+      - name: Unit Test JIT PCSP
+        run: |
+          GOMAXPROCS=4 go test  -v ./internal/decoder/jitdec 
 
       - name: Unit Test VM
         run: |

--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -31,6 +31,10 @@ jobs:
             ${{ github.workspace }}/go.sum
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
+      - name: Disable checklinkname in Go 1.25
+        if: matrix.go-version == '1.25.x'
+        run: echo "GODEBUG=checklinkname=0" >> $GITHUB_ENV
+
       - name: Unit Test JIT
         run: |
           GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage.txt ./...

--- a/internal/caching/pcache.go
+++ b/internal/caching/pcache.go
@@ -145,6 +145,12 @@ func CreateProgramCache() *ProgramCache {
     }
 }
 
+func (self *ProgramCache) Reset() {
+    self.m.Lock()
+    defer self.m.Unlock()
+    self.p = unsafe.Pointer(newProgramMap())
+}
+
 func (self *ProgramCache) Get(vt *rt.GoType) interface{} {
     return (*_ProgramMap)(atomic.LoadPointer(&self.p)).get(vt)
 }

--- a/internal/decoder/jitdec/compiler_test.go
+++ b/internal/decoder/jitdec/compiler_test.go
@@ -17,14 +17,28 @@
 package jitdec
 
 import (
-    `reflect`
-    `testing`
+	"reflect"
+	"testing"
 
-    `github.com/stretchr/testify/assert`
+	"github.com/bytedance/sonic/internal/encoder/vars"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCompiler_Compile(t *testing.T) {
     prg, err := newCompiler().compile(reflect.TypeOf(TwitterStruct{}))
     assert.Nil(t, err)
     prg.disassemble()
+}
+
+func BenchmarkCompiler_Compile(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        pp, err :=  newCompiler().compile(reflect.TypeOf(TwitterStruct{}))
+        if err != nil {
+            panic("compile failed")
+        } 
+        as := newAssembler(pp)
+        as.name = "twitter struct"
+        _ = as.Load()
+        vars.ResetProgramCache()
+    }
 }

--- a/internal/decoder/jitdec/pcsp_test.go
+++ b/internal/decoder/jitdec/pcsp_test.go
@@ -1,0 +1,144 @@
+/*
+* Copyright 2025 ByteDance Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+ package jitdec
+
+import (
+	"testing"
+	"unsafe"
+
+    "github.com/bytedance/sonic/internal/jit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type _MockDecoder struct {
+    jit.BaseAssembler
+}
+
+func (self *_MockDecoder) compile() {
+    self.Emit("SUBQ", jit.Imm(_VD_size), _SP)       // SUBQ $_VD_size, SP
+    self.Byte(0xcc) // INT3
+    self.Emit("MOVQ", _BP, jit.Ptr(_SP, _VD_offs))  // MOVQ BP, _VD_offs(SP)
+    self.Byte(0xcc) // INT3
+
+    self.Emit("MOVQ", jit.Ptr(_SP, _VD_offs), _BP)  // MOVQ _VD_offs(SP), BP
+    self.Emit("MOVQ", jit.Imm(199), _AX)
+    self.Byte(0xcc) // INT3
+    self.Emit("ADDQ", jit.Imm(_VD_size), _SP)       // ADDQ $_VD_size, SP
+    self.Byte(0xcc) // INT3
+    self.Emit("RET")
+}
+
+func (self *_MockDecoder) Load() _Decoder {
+    self.Init(self.compile)
+    return ptodec(self.BaseAssembler.Load("decode_mock", _FP_size, _FP_args, argPtrs, localPtrs))
+}
+
+// copied from g01.20.4 signal_linux_amd64.go
+type sigctxt struct {
+	info unsafe.Pointer
+	ctxt unsafe.Pointer
+}
+
+type stackt struct {
+	ss_sp     *byte
+	ss_flags  int32
+	pad_cgo_0 [4]byte
+	ss_size   uintptr
+}
+
+type mcontext struct {
+	gregs       [23]uint64
+	fpregs      unsafe.Pointer
+	__reserved1 [8]uint64
+}
+
+type sigcontext struct {
+	r8          uint64
+	r9          uint64
+	r10         uint64
+	r11         uint64
+	r12         uint64
+	r13         uint64
+	r14         uint64
+	r15         uint64
+	rdi         uint64
+	rsi         uint64
+	rbp         uint64
+	rbx         uint64
+	rdx         uint64
+	rax         uint64
+	rcx         uint64
+	rsp         uint64
+	rip         uint64
+	eflags      uint64
+	cs          uint16
+	gs          uint16
+	fs          uint16
+	__pad0      uint16
+	err         uint64
+	trapno      uint64
+	oldmask     uint64
+	cr2         uint64
+	fpstate     unsafe.Pointer
+	__reserved1 [8]uint64
+}
+type ucontext struct {
+	uc_flags     uint64
+	uc_link      *ucontext
+	uc_stack     stackt
+	uc_mcontext  mcontext
+}
+
+//go:nosplit
+func (c *sigctxt) regs() *sigcontext {
+	return (*sigcontext)(unsafe.Pointer(&(*ucontext)(c.ctxt).uc_mcontext))
+}
+
+func (c *sigctxt) rsp() uint64 { return c.regs().rsp }
+
+//go:nosplit
+func (c *sigctxt) sigpc() uintptr { return uintptr(c.rip()) }
+
+//go:nosplit
+func (c *sigctxt) rip() uint64 { return c.regs().rip }
+func (c *sigctxt) sigsp() uintptr    { return uintptr(c.rsp()) }
+func (c *sigctxt) siglr() uintptr    { return 0 }
+
+// only used for test sonic trace
+//go:linkname testSigtrap runtime.testSigtrap
+var testSigtrap func(info unsafe.Pointer, c *sigctxt, gp unsafe.Pointer) bool 
+
+//go:linkname traceback1 runtime.traceback1
+func traceback1(pc, sp, lr uintptr, gp unsafe.Pointer, flags uint);
+
+func sonicSigTrap(info unsafe.Pointer, c *sigctxt, gp unsafe.Pointer) bool {
+	pc := c.sigpc()
+	sp := c.sigsp()
+	lr := c.siglr()
+	traceback1(pc, sp, lr, gp, 0);
+	return true
+}
+
+func TestAssembler_PCSP(t *testing.T) {
+    testSigtrap = sonicSigTrap
+    f := new(_MockDecoder).Load()
+    pos, err := f("", 0, nil, nil, 0, "", nil)
+    require.NoError(t, err)
+    assert.Equal(t, 199, pos)
+    testSigtrap = nil
+}

--- a/internal/decoder/jitdec/pcsp_test.go
+++ b/internal/decoder/jitdec/pcsp_test.go
@@ -1,3 +1,6 @@
+//go:build !race && amd64 && !go1.23
+// +build !race,amd64,!go1.23
+
 /*
 * Copyright 2025 ByteDance Inc.
 *

--- a/internal/encoder/vars/stack.go
+++ b/internal/encoder/vars/stack.go
@@ -49,6 +49,10 @@ var (
 	programCache = caching.CreateProgramCache()
 )
 
+func ResetProgramCache() {
+	programCache.Reset()
+}
+
 func NewBytes() *[]byte {
 	if ret := bytesPool.Get(); ret != nil {
 		return ret.(*[]byte)

--- a/internal/jit/assembler_amd64.go
+++ b/internal/jit/assembler_amd64.go
@@ -36,6 +36,7 @@ type BaseAssembler struct {
     i        int
     f        func()
     c        []byte
+    pcdata   loader.Pcdata
     o        sync.Once
     pb       *Backend
     xrefs    map[string][]*obj.Prog
@@ -212,7 +213,7 @@ var jitLoader = loader.Loader{
 
 func (self *BaseAssembler) Load(name string, frameSize int, argSize int, argStackmap []bool, localStackmap []bool) loader.Function {
     self.build()
-    return jitLoader.LoadOne(self.c, name, frameSize, argSize, argStackmap, localStackmap)
+    return jitLoader.LoadOne(self.c, name, frameSize, argSize, argStackmap, localStackmap, self.pcdata)
 }
 
 /** Assembler Stages **/
@@ -265,5 +266,5 @@ func (self *BaseAssembler) validate() {
 }
 
 func (self *BaseAssembler) assemble() {
-    self.c = self.pb.Assemble()
+    self.c, self.pcdata = self.pb.Assemble()
 }

--- a/internal/jit/backend.go
+++ b/internal/jit/backend.go
@@ -133,7 +133,8 @@ func pcdelta(ctxt *obj.Link, p *obj.Prog) uint32 {
     return uint32(p.Pc / int64(ctxt.Arch.MinLC))
 }
 
-// NOTE: 
+// NOTE: copied from https://github.com/twitchyliquid64/golang-asm/blob/8d7f1f783b11f9a00f5bcdfcae17f5ac8f22512e/obj/x86/obj6.go#L811.
+// we add two instructions such as subq/addq %rsp, $imm to the table.
 func (self *Backend) GetPcspTable(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) loader.Pcdata {
     pcdata := loader.Pcdata{}
     var deltasp int32

--- a/loader/loader_latest.go
+++ b/loader/loader_latest.go
@@ -32,7 +32,7 @@ import (
 // WARN: 
 //   - the function MUST has fixed SP offset equaling to this, otherwise it go.gentraceback will fail
 //   - the function MUST has only one stack map for all arguments and local variants
-func (self Loader) LoadOne(text []byte, funcName string, frameSize int, argSize int, argPtrs []bool, localPtrs []bool) Function {
+func (self Loader) LoadOne(text []byte, funcName string, frameSize int, argSize int, argPtrs []bool, localPtrs []bool, pcdata Pcdata) Function {
     size := uint32(len(text))
 
     fn := Func{
@@ -41,18 +41,8 @@ func (self Loader) LoadOne(text []byte, funcName string, frameSize int, argSize 
         ArgsSize: int32(argSize),
     }
 
-    // NOTICE: suppose the function has fixed SP offset equaling to frameSize, the pattern is as follows:
-    // ```
-    // PC 0: subq $frameSize, %rsp
-    // PC 7: xxx
-    // PC size - 1: addq $frameSize, %rsp
-    // PC size: ret
-    // ```
-    fn.Pcsp = &Pcdata{
-        {PC: 0x7, Val: 0},
-        {PC: size - 1, Val: int32(frameSize)},
-        {PC: size, Val: 0},
-    }
+
+    fn.Pcsp = &pcdata
 
     if self.NoPreempt {
         fn.PcUnsafePoint = &Pcdata{

--- a/loader/loader_latest.go
+++ b/loader/loader_latest.go
@@ -41,9 +41,17 @@ func (self Loader) LoadOne(text []byte, funcName string, frameSize int, argSize 
         ArgsSize: int32(argSize),
     }
 
-    // NOTICE: suppose the function has fixed SP offset equaling to frameSize, thus make only one pcsp pair
+    // NOTICE: suppose the function has fixed SP offset equaling to frameSize, the pattern is as follows:
+    // ```
+    // PC 0: subq $frameSize, %rsp
+    // PC 7: xxx
+    // PC size - 1: addq $frameSize, %rsp
+    // PC size: ret
+    // ```
     fn.Pcsp = &Pcdata{
-        {PC: size, Val: int32(frameSize)},
+        {PC: 0x7, Val: 0},
+        {PC: size - 1, Val: int32(frameSize)},
+        {PC: size, Val: 0},
     }
 
     if self.NoPreempt {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fix panic caused by invalid pcsp table.

the compile time decrease 1%
```
# compiled with PCSP table
➜  jitdec git:(fix/panic) ✗ go test -v -run=none -bench=BenchmarkCompiler_Compile ./
goos: linux
goarch: amd64
pkg: github.com/bytedance/sonic/internal/decoder/jitdec
cpu: AMD EPYC 9Y25 128-Core Processor               
BenchmarkCompiler_Compile
BenchmarkCompiler_Compile-4          252       4483593 ns/op
PASS
ok      github.com/bytedance/sonic/internal/decoder/jitdec  1.620s
# compiled without PCSP table
➜  jitdec git:(fix/panic) ✗ go test -v -run=none -bench=BenchmarkCompiler_Compile ./
goos: linux
goarch: amd64
pkg: github.com/bytedance/sonic/internal/decoder/jitdec
cpu: AMD EPYC 9Y25 128-Core Processor               
BenchmarkCompiler_Compile
BenchmarkCompiler_Compile-4          258       4434639 ns/op
PASS
ok      github.com/bytedance/sonic/internal/decoder/jitdec  1.623s
```

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute real `pcsp` from emitted x86 instructions and plumb it through loader; add test to validate traceback/PC-SP correctness.
> 
> - **JIT Assembler/Backend**:
>   - Track and return `pcdata` from `Backend.Assemble()`; `BaseAssembler` stores it and passes it to loader.
>   - Implement `GetPcspTable` to derive `pcsp` by scanning `PUSH/POP/ADDQ/SUBQ/ADJSP/RET` and record max stack depth.
> - **Loader**:
>   - Update `Loader.LoadOne` to accept provided `pcdata` instead of assuming fixed `frameSize`.
> - **Tests**:
>   - Add `internal/decoder/jitdec/pcsp_test.go` to exercise JIT-assembled code, hook runtime `testSigtrap`, and verify proper return value and traceback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f78ba6f8d435ebf2bc8950fd63abd1826265c161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->