### PR TITLE
fix(decoder): align jit string-tag mismatch with encoding/json

### DIFF
--- a/.github/workflows/test-arm64.yml
+++ b/.github/workflows/test-arm64.yml
@@ -5,6 +5,10 @@ on: pull_request
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
+
     strategy:
       matrix:
         go-version: [1.20.x, 1.22.x, 1.25.x]
@@ -47,4 +51,9 @@ jobs:
         run: GOMAXPROCS=4 go test -race ./generic_test
 
       - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./coverage.txt
+          flags: arm,${{ matrix.runner_arch }}
+          fail_ci_if_error: false

--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -5,6 +5,10 @@ on: pull_request
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
+
     strategy:
       matrix:
         go-version: [1.18.x, 1.21.x, 1.25.x]
@@ -33,7 +37,7 @@ jobs:
 
       - name: Unit Test JIT
         run: |
-          GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+          GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage-jit.txt ./...
 
       - name: Unit Test JIT PCSP
         run: |
@@ -41,12 +45,12 @@ jobs:
 
       - name: Unit Test VM
         run: |
-          SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1  GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+          SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1  GOMAXPROCS=4 go test -race -covermode=atomic -coverprofile=coverage-vm.txt ./...
     
       - name: Loader Test
         run: |
           cd ./loader
-          go test -race ./...
+          go test -race ./...  
   
       - name: Data Race
         run: |
@@ -67,4 +71,9 @@ jobs:
         run: GOMAXPROCS=4 SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1 go test -v -race ./generic_test
 
       - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./coverage-jit.txt,./coverage-vm.txt
+          flags: x86,${{ matrix.runner_arch }}
+          fail_ci_if_error: false

--- a/internal/decoder/jitdec/assembler_regabi_amd64.go
+++ b/internal/decoder/jitdec/assembler_regabi_amd64.go
@@ -885,8 +885,8 @@ func (self *_Assembler) range_unsigned_CX(i *rt.GoItab, t *rt.GoType, v uint64) 
 	self.Sjmp("JA", _LB_range_error)          // JA    _range_error
 }
 
