### PR TITLE
chore: benchmark with msgpack

### DIFF
--- a/external_jsonlib_test/benchmark_test/msgpack_test.go
+++ b/external_jsonlib_test/benchmark_test/msgpack_test.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/require"
+	msgpack "github.com/vmihailenco/msgpack/v5"
+)
+
+var (
+	twitterJSONBytes       = []byte(TwitterJson)
+	twitterStructForBench  TwitterStruct
+	twitterGenericForBench interface{}
+	twitterMsgpackBinding  []byte
+	twitterMsgpackGeneric  []byte
+)
+
+func init() {
+	if err := json.Unmarshal(twitterJSONBytes, &twitterStructForBench); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(twitterJSONBytes, &twitterGenericForBench); err != nil {
+		panic(err)
+	}
+	var err error
+	twitterMsgpackBinding, err = msgpack.Marshal(&twitterStructForBench)
+	if err != nil {
+		panic(err)
+	}
+	twitterMsgpackGeneric, err = msgpack.Marshal(twitterGenericForBench)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkWithMsgPackDecode_Generic_Sonic_JSON(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v interface{}
+		if err := sonic.Unmarshal(twitterJSONBytes, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackDecode_Generic_Msgpack(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v interface{}
+		if err := msgpack.Unmarshal(twitterMsgpackGeneric, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackDecode_Binding_Sonic_JSON(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v TwitterStruct
+		if err := sonic.Unmarshal(twitterJSONBytes, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackDecode_Binding_Msgpack(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v TwitterStruct
+		if err := msgpack.Unmarshal(twitterMsgpackBinding, &v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackEncode_Generic_Sonic_JSON(b *testing.B) {
+	if _, err := sonic.Marshal(twitterGenericForBench); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sonic.Marshal(twitterGenericForBench); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackEncode_Generic_Msgpack(b *testing.B) {
+	if _, err := msgpack.Marshal(twitterGenericForBench); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := msgpack.Marshal(twitterGenericForBench); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackEncode_Binding_Sonic_JSON(b *testing.B) {
+	if _, err := sonic.Marshal(&twitterStructForBench); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sonic.Marshal(&twitterStructForBench); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWithMsgPackEncode_Binding_Msgpack(b *testing.B) {
+	if _, err := msgpack.Marshal(&twitterStructForBench); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := msgpack.Marshal(&twitterStructForBench); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMsgpackDecodeMatchesSonicGeneric(t *testing.T) {
+	var sonicGeneric interface{}
+	require.NoError(t, sonic.Unmarshal(twitterJSONBytes, &sonicGeneric))
+
+	var msgpackGeneric interface{}
+	require.NoError(t, msgpack.Unmarshal(twitterMsgpackGeneric, &msgpackGeneric))
+
+	require.Equal(t, sonicGeneric, msgpackGeneric)
+}
+
+func TestMsgpackDecodeMatchesSonicBinding(t *testing.T) {
+	var sonicStruct TwitterStruct
+	require.NoError(t, sonic.Unmarshal(twitterJSONBytes, &sonicStruct))
+
+	var msgpackStruct TwitterStruct
+	require.NoError(t, msgpack.Unmarshal(twitterMsgpackBinding, &msgpackStruct))
+
+	require.Equal(t, sonicStruct, msgpackStruct)
+}
+
+func TestMsgpackEncodeMatchesSonicGeneric(t *testing.T) {
+	sonicBytes, err := sonic.Marshal(twitterGenericForBench)
+	require.NoError(t, err)
+
+	var sonicDecoded interface{}
+	require.NoError(t, json.Unmarshal(sonicBytes, &sonicDecoded))
+
+	msgpackBytes, err := msgpack.Marshal(twitterGenericForBench)
+	require.NoError(t, err)
+
+	var msgpackDecoded interface{}
+	require.NoError(t, msgpack.Unmarshal(msgpackBytes, &msgpackDecoded))
+
+	require.Equal(t, sonicDecoded, msgpackDecoded)
+}
+
+func TestMsgpackEncodeMatchesSonicBinding(t *testing.T) {
+	sonicBytes, err := sonic.Marshal(&twitterStructForBench)
+	require.NoError(t, err)
+
+	var sonicDecoded TwitterStruct
+	require.NoError(t, sonic.Unmarshal(sonicBytes, &sonicDecoded))
+
+	msgpackBytes, err := msgpack.Marshal(&twitterStructForBench)
+	require.NoError(t, err)
+
+	var msgpackDecoded TwitterStruct
+	require.NoError(t, msgpack.Unmarshal(msgpackBytes, &msgpackDecoded))
+
+	require.Equal(t, sonicDecoded, msgpackDecoded)
+}

--- a/external_jsonlib_test/go.mod
+++ b/external_jsonlib_test/go.mod
@@ -11,11 +11,12 @@ require (
 	github.com/tidwall/gjson v1.14.3
 	github.com/tidwall/sjson v1.2.5
 	github.com/valyala/fastjson v1.6.4
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic/loader v0.4.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
@@ -25,6 +26,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/external_jsonlib_test/go.sum
+++ b/external_jsonlib_test/go.sum
@@ -2,8 +2,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
-github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
+github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -25,11 +25,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
 github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -43,6 +45,10 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670 h1:18EFjUmQOcUvxNYSkA6jO9VAiXCnxFY6NyDX0bHDmkU=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=


### PR DESCRIPTION
benchmark results

```
➜  benchmark_test git:(chore/benchmark) SONIC_NO_ASYNC_GC=1  go test -v -run=none -bench=BenchmarkWithMsg -benchmem ./ 
goos: linux
goarch: amd64
pkg: github.com/bytedance/sonic/external_jsonlib_test/benchmark_test
cpu: AMD EPYC 9Y25 128-Core Processor               
BenchmarkWithMsgPackDecode_Generic_Sonic_JSON
BenchmarkWithMsgPackDecode_Generic_Sonic_JSON-256          26365         45059 ns/op       63213 B/op        315 allocs/op
BenchmarkWithMsgPackDecode_Generic_Msgpack
BenchmarkWithMsgPackDecode_Generic_Msgpack-256             30133         39647 ns/op       36725 B/op        688 allocs/op
BenchmarkWithMsgPackDecode_Binding_Sonic_JSON
BenchmarkWithMsgPackDecode_Binding_Sonic_JSON-256          59922         19710 ns/op       20537 B/op         25 allocs/op
BenchmarkWithMsgPackDecode_Binding_Msgpack
BenchmarkWithMsgPackDecode_Binding_Msgpack-256             53305         22616 ns/op       13136 B/op        206 allocs/op
BenchmarkWithMsgPackEncode_Generic_Sonic_JSON
BenchmarkWithMsgPackEncode_Generic_Sonic_JSON-256          98030         12223 ns/op        9820 B/op          2 allocs/op
BenchmarkWithMsgPackEncode_Generic_Msgpack
BenchmarkWithMsgPackEncode_Generic_Msgpack-256             68619         17696 ns/op       16581 B/op          9 allocs/op
BenchmarkWithMsgPackEncode_Binding_Sonic_JSON
BenchmarkWithMsgPackEncode_Binding_Sonic_JSON-256         237344          4880 ns/op        9851 B/op          2 allocs/op
BenchmarkWithMsgPackEncode_Binding_Msgpack
BenchmarkWithMsgPackEncode_Binding_Msgpack-256             96565         12427 ns/op       16468 B/op          9 allocs/op
PASS
ok      github.com/bytedance/sonic/external_jsonlib_test/benchmark_test 11.309s
```