### PR TITLE
fix(loader): encode initial pcdata safe value

### DIFF
--- a/loader/pcdata.go
+++ b/loader/pcdata.go
@@ -71,13 +71,14 @@ func (self Pcdata) MarshalBinary() (data []byte, err error) {
     sv := int32(_PCDATA_START_VAL)
     sp := uint32(0)
     buf := make([]byte, binary.MaxVarintLen32)
+    started := false
     for _, v := range self {
         if v.PC < sp {
             panic("PC must be in ascending order!")
         }
         dp := uint64(v.PC - sp)
         dv := int64(v.Val - sv)
-        if dv == 0 || dp == 0 {
+        if dp == 0 || (dv == 0 && started) {
             continue
         }
         n := binary.PutVarint(buf, dv)
@@ -86,6 +87,7 @@ func (self Pcdata) MarshalBinary() (data []byte, err error) {
         data = append(data, buf[:n2]...)
         sp = v.PC
         sv = v.Val
+        started = true
     }
     // put 0 to indicate ends
     data = append(data, 0)

--- a/loader/pcdata_test.go
+++ b/loader/pcdata_test.go
@@ -1,0 +1,42 @@
+package loader
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPcdataMarshalBinarySingleSafeEntry(t *testing.T) {
+	data, err := (Pcdata{{PC: 32, Val: PCDATA_UnsafePointSafe}}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte{0, 32, 0}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("unexpected encoded table: got %x want %x", data, want)
+	}
+}
+
+func TestPcdataMarshalBinarySingleUnsafeEntry(t *testing.T) {
+	data, err := (Pcdata{{PC: 32, Val: PCDATA_UnsafePointUnsafe}}).MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte{1, 32, 0}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("unexpected encoded table: got %x want %x", data, want)
+	}
+}
+
+func TestBuildLoadFuncNoPreemptEncodesSafeUnsafePoint(t *testing.T) {
+	fn := buildLoadFunc(false, LoadOneItem{FuncName: "spin"}, 32, 0)
+
+	data, err := fn.PcUnsafePoint.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) <= 1 {
+		t.Fatalf("encoded unsafe-point table has no entries: %x", data)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. Not required for this loader metadata correctness fix.

#### (Optional) Translate the PR title into Chinese.
fix(loader): 编码初始 pcdata safe 值

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
This PR fixes a loader pcdata encoder edge case where a single entry whose value equals the runtime pcdata start value (-1) was skipped entirely. In particular, Loader.LoadOne/LoadMany with NoPreempt left as false builds a PcUnsafePoint table containing one PCDATA_UnsafePointSafe entry. Before this change, MarshalBinary encoded that table as only the trailing terminator byte, so the runtime async-preempt path could hit an invalid pc-encoded table.

The fix allows the first emitted pcdata record to carry a zero value delta, which matches the runtime decoder behavior for the first pcdata step. Later zero value deltas are still skipped so the terminator encoding remains unambiguous. The PR also adds regression coverage for the single safe-entry encoding and the LoadOne/LoadMany helper path.

zh(optional):
修复 loader pcdata 编码的边界情况：当首条记录的值等于 runtime pcdata 初始值 -1 时，之前会被 dv == 0 逻辑跳过，导致 NoPreempt=false 生成的 PcUnsafePoint 表只剩 terminator。现在允许首条实际发出的记录使用零 value delta，同时保留后续 dv == 0 的跳过逻辑，避免和 terminator 语义冲突。

Validation:
- go test ./... (from loader/)
- go test ./...
- SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1 go test ./... -count=1

#### (Optional) Which issue(s) this PR fixes:
Fixes #939

#### (optional) The PR that updates user documentation:
Not required.