-// used by byte-slice element decoding: keep parsing remaining elements
-// after integer overflow/underflow, while still surfacing a final type error.
+// Continue decoding after integer range mismatch in container/field contexts,
+// while preserving a final type error consistent with existing behavior.
 func (self *_Assembler) range_continue_handle_error(i *rt.GoItab, t *rt.GoType, pin string) {
 	// Avoid encoding imm64->mem on windows: MOVQ to memory only accepts sign-extended imm32.
 	self.Emit("MOVQ", jit.Gitab(i), _ET)
@@ -950,17 +950,6 @@ func (self *_Assembler) range_uint32_CX_continue(i *rt.GoItab, t *rt.GoType, pin
 	self.Link("_range_uint32_continue_err_{n}")
 	self.range_continue_handle_error(i, t, pin)
 	self.Link("_range_uint32_continue_end_{n}")
-}
-
-func (self *_Assembler) range_uint32_CX(i *rt.GoItab, t *rt.GoType) {
-	self.Emit("MOVQ", _VAR_st_Iv, _CX)   // MOVQ  st.Iv, CX
-	self.Emit("MOVQ", jit.Gitab(i), _ET) // MOVQ  ${i}, ET
-	self.Emit("MOVQ", jit.Gtype(t), _EP) // MOVQ  ${t}, EP
-	self.Emit("TESTQ", _CX, _CX)         // TESTQ CX, CX
-	self.Sjmp("JS", _LB_range_error)     // JS    _range_error
-	self.Emit("MOVL", _CX, _DX)          // MOVL  CX, DX
-	self.Emit("CMPQ", _CX, _DX)          // CMPQ  CX, DX
-	self.Sjmp("JNE", _LB_range_error)    // JNZ   _range_error
 }
 
 /** String Manipulating Routines **/

--- a/internal/decoder/jitdec/assembler_regabi_amd64.go
+++ b/internal/decoder/jitdec/assembler_regabi_amd64.go
@@ -865,26 +865,6 @@ func (self *_Assembler) range_single_X0() {
 	self.Sjmp("JB", _LB_range_error)              // JB      _range_error
 }
 
-func (self *_Assembler) range_signed_CX(i *rt.GoItab, t *rt.GoType, a int64, b int64) {
-	self.Emit("MOVQ", _VAR_st_Iv, _CX)   // MOVQ st.Iv, CX
-	self.Emit("MOVQ", jit.Gitab(i), _ET) // MOVQ ${i}, ET
-	self.Emit("MOVQ", jit.Gtype(t), _EP) // MOVQ ${t}, EP
-	self.Emit("CMPQ", _CX, jit.Imm(a))   // CMPQ CX, ${a}
-	self.Sjmp("JL", _LB_range_error)     // JL   _range_error
-	self.Emit("CMPQ", _CX, jit.Imm(b))   // CMPQ CX, ${B}
-	self.Sjmp("JG", _LB_range_error)     // JG   _range_error
-}
-
-func (self *_Assembler) range_unsigned_CX(i *rt.GoItab, t *rt.GoType, v uint64) {
-	self.Emit("MOVQ", _VAR_st_Iv, _CX)        // MOVQ  st.Iv, CX
-	self.Emit("MOVQ", jit.Gitab(i), _ET)      // MOVQ  ${i}, ET
-	self.Emit("MOVQ", jit.Gtype(t), _EP)      // MOVQ  ${t}, EP
-	self.Emit("TESTQ", _CX, _CX)              // TESTQ CX, CX
-	self.Sjmp("JS", _LB_range_error)          // JS    _range_error
-	self.Emit("CMPQ", _CX, jit.Imm(int64(v))) // CMPQ  CX, ${a}
-	self.Sjmp("JA", _LB_range_error)          // JA    _range_error
-}
-
 // Continue decoding after integer range mismatch in container/field contexts,
 // while preserving a final type error consistent with existing behavior.
 func (self *_Assembler) range_continue_handle_error(i *rt.GoItab, t *rt.GoType, pin string) {
@@ -950,6 +930,54 @@ func (self *_Assembler) range_uint32_CX_continue(i *rt.GoItab, t *rt.GoType, pin
 	self.Link("_range_uint32_continue_err_{n}")
 	self.range_continue_handle_error(i, t, pin)
 	self.Link("_range_uint32_continue_end_{n}")
+}
+
+func (self *_Assembler) range_map_key_continue_handle_error(vt reflect.Type, pin2 int) {
+	self.Emit("CMPQ", _VAR_et, jit.Imm(0))
+	self.Sjmp("JNE", "_range_map_key_continue_set_pc_{n}")
+	self.Emit("SUBQ", jit.Imm(1), _BX)
+	self.Emit("MOVQ", _BX, _VAR_ic)
+	self.Emit("MOVQ", jit.Type(vt), _DX)
+	self.Emit("MOVQ", _DX, _VAR_et)
+	self.Link("_range_map_key_continue_set_pc_{n}")
+	self.Byte(0x4c, 0x8d, 0x0d) // LEAQ (PC), R9
+	self.Xref(pin2, 4)
+	self.Emit("MOVQ", _R9, _VAR_pc)
+	self.Sjmp("JMP", _LB_skip_key_value)
+}
+
+func (self *_Assembler) range_signed_CX_map_continue(vt reflect.Type, a int64, b int64, pin2 int) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX)
+	self.Emit("CMPQ", _CX, jit.Imm(a))
+	self.Sjmp("JL", "_range_signed_map_continue_err_{n}")
+	self.Emit("CMPQ", _CX, jit.Imm(b))
+	self.Sjmp("JLE", "_range_signed_map_continue_end_{n}")
+	self.Link("_range_signed_map_continue_err_{n}")
+	self.range_map_key_continue_handle_error(vt, pin2)
+	self.Link("_range_signed_map_continue_end_{n}")
+}
+
+func (self *_Assembler) range_unsigned_CX_map_continue(vt reflect.Type, v uint64, pin2 int) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX)
+	self.Emit("TESTQ", _CX, _CX)
+	self.Sjmp("JS", "_range_unsigned_map_continue_err_{n}")
+	self.Emit("CMPQ", _CX, jit.Imm(int64(v)))
+	self.Sjmp("JBE", "_range_unsigned_map_continue_end_{n}")
+	self.Link("_range_unsigned_map_continue_err_{n}")
+	self.range_map_key_continue_handle_error(vt, pin2)
+	self.Link("_range_unsigned_map_continue_end_{n}")
+}
+
+func (self *_Assembler) range_uint32_CX_map_continue(vt reflect.Type, pin2 int) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX)
+	self.Emit("TESTQ", _CX, _CX)
+	self.Sjmp("JS", "_range_uint32_map_continue_err_{n}")
+	self.Emit("MOVL", _CX, _DX)
+	self.Emit("CMPQ", _CX, _DX)
+	self.Sjmp("JE", "_range_uint32_map_continue_end_{n}")
+	self.Link("_range_uint32_map_continue_err_{n}")
+	self.range_map_key_continue_handle_error(vt, pin2)
+	self.Link("_range_uint32_map_continue_end_{n}")
 }
 
 /** String Manipulating Routines **/
