### PR TITLE
opt: ast node set

### DIFF
--- a/external_jsonlib_test/benchmark_test/ast_set_benchmark_test.go
+++ b/external_jsonlib_test/benchmark_test/ast_set_benchmark_test.go
@@ -1,0 +1,29 @@
+package benchmark_test
+
+import (
+	"strconv"
+	"testing"
+
+	simplejson "github.com/bitly/go-simplejson"
+	"github.com/bytedance/sonic/ast"
+)
+
+func BenchmarkBuildObject_SonicAST_Original(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		root := ast.NewNull()
+		for j := 0; j < 100; j++ {
+			if _, err := root.Set(strconv.Itoa(j), ast.NewString("123321")); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkBuildObject_Simplejson(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		root := simplejson.New()
+		for j := 0; j < 100; j++ {
+			root.Set(strconv.Itoa(j), "123321")
+		}
+	}
+}

--- a/external_jsonlib_test/go.mod
+++ b/external_jsonlib_test/go.mod
@@ -3,6 +3,7 @@ module github.com/bytedance/sonic/external_jsonlib_test
 go 1.18
 
 require (
+	github.com/bitly/go-simplejson v0.5.1
 	github.com/buger/jsonparser v1.1.1
 	github.com/bytedance/sonic v1.11.5-alpha3
 	github.com/goccy/go-json v0.9.11

--- a/external_jsonlib_test/go.sum
+++ b/external_jsonlib_test/go.sum
@@ -1,3 +1,5 @@
+github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
+github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=

--- a/go.work.sum
+++ b/go.work.sum
@@ -2,10 +2,8 @@ github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4
 github.com/bytedance/sonic/loader v0.2.3/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
+github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
+github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
-golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=


### PR DESCRIPTION
origin:
```
goos: linux
goarch: amd64
pkg: github.com/bytedance/sonic/external_jsonlib_test/benchmark_test
cpu: AMD EPYC 9Y25 128-Core Processor               
BenchmarkBuildObject_SonicAST_Original-256         61124             19610 ns/op           10522 B/op        112 allocs/op
BenchmarkBuildObject_Simplejson-256               176790              6742 ns/op           10171 B/op          9 allocs/op
```

new:
```
goos: linux
goarch: amd64
pkg: github.com/bytedance/sonic/external_jsonlib_test/benchmark_test
cpu: AMD EPYC 9Y25 128-Core Processor               
BenchmarkBuildObject_SonicAST_Original-256         72648             16720 ns/op            7321 B/op         12 allocs/op
BenchmarkBuildObject_Simplejson-256               171136              6841 ns/op           10174 B/op          9 allocs/op
```

