### PR TITLE
feat(loader): support Go 1.27

### DIFF
--- a/.github/workflows/compatibility_test.yml
+++ b/.github/workflows/compatibility_test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x, 1.25.x]
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clear repository

--- a/.github/workflows/test-arm64.yml
+++ b/.github/workflows/test-arm64.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.22.x, 1.25.x]
-        runner_arch: [ubuntu-24.04-arm, macos-latest]
+        runner_arch: [ubuntu-24.04-arm, macos-15]
 
     runs-on: ${{ matrix.runner_arch }}
     

--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -4,6 +4,33 @@ name: Unit Test
 on: pull_request
 
 jobs:
+  loader-go127:
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, windows-latest, macos-15-intel]
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go 1.27
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.0-rc.2'
+          cache: true
+          cache-dependency-path: loader/go.sum
+
+      - name: Loader Test
+        working-directory: loader
+        env:
+          GOWORK: "off"
+        run: go test -race ./... -count=1
+
   build:
     permissions:
       contents: read

--- a/loader/funcdata_compat.go
+++ b/loader/funcdata_compat.go
@@ -1,5 +1,5 @@
-//go:build !go1.17 || go1.27
-// +build !go1.17 go1.27
+//go:build !go1.17
+// +build !go1.17
 
 /*
  * Copyright 2021 ByteDance Inc.

--- a/loader/funcdata_go127.go
+++ b/loader/funcdata_go127.go
@@ -1,0 +1,130 @@
+//go:build go1.27 && !go1.28
+// +build go1.27,!go1.28
+
+/*
+ * Copyright 2021 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loader
+
+import (
+	"unsafe"
+
+	"github.com/bytedance/sonic/loader/internal/rt"
+)
+
+const (
+	_Magic uint32 = 0xFFFFFFF1
+)
+
+// In Go 1.27 the moduledata layout changed around the type/itab linker rework:
+//   - `types, etypes` gained a `typedesclen` field in between;
+//   - `itaboffset, itabsize` were added after etypes;
+//   - the `typelinks []int32` and `itablinks []*itab` slices were removed;
+//   - `typemap` was retyped from map[typeOff]*_type to map[*_type]*_type.
+//
+// See runtime/symtab.go in the go1.27 release branch.
+type moduledata struct {
+	pcHeader     *pcHeader
+	funcnametab  []byte
+	cutab        []uint32
+	filetab      []byte
+	pctab        []byte
+	pclntable    []byte
+	ftab         []funcTab
+	findfunctab  uintptr
+	minpc, maxpc uintptr // first func address, last func address + last func size
+
+	text, etext                uintptr // start/end of text, (etext-text) must be greater than MIN_FUNC
+	noptrdata, enoptrdata      uintptr
+	data, edata                uintptr
+	bss, ebss                  uintptr
+	noptrbss, enoptrbss        uintptr
+	covctrs, ecovctrs          uintptr
+	end, gcdata, gcbss         uintptr
+	types, typedesclen, etypes uintptr
+	itaboffset, itabsize       uintptr
+	rodata                     uintptr
+	gofunc                     uintptr // go.func.* is actual funcinfo object in image
+	epclntab                   uintptr
+
+	textsectmap []textSection // see runtime/symtab.go: textAddr()
+
+	ptab []ptabEntry
+
+	pluginpath string
+	pkghashes  []modulehash
+
+	// This slice records the initializing tasks that need to be
+	// done to start up the program. It is built by the linker.
+	inittasks []unsafe.Pointer
+
+	modulename   string
+	modulehashes []modulehash
+
+	hasmain uint8 // 1 if module contains the main function, 0 otherwise
+	bad     bool  // module failed to load and should be ignored
+
+	gcdatamask, gcbssmask bitVector
+
+	typemap map[*rt.GoType]*rt.GoType // *_type to use from previous module
+
+	next *moduledata
+}
+
+type _func struct {
+	entryOff uint32 // start pc, as offset from moduledata.text/pcHeader.textStart
+	nameOff  int32  // function name, as index into moduledata.funcnametab.
+
+	args        int32  // in/out args size
+	deferreturn uint32 // offset of start of a deferreturn call instruction from entry, if any.
+
+	pcsp      uint32
+	pcfile    uint32
+	pcln      uint32
+	npcdata   uint32
+	cuOffset  uint32 // runtime.cutab offset of this function's CU
+	startLine int32  // line number of start of function (func keyword/TEXT directive)
+	funcID    uint8  // set for certain special runtime functions
+	flag      uint8
+	_         [1]byte // pad
+	nfuncdata uint8   //
+
+	// The end of the struct is followed immediately by two variable-length
+	// arrays that reference the pcdata and funcdata locations for this
+	// function.
+
+	// pcdata contains the offset into moduledata.pctab for the start of
+	// that index's table. e.g.,
+	// &moduledata.pctab[_func.pcdata[_PCDATA_UnsafePoint]] is the start of
+	// the unsafe point table.
+	//
+	// An offset of 0 indicates that there is no table.
+	//
+	// pcdata [npcdata]uint32
+
+	// funcdata contains the offset past moduledata.gofunc which contains a
+	// pointer to that index's funcdata. e.g.,
+	// *(moduledata.gofunc + _func.funcdata[_FUNCDATA_ArgsPointerMaps]) is
+	// the argument pointer map.
+	//
+	// An offset of ^uint32(0) indicates that there is no entry.
+	//
+	// funcdata [nfuncdata]uint32
+}
+
+func setEpclntab(mod *moduledata, val uintptr) {
+	mod.epclntab = val
+}

--- a/loader/go.sum
+++ b/loader/go.sum
@@ -6,10 +6,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/loader/moduledata.go
+++ b/loader/moduledata.go
@@ -1,5 +1,5 @@
-// go:build go1.18 && !go1.27
-// +build go1.18,!go1.27
+//go:build go1.18 && !go1.28
+// +build go1.18,!go1.28
 
 /*
  * Copyright 2021 ByteDance Inc.


### PR DESCRIPTION
## Summary

- add the Go 1.27 runtime `moduledata` and `_func` layouts used by the JIT loader
- keep the existing loader implementation for Go 1.18 through Go 1.27
- test the loader as an independent module with workspace mode disabled

## Motivation

Go 1.27 changes the runtime module metadata layout. Loader v0.5.1 therefore registers an invalid function symbol table and crashes when Sonic JIT code is loaded.

The repository workspace previously masked this release issue by resolving `github.com/bytedance/sonic/loader` to the local `./loader` module. Running the new CI job with `GOWORK=off` verifies the module in the same mode used by downstream consumers.

## Validation

- `GOWORK=off GOTOOLCHAIN=go1.22.5 go test ./... -count=1`
- `GOWORK=off GOTOOLCHAIN=go1.26.3 go test ./... -count=1`
- `GOWORK=off GOTOOLCHAIN=go1.27rc2 go test -race ./... -count=1`
- GitHub Actions runs the Go 1.27 loader module test on Ubuntu, Windows, and Intel macOS

## Follow-up

After this change is merged, publish `loader/v0.5.2`. The main Sonic Go 1.27 PR can then require that version and add a root-module consumer test with workspace mode disabled.