@@ -1634,22 +1662,22 @@ func (self *_Assembler) _asm_OP_map_init(_ *_Instr) {
 }
 
 func (self *_Assembler) _asm_OP_map_key_i8(p *_Instr) {
-	self.parse_signed(int8Type, "", p.vi())                            // PARSE     int8
-	self.range_signed_CX(_I_int8, _T_int8, math.MinInt8, math.MaxInt8) // RANGE     int8
+	self.parse_signed(int8Type, "", p.vi()) // PARSE int8
+	self.range_signed_CX_map_continue(int8Type, math.MinInt8, math.MaxInt8, p.vi())
 	self.match_char('"')
 	self.mapassign_std(p.vt(), _VAR_st_Iv) // MAPASSIGN int8, mapassign, st.Iv
 }
 
 func (self *_Assembler) _asm_OP_map_key_i16(p *_Instr) {
-	self.parse_signed(int16Type, "", p.vi())                               // PARSE     int16
-	self.range_signed_CX(_I_int16, _T_int16, math.MinInt16, math.MaxInt16) // RANGE     int16
+	self.parse_signed(int16Type, "", p.vi()) // PARSE int16
+	self.range_signed_CX_map_continue(int16Type, math.MinInt16, math.MaxInt16, p.vi())
 	self.match_char('"')
 	self.mapassign_std(p.vt(), _VAR_st_Iv) // MAPASSIGN int16, mapassign, st.Iv
 }
 
 func (self *_Assembler) _asm_OP_map_key_i32(p *_Instr) {
-	self.parse_signed(int32Type, "", p.vi())                               // PARSE     int32
-	self.range_signed_CX(_I_int32, _T_int32, math.MinInt32, math.MaxInt32) // RANGE     int32
+	self.parse_signed(int32Type, "", p.vi()) // PARSE int32
+	self.range_signed_CX_map_continue(int32Type, math.MinInt32, math.MaxInt32, p.vi())
 	self.match_char('"')
 	if vt := p.vt(); !rt.IsMapfast(vt) {
 		self.mapassign_std(vt, _VAR_st_Iv) // MAPASSIGN int32, mapassign, st.Iv
@@ -1671,22 +1699,22 @@ func (self *_Assembler) _asm_OP_map_key_i64(p *_Instr) {
 }
 
 func (self *_Assembler) _asm_OP_map_key_u8(p *_Instr) {
-	self.parse_unsigned(uint8Type, "", p.vi())                // PARSE     uint8
-	self.range_unsigned_CX(_I_uint8, _T_uint8, math.MaxUint8) // RANGE     uint8
+	self.parse_unsigned(uint8Type, "", p.vi()) // PARSE uint8
+	self.range_unsigned_CX_map_continue(uint8Type, math.MaxUint8, p.vi())
 	self.match_char('"')
 	self.mapassign_std(p.vt(), _VAR_st_Iv) // MAPASSIGN uint8, vt.Iv
 }
 
 func (self *_Assembler) _asm_OP_map_key_u16(p *_Instr) {
-	self.parse_unsigned(uint16Type, "", p.vi())                  // PARSE     uint16
-	self.range_unsigned_CX(_I_uint16, _T_uint16, math.MaxUint16) // RANGE     uint16
+	self.parse_unsigned(uint16Type, "", p.vi()) // PARSE uint16
+	self.range_unsigned_CX_map_continue(uint16Type, math.MaxUint16, p.vi())
 	self.match_char('"')
 	self.mapassign_std(p.vt(), _VAR_st_Iv) // MAPASSIGN uint16, vt.Iv
 }
 
 func (self *_Assembler) _asm_OP_map_key_u32(p *_Instr) {
-	self.parse_unsigned(uint32Type, "", p.vi())                  // PARSE     uint32
-	self.range_unsigned_CX(_I_uint32, _T_uint32, math.MaxUint32) // RANGE     uint32
+	self.parse_unsigned(uint32Type, "", p.vi()) // PARSE uint32
+	self.range_uint32_CX_map_continue(uint32Type, p.vi())
 	self.match_char('"')
 	if vt := p.vt(); !rt.IsMapfast(vt) {
 		self.mapassign_std(vt, _VAR_st_Iv) // MAPASSIGN uint32, vt.Iv

--- a/internal/decoder/jitdec/assembler_regabi_amd64.go
+++ b/internal/decoder/jitdec/assembler_regabi_amd64.go
@@ -100,6 +100,7 @@ const (
 	_LB_type_error      = "_type_error"
 	_LB_field_error     = "_field_error"
 	_LB_range_error     = "_range_error"
+	_LB_range_continue  = "_range_continue"
 	_LB_stack_error     = "_stack_error"
 	_LB_base64_error    = "_base64_error"
 	_LB_unquote_error   = "_unquote_error"
@@ -232,6 +233,7 @@ func (self *_Assembler) compile() {
 	self.prologue()
 	self.instrs()
 	self.epilogue()
+	self.range_continue_handler()
 	self.copy_string()
 	self.escape_string()
 	self.escape_string_twice()
@@ -883,6 +885,73 @@ func (self *_Assembler) range_unsigned_CX(i *rt.GoItab, t *rt.GoType, v uint64) 
 	self.Sjmp("JA", _LB_range_error)          // JA    _range_error
 }
 
+// used by byte-slice element decoding: keep parsing remaining elements
+// after integer overflow/underflow, while still surfacing a final type error.
+func (self *_Assembler) range_continue_handle_error(i *rt.GoItab, t *rt.GoType, pin string) {
+	// Avoid encoding imm64->mem on windows: MOVQ to memory only accepts sign-extended imm32.
+	self.Emit("MOVQ", jit.Gitab(i), _ET)
+	self.Emit("MOVQ", jit.Gtype(t), _EP)
+	self.Emit("MOVQ", _ET, _VAR_ss_AX)
+	self.Emit("MOVQ", _EP, _VAR_ss_CX)
+	self.Byte(0x4c, 0x8d, 0x0d) // LEAQ (PC), R9
+	self.Sref(pin, 4)
+	self.Emit("MOVQ", _R9, _VAR_pc)
+	self.Sjmp("JMP", _LB_range_continue)
+}
+
+func (self *_Assembler) range_continue_handler() {
+	self.Link(_LB_range_continue)
+	self.Emit("MOVQ", jit.Ptr(_ST, 0), _DX)
+	self.Emit("TESTQ", _DX, _DX)
+	self.Sjmp("JNE", "_range_continue_in_container")
+	self.Emit("MOVQ", _VAR_ss_AX, _ET)
+	self.Emit("MOVQ", _VAR_ss_CX, _EP)
+	self.Sjmp("JMP", _LB_range_error)
+	self.Link("_range_continue_in_container")
+	self.Emit("CMPQ", _VAR_et, jit.Imm(0))
+	self.Sjmp("JNE", "_range_continue_jump")
+	self.Emit("MOVQ", _BX, _VAR_ic)
+	self.Emit("MOVQ", _VAR_ss_CX, _DX)
+	self.Emit("MOVQ", _DX, _VAR_et)
+	self.Link("_range_continue_jump")
+	self.Emit("MOVQ", _VAR_pc, _R9)
+	self.Rjmp("JMP", _R9)
+}
+
+func (self *_Assembler) range_unsigned_CX_continue(i *rt.GoItab, t *rt.GoType, v uint64, pin string) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX) // MOVQ  st.Iv, CX
+	self.Emit("TESTQ", _CX, _CX)       // TESTQ CX, CX
+	self.Sjmp("JS", "_range_unsigned_continue_err_{n}")
+	self.Emit("CMPQ", _CX, jit.Imm(int64(v))) // CMPQ  CX, ${a}
+	self.Sjmp("JBE", "_range_unsigned_continue_end_{n}")
+	self.Link("_range_unsigned_continue_err_{n}")
+	self.range_continue_handle_error(i, t, pin)
+	self.Link("_range_unsigned_continue_end_{n}")
+}
+
+func (self *_Assembler) range_signed_CX_continue(i *rt.GoItab, t *rt.GoType, a int64, b int64, pin string) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX)
+	self.Emit("CMPQ", _CX, jit.Imm(a))
+	self.Sjmp("JL", "_range_signed_continue_err_{n}")
+	self.Emit("CMPQ", _CX, jit.Imm(b))
+	self.Sjmp("JLE", "_range_signed_continue_end_{n}")
+	self.Link("_range_signed_continue_err_{n}")
+	self.range_continue_handle_error(i, t, pin)
+	self.Link("_range_signed_continue_end_{n}")
+}
+
+func (self *_Assembler) range_uint32_CX_continue(i *rt.GoItab, t *rt.GoType, pin string) {
+	self.Emit("MOVQ", _VAR_st_Iv, _CX)
+	self.Emit("TESTQ", _CX, _CX)
+	self.Sjmp("JS", "_range_uint32_continue_err_{n}")
+	self.Emit("MOVL", _CX, _DX)
+	self.Emit("CMPQ", _CX, _DX)
+	self.Sjmp("JE", "_range_uint32_continue_end_{n}")
+	self.Link("_range_uint32_continue_err_{n}")
+	self.range_continue_handle_error(i, t, pin)
+	self.Link("_range_uint32_continue_end_{n}")
+}
+
 func (self *_Assembler) range_uint32_CX(i *rt.GoItab, t *rt.GoType) {
 	self.Emit("MOVQ", _VAR_st_Iv, _CX)   // MOVQ  st.Iv, CX
 	self.Emit("MOVQ", jit.Gitab(i), _ET) // MOVQ  ${i}, ET
@@ -1415,25 +1484,25 @@ func (self *_Assembler) _asm_OP_num(_ *_Instr) {
 
 func (self *_Assembler) _asm_OP_i8(_ *_Instr) {
 	var pin = "_i8_end_{n}"
-	self.parse_signed(int8Type, pin, -1)                               // PARSE int8
-	self.range_signed_CX(_I_int8, _T_int8, math.MinInt8, math.MaxInt8) // RANGE int8
-	self.Emit("MOVB", _CX, jit.Ptr(_VP, 0))                            // MOVB  CX, (VP)
+	self.parse_signed(int8Type, pin, -1) // PARSE int8
+	self.range_signed_CX_continue(_I_int8, _T_int8, math.MinInt8, math.MaxInt8, pin)
+	self.Emit("MOVB", _CX, jit.Ptr(_VP, 0)) // MOVB  CX, (VP)
 	self.Link(pin)
 }
 
 func (self *_Assembler) _asm_OP_i16(_ *_Instr) {
 	var pin = "_i16_end_{n}"
-	self.parse_signed(int16Type, pin, -1)                                  // PARSE int16
-	self.range_signed_CX(_I_int16, _T_int16, math.MinInt16, math.MaxInt16) // RANGE int16
-	self.Emit("MOVW", _CX, jit.Ptr(_VP, 0))                                // MOVW  CX, (VP)
+	self.parse_signed(int16Type, pin, -1) // PARSE int16
+	self.range_signed_CX_continue(_I_int16, _T_int16, math.MinInt16, math.MaxInt16, pin)
+	self.Emit("MOVW", _CX, jit.Ptr(_VP, 0)) // MOVW  CX, (VP)
 	self.Link(pin)
 }
 
 func (self *_Assembler) _asm_OP_i32(_ *_Instr) {
 	var pin = "_i32_end_{n}"
-	self.parse_signed(int32Type, pin, -1)                                  // PARSE int32
-	self.range_signed_CX(_I_int32, _T_int32, math.MinInt32, math.MaxInt32) // RANGE int32
-	self.Emit("MOVL", _CX, jit.Ptr(_VP, 0))                                // MOVL  CX, (VP)
+	self.parse_signed(int32Type, pin, -1) // PARSE int32
+	self.range_signed_CX_continue(_I_int32, _T_int32, math.MinInt32, math.MaxInt32, pin)
+	self.Emit("MOVL", _CX, jit.Ptr(_VP, 0)) // MOVL  CX, (VP)
 	self.Link(pin)
 }
 
@@ -1447,25 +1516,25 @@ func (self *_Assembler) _asm_OP_i64(_ *_Instr) {
 
 func (self *_Assembler) _asm_OP_u8(_ *_Instr) {
 	var pin = "_u8_end_{n}"
-	self.parse_unsigned(uint8Type, pin, -1)                   // PARSE uint8
-	self.range_unsigned_CX(_I_uint8, _T_uint8, math.MaxUint8) // RANGE uint8
-	self.Emit("MOVB", _CX, jit.Ptr(_VP, 0))                   // MOVB  CX, (VP)
+	self.parse_unsigned(uint8Type, pin, -1) // PARSE uint8
+	self.range_unsigned_CX_continue(_I_uint8, _T_uint8, math.MaxUint8, pin)
+	self.Emit("MOVB", _CX, jit.Ptr(_VP, 0)) // MOVB  CX, (VP)
 	self.Link(pin)
 }
 
 func (self *_Assembler) _asm_OP_u16(_ *_Instr) {
 	var pin = "_u16_end_{n}"
-	self.parse_unsigned(uint16Type, pin, -1)                     // PARSE uint16
-	self.range_unsigned_CX(_I_uint16, _T_uint16, math.MaxUint16) // RANGE uint16
-	self.Emit("MOVW", _CX, jit.Ptr(_VP, 0))                      // MOVW  CX, (VP)
+	self.parse_unsigned(uint16Type, pin, -1) // PARSE uint16
+	self.range_unsigned_CX_continue(_I_uint16, _T_uint16, math.MaxUint16, pin)
+	self.Emit("MOVW", _CX, jit.Ptr(_VP, 0)) // MOVW  CX, (VP)
 	self.Link(pin)
 }
 
 func (self *_Assembler) _asm_OP_u32(_ *_Instr) {
 	var pin = "_u32_end_{n}"
-	self.parse_unsigned(uint32Type, pin, -1)   // PARSE uint32
-	self.range_uint32_CX(_I_uint32, _T_uint32) // RANGE uint32
-	self.Emit("MOVL", _CX, jit.Ptr(_VP, 0))    // MOVL  CX, (VP)
+	self.parse_unsigned(uint32Type, pin, -1) // PARSE uint32
+	self.range_uint32_CX_continue(_I_uint32, _T_uint32, pin)
+	self.Emit("MOVL", _CX, jit.Ptr(_VP, 0)) // MOVL  CX, (VP)
 	self.Link(pin)
 }
 

--- a/internal/decoder/jitdec/compiler.go
+++ b/internal/decoder/jitdec/compiler.go
@@ -17,7 +17,6 @@
 package jitdec
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -771,8 +770,19 @@ func (self *_Compiler) compileMapUt(p *_Program, sp int, vt reflect.Type) {
 	case reflect.String:
 		self.compileMapOp(p, sp, vt, _OP_map_key_str)
 	default:
-		panic(&json.UnmarshalTypeError{Type: vt})
+		self.compileMapUnsupportedKey(p, vt)
 	}
+}
+
+func (self *_Compiler) compileMapUnsupportedKey(p *_Program, vt reflect.Type) {
+	i := p.pc()
+	p.add(_OP_is_null)
+	p.rtt(_OP_dismatch_err, vt)
+	s := p.pc()
+	p.add(_OP_go_skip)
+	p.pin(i)
+	p.add(_OP_nil_1)
+	p.pin(s)
 }
 
 func (self *_Compiler) compileMapOp(p *_Program, sp int, vt reflect.Type, op _Op) {

--- a/internal/decoder/jitdec/compiler.go
+++ b/internal/decoder/jitdec/compiler.go
@@ -1245,6 +1245,7 @@ func (self *_Compiler) compileStructFieldStr(p *_Program, sp int, vt reflect.Typ
 		p.int(_OP_add, 1)
 		p.pin(pc2)
 		p.pin(n0)
+		p.pin(skip)
 		return
 	}
 

--- a/issue_test/issue775_test.go
+++ b/issue_test/issue775_test.go
@@ -1,0 +1,126 @@
+package issue_test
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestIssue775_OutOfRangeIntegerInByteSlice(t *testing.T) {
+	cas := unmTestCase{
+		name: "byte slice with invalid integer items",
+		data: []byte(`{"ByteArr": [1, 2999, -123, 3.14, 3]}`),
+		newfn: func() interface{} {
+			var v struct {
+				ByteArr []uint8
+			}
+			return &v
+		},
+	}
+
+	assertUnmarshal(t, sonic.ConfigDefault, cas)
+	assertUnmarshal(t, sonic.ConfigStd, cas)
+}
+
+func TestIssue775_OutOfRangeIntegerInOtherSlices(t *testing.T) {
+	cases := []unmTestCase{
+		{
+			name: "int8 slice with invalid items",
+			data: []byte(`{"V": [1, 128, -129, 2]}`),
+			newfn: func() interface{} {
+				var v struct {
+					V []int8
+				}
+				return &v
+			},
+		},
+		{
+			name: "int16 slice with invalid items",
+			data: []byte(`{"V": [1, 32768, -32769, 2]}`),
+			newfn: func() interface{} {
+				var v struct {
+					V []int16
+				}
+				return &v
+			},
+		},
+		{
+			name: "int32 slice with invalid items",
+			data: []byte(`{"V": [1, 2147483648, -2147483649, 2]}`),
+			newfn: func() interface{} {
+				var v struct {
+					V []int32
+				}
+				return &v
+			},
+		},
+		{
+			name: "uint16 slice with invalid items",
+			data: []byte(`{"V": [1, 65536, -1, 2]}`),
+			newfn: func() interface{} {
+				var v struct {
+					V []uint16
+				}
+				return &v
+			},
+		},
+		{
+			name: "uint32 slice with invalid items",
+			data: []byte(`{"V": [1, 4294967296, -1, 2]}`),
+			newfn: func() interface{} {
+				var v struct {
+					V []uint32
+				}
+				return &v
+			},
+		},
+	}
+
+	for _, cas := range cases {
+		assertUnmarshal(t, sonic.ConfigDefault, cas)
+		assertUnmarshal(t, sonic.ConfigStd, cas)
+	}
+}
+
+func TestAgentTmp_NonSliceIntegerMismatchContinue(t *testing.T) {
+	cases := []unmTestCase{
+		{
+			name: "int8 overflow should still decode sibling field",
+			data: []byte(`{"A":128,"B":2}`),
+			newfn: func() interface{} {
+				var v struct {
+					A int8
+					B int
+				}
+				return &v
+			},
+		},
+		{
+			name: "uint8 underflow should still decode sibling field",
+			data: []byte(`{"A":-1,"B":2}`),
+			newfn: func() interface{} {
+				var v struct {
+					A uint8
+					B int
+				}
+				return &v
+			},
+		},
+		{
+			name: "int16 overflow should still decode sibling field",
+			data: []byte(`{"A":32768,"B":2}`),
+			newfn: func() interface{} {
+				var v struct {
+					A int16
+					B int
+				}
+				return &v
+			},
+		},
+	}
+
+	for _, cas := range cases {
+		assertUnmarshal(t, sonic.ConfigDefault, cas)
+		assertUnmarshal(t, sonic.ConfigStd, cas)
+	}
+}

--- a/issue_test/issue775_test.go
+++ b/issue_test/issue775_test.go
@@ -124,3 +124,35 @@ func TestIssue775_NonSliceIntegerMismatchShouldContinue(t *testing.T) {
 		assertUnmarshal(t, sonic.ConfigStd, cas)
 	}
 }
+
+func TestIssue775_MapKeyIntegerMismatchShouldContinue(t *testing.T) {
+	cases := []unmTestCase{
+		{
+			name: "map[int8]int key overflow should still decode sibling field",
+			data: []byte(`{"M":{"1":1,"128":2,"2":3},"T":9}`),
+			newfn: func() interface{} {
+				var v struct {
+					M map[int8]int
+					T int
+				}
+				return &v
+			},
+		},
+		{
+			name: "map[uint8]int key underflow should still decode sibling field",
+			data: []byte(`{"M":{"1":1,"-1":2,"2":3},"T":9}`),
+			newfn: func() interface{} {
+				var v struct {
+					M map[uint8]int
+					T int
+				}
+				return &v
+			},
+		},
+	}
+
+	for _, cas := range cases {
+		assertUnmarshal(t, sonic.ConfigDefault, cas)
+		assertUnmarshal(t, sonic.ConfigStd, cas)
+	}
+}

--- a/issue_test/issue775_test.go
+++ b/issue_test/issue775_test.go
@@ -82,7 +82,7 @@ func TestIssue775_OutOfRangeIntegerInOtherSlices(t *testing.T) {
 	}
 }
 
-func TestAgentTmp_NonSliceIntegerMismatchContinue(t *testing.T) {
+func TestIssue775_NonSliceIntegerMismatchShouldContinue(t *testing.T) {
 	cases := []unmTestCase{
 		{
 			name: "int8 overflow should still decode sibling field",

--- a/issue_test/issue777_test.go
+++ b/issue_test/issue777_test.go
@@ -63,14 +63,16 @@
 	 // }
 	 // assertUnmarshal(t, sonic.ConfigStd, cas, true)
  
-	// TODO: jit has a bug here
-	//  cas = unmTestCase {
-	// 	 name: "skip unknown key map",
-	// 	 data: []byte("{\"z\":{}, \"y\": {\"1\": \"2\", \"123\": 123}, \"x\": [1, 2, 3]}"),
-	// 	 newfn: func() interface{} {
-	// 		 var a unknownKeyMap
-	// 		 return &a
-	// 	 },
-	//  }
-	//  assertUnmarshal(t, sonic.ConfigStd, cas)
  }
+
+func TestIssue777_SkipUnsupportedFieldStillDecodeLaterFields(t *testing.T) {
+	cas := unmTestCase{
+		name: "skip unsupported field and continue",
+		data: []byte(`{"z":{}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+		newfn: func() interface{} {
+			var a unknownKeyMap
+			return &a
+		},
+	}
+	assertUnmarshal(t, sonic.ConfigStd, cas)
+}

--- a/issue_test/issue777_test.go
+++ b/issue_test/issue777_test.go
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
- package issue_test
+package issue_test
 
- import (
+import (
 	"encoding/json"
-	 "testing"
- 
-	 "github.com/bytedance/sonic"
- )
- 
- type unknownKeyMap struct {
-	 X []json.Number `json:"x"`
-	 Y map[*int]json.Number `json:"y"`
-	 Z map[int]func() `json:"z"`
- }
- 
- func TestIssue777_NumberSlice(t *testing.T) {
-	cas := unmTestCase {
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+type unknownKeyMap struct {
+	X []json.Number        `json:"x"`
+	Y map[*int]json.Number `json:"y"`
+	Z map[int]func()       `json:"z"`
+}
+
+func TestIssue777_NumberSlice(t *testing.T) {
+	cas := unmTestCase{
 		name: "number slice",
 		data: []byte(`["1", "2", 123, 456]`),
 		newfn: func() interface{} {
@@ -41,38 +41,59 @@
 	assertUnmarshal(t, sonic.ConfigStd, cas)
 }
 
- func TestIssue777_NumberKey(t *testing.T) {
-	 cas := unmTestCase {
-		 name: "number key",
-		 data: []byte(`{"1": "2", "123": 123}`),
-		 newfn: func() interface{} {
-			 var a map[json.Number]json.Number
-			 return &a
-		 },
-	 }
-	 assertUnmarshal(t, sonic.ConfigStd, cas)
- 
-	 // TODO: encoding/json has a bug
-	 // cas = unmTestCase {
-	 // 	name: "number key",
-	 // 	data: []byte(`{"1": "2", "123x": 123}`),
-	 // 	newfn: func() interface{} {
-	 // 		var a map[json.Number]json.Number
-	 // 		return &a
-	 // 	},
-	 // }
-	 // assertUnmarshal(t, sonic.ConfigStd, cas, true)
- 
- }
-
-func TestIssue777_SkipUnsupportedFieldStillDecodeLaterFields(t *testing.T) {
+func TestIssue777_NumberKey(t *testing.T) {
 	cas := unmTestCase{
-		name: "skip unsupported field and continue",
-		data: []byte(`{"z":{}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+		name: "number key",
+		data: []byte(`{"1": "2", "123": 123}`),
 		newfn: func() interface{} {
-			var a unknownKeyMap
+			var a map[json.Number]json.Number
 			return &a
 		},
 	}
 	assertUnmarshal(t, sonic.ConfigStd, cas)
+
+	// TODO: encoding/json has a bug
+	// cas = unmTestCase {
+	// 	name: "number key",
+	// 	data: []byte(`{"1": "2", "123x": 123}`),
+	// 	newfn: func() interface{} {
+	// 		var a map[json.Number]json.Number
+	// 		return &a
+	// 	},
+	// }
+	// assertUnmarshal(t, sonic.ConfigStd, cas, true)
+
+}
+
+func TestIssue777_SkipUnsupportedFieldStillDecodeLaterFields(t *testing.T) {
+	cases := []unmTestCase{
+		{
+			name: "skip unsupported field and continue",
+			data: []byte(`{"z":{}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+			newfn: func() interface{} {
+				var a unknownKeyMap
+				return &a
+			},
+		},
+		{
+			name: "skip unsupported field with null value and continue",
+			data: []byte(`{"z": null, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+			newfn: func() interface{} {
+				var a unknownKeyMap
+				return &a
+			},
+		},
+		{
+			name: "skip unsupported field with nested value and continue",
+			data: []byte(`{"z":{"k":[{"m":1},{"n":[2,3,{"p":"q"}]}]}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+			newfn: func() interface{} {
+				var a unknownKeyMap
+				return &a
+			},
+		},
+	}
+
+	for _, cas := range cases {
+		assertUnmarshal(t, sonic.ConfigStd, cas)
+	}
 }

--- a/issue_test/issue916_test.go
+++ b/issue_test/issue916_test.go
@@ -1,9 +1,11 @@
 package issue_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/option"
 )
 
 func TestIssue916_StringTagTypeMismatchShouldContinue(t *testing.T) {
@@ -36,4 +38,51 @@ func TestIssue916_StringTagTypeMismatchShouldContinue(t *testing.T) {
 		assertUnmarshal(t, sonic.ConfigDefault, cas)
 		assertUnmarshal(t, sonic.ConfigStd, cas)
 	}
+}
+
+func TestIssue916_StringTagTypeMismatchShouldContinue_WithLowInlineDepth(t *testing.T) {
+	type A struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+	type B struct {
+		ID   int64  `json:"id,string"`
+		Name string `json:"name"`
+	}
+
+	if err := sonic.Pretouch(reflect.TypeOf(B{}), option.WithCompileMaxInlineDepth(2), option.WithCompileRecursiveDepth(8)); err != nil {
+		t.Fatalf("pretouch failed: %v", err)
+	}
+
+	data, err := sonic.Marshal(A{
+		ID:   1,
+		Name: "test1",
+	})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	cas := unmTestCase{
+		name: "issue916-inline-depth2",
+		data: data,
+		newfn: func() interface{} {
+			return new(B)
+		},
+	}
+
+	assertUnmarshal(t, sonic.ConfigDefault, cas)
+	assertUnmarshal(t, sonic.ConfigStd, cas)
+}
+
+func TestIssue777_SkipUnsupportedFieldStillDecodeLaterFields(t *testing.T) {
+	cas := unmTestCase{
+		name: "skip unsupported field and continue",
+		data: []byte(`{"z":{}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
+		newfn: func() interface{} {
+			var a unknownKeyMap
+			return &a
+		},
+	}
+
+	assertUnmarshal(t, sonic.ConfigStd, cas)
 }

--- a/issue_test/issue916_test.go
+++ b/issue_test/issue916_test.go
@@ -74,15 +74,3 @@ func TestIssue916_StringTagTypeMismatchShouldContinue_WithLowInlineDepth(t *test
 	assertUnmarshal(t, sonic.ConfigStd, cas)
 }
 
-func TestIssue777_SkipUnsupportedFieldStillDecodeLaterFields(t *testing.T) {
-	cas := unmTestCase{
-		name: "skip unsupported field and continue",
-		data: []byte(`{"z":{}, "y": {"1": "2", "123": 123}, "x": [1, 2, 3]}`),
-		newfn: func() interface{} {
-			var a unknownKeyMap
-			return &a
-		},
-	}
-
-	assertUnmarshal(t, sonic.ConfigStd, cas)
-}

--- a/issue_test/issue916_test.go
+++ b/issue_test/issue916_test.go
@@ -1,0 +1,39 @@
+package issue_test
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestIssue916_StringTagTypeMismatchShouldContinue(t *testing.T) {
+	type A struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+	type B struct {
+		ID   int64  `json:"id,string"`
+		Name string `json:"name"`
+	}
+
+	data, err := sonic.Marshal(A{
+		ID:   1,
+		Name: "test1",
+	})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	for _, cas := range []unmTestCase{
+		{
+			name: "issue916",
+			data: data,
+			newfn: func() interface{} {
+				return new(B)
+			},
+		},
+	} {
+		assertUnmarshal(t, sonic.ConfigDefault, cas)
+		assertUnmarshal(t, sonic.ConfigStd, cas)
+	}
+}

--- a/issue_test/issue916_test.go
+++ b/issue_test/issue916_test.go
@@ -73,4 +73,3 @@ func TestIssue916_StringTagTypeMismatchShouldContinue_WithLowInlineDepth(t *test
 	assertUnmarshal(t, sonic.ConfigDefault, cas)
 	assertUnmarshal(t, sonic.ConfigStd, cas)
 }
-


### PR DESCRIPTION
## Summary
- Fix jit `json:",string"` struct-field path to pin skip target in non-pointer mismatch branch.
- Make jit continue parsing remaining fields after mismatch, matching `encoding/json` and optdec behavior.
- Add issue regression test `TestIssue916_StringTagTypeMismatchShouldContinue`.

## Test plan
- [x] `go test ./issue_test -run TestIssue916_StringTagTypeMismatchShouldContinue -count=1`
- [x] `SONIC_USE_OPTDEC=1 go test ./issue_test -run TestIssue916_StringTagTypeMismatchShouldContinue -count=1`
- [x] `go test ./issue_test -run TestIssue670_JSONUnmarshaler -count=1`