### PR TITLE
chore: update loader to v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.18
 
 require (
 	github.com/bytedance/gopkg v0.1.3
-	github.com/bytedance/sonic/loader v0.5.1
+	github.com/bytedance/sonic/loader v0.5.2
 	github.com/cloudwego/base64x v0.1.6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/klauspost/cpuid/v2 v2.2.9

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
-github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic/loader v0.5.2 h1:0QtP1gevc1OZ6/H8Lb9BRZiCXd1Ftjd3OKuj1T1lBIo=
+github.com/bytedance/sonic/loader v0.5.2/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

- update the root module dependency from loader v0.5.1 to v0.5.2
- refresh the loader module checksums
- consume the independently published Go 1.27-compatible loader from #965

This dependency-only change is intentionally separate from the root Go 1.27 build-tag and compatibility changes in #957.

## Validation

- `GOWORK=off GOTOOLCHAIN=go1.25.12 go test -race -gcflags="all=-l" ./... -count=1`
- `GOWORK=off GOTOOLCHAIN=go1.25.12 SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1 go test ./... -count=1`
- verified `github.com/bytedance/sonic/loader v0.5.2` resolves from the module cache rather than the workspace module