### PR TITLE
fix[bsd]: MAP_ANON should be set to -1 , ignored on Linux, required on BSD + go fmt

### DIFF
--- a/loader/mmap_unix.go
+++ b/loader/mmap_unix.go
@@ -20,26 +20,25 @@
 package loader
 
 import (
-    `syscall`
+	"syscall"
 )
 
 const (
-    _AP = syscall.MAP_ANON  | syscall.MAP_PRIVATE
-    _RX = syscall.PROT_READ | syscall.PROT_EXEC
-    _RW = syscall.PROT_READ | syscall.PROT_WRITE
+	_AP = syscall.MAP_ANON | syscall.MAP_PRIVATE
+	_RX = syscall.PROT_READ | syscall.PROT_EXEC
+	_RW = syscall.PROT_READ | syscall.PROT_WRITE
 )
 
-
 func mmap(nb int) uintptr {
-    if m, _, e := syscall.RawSyscall6(syscall.SYS_MMAP, 0, uintptr(nb), _RW, _AP, 0, 0); e != 0 {
-        panic(e)
-    } else {
-        return m
-    }
+	if m, _, e := syscall.RawSyscall6(syscall.SYS_MMAP, 0, uintptr(nb), _RW, _AP, ^uintptr(0), 0); e != 0 {
+		panic(e)
+	} else {
+		return m
+	}
 }
 
 func mprotect(p uintptr, nb int) {
-    if _, _, err := syscall.RawSyscall(syscall.SYS_MPROTECT, p, uintptr(nb), _RX); err != 0 {
-        panic(err)
-    }
+	if _, _, err := syscall.RawSyscall(syscall.SYS_MPROTECT, p, uintptr(nb), _RX); err != 0 {
+		panic(err)
+	}
 }


### PR DESCRIPTION
- fix ( #564 , closed but still present on freebsd )

### Description
This PR fixes a panic occurring on FreeBSD (and potentially macOS/other BSDs) where `mmap` fails with `EINVAL` (invalid argument).

### The Issue
Currently, `mmap_unix.go` passes `0` as the file descriptor (`fd`) when calling `syscall.SYS_MMAP` with `MAP_ANON`.
* **On Linux:** The kernel ignores the `fd` argument for anonymous mappings, so passing `0` works fine.
* **On FreeBSD:** The kernel strictly adheres to POSIX behavior for `MAP_ANON`, which requires the `fd` to be `-1`. Passing `0` results in an immediate crash.

**Panic Output (FreeBSD):**
```text
panic: invalid argument
goroutine 1 [running]:
[github.com/bytedance/sonic/loader.mmap](https://github.com/bytedance/sonic/loader.mmap)(...)
    .../loader/mmap_unix.go:35 +0x7b