### PR TITLE
fix(jitdec): prevent GC crashes when decoding full arrays

### DIFF
--- a/ast/search.go
+++ b/ast/search.go
@@ -98,7 +98,7 @@ func (self *Searcher) getByPath(path ...interface{}) (Node, error) {
 	return newRawNode(raw, t, self.ConcurrentRead), nil
 }
 
-// GetByPath searches a path and returns relaction and types of target
+// _GetByPath returns the start and end byte offsets and type of the target node.
 func _GetByPath(src string, path ...interface{}) (start int, end int, typ int, err error) {
 	p := NewParserObj(src)
 	s, e := p.getByPath(false, path...)

--- a/internal/decoder/jitdec/assembler_regabi_amd64.go
+++ b/internal/decoder/jitdec/assembler_regabi_amd64.go
@@ -987,8 +987,12 @@ func (self *_Assembler) mem_clear_rem(size int64, ptrfree bool) {
 	self.Emit("MOVQ", jit.Sib(_ST, _AX, 1, 0), _AX) // MOVQ    (ST)(AX), AX
 	self.Emit("SUBQ", _VP, _AX)                     // SUBQ    VP, AX
 	self.Emit("ADDQ", _AX, _BX)                     // ADDQ    AX, BX
+	// A full array leaves VP one past its end. Even a zero-length pointer
+	// clear can inspect that address in the runtime's write barrier.
+	self.Sjmp("JZ", "_clear_rem_end_{n}")
 	self.Emit("MOVQ", _VP, _AX)                     // MOVQ    VP, (SP)
 	self.mem_clear_fn(ptrfree)                      // CALL_GO memclr{Has,NoHeap}Pointers
+	self.Link("_clear_rem_end_{n}")
 }
 
 /** Map Assigning Routines **/

--- a/issue_test/issue985_test.go
+++ b/issue_test/issue985_test.go
@@ -1,0 +1,94 @@
+package issue_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestIssue985ArrayClear(t *testing.T) {
+	for _, input := range []string{`[]`, `[null]`, `[1]`, `[1,2]`, `[1,2,3]`, `null`} {
+		t.Run(input, func(t *testing.T) {
+			for _, makeArray := range []func() interface{}{
+				func() interface{} { return &[2]interface{}{"old", "tail"} },
+				func() interface{} { return &[2]*int{new(int), new(int)} },
+				func() interface{} { return &[2]int{7, 8} },
+				func() interface{} { return &[0]interface{}{} },
+			} {
+				got, want := makeArray(), makeArray()
+				if err := json.Unmarshal([]byte(input), want); err != nil {
+					t.Fatal(err)
+				}
+				if err := sonic.Unmarshal([]byte(input), got); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("%T: got %v, want %v", got, got, want)
+				}
+			}
+		})
+	}
+}
+
+type issue985Payload struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+			Value  [2]interface{}    `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func TestIssue985ConcurrentFirstDecode(t *testing.T) {
+	const rows = 3400
+	var b bytes.Buffer
+	b.WriteString(`{"status":"success","data":{"resultType":"vector","result":[`)
+	for i := 0; i < rows; i++ {
+		if i != 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"metric":{"__name__":"up","instance":"172.%d.%d.%d:1888","job":"agent_env_all","env":"pro"},"value":[1788943336,"1"]}`, 16+i%40, i/250, i%250+1)
+	}
+	b.WriteString(`]}}`)
+
+	// Distinct types keep each round's top-level decoder cold.
+	for round := 0; round < 10; round++ {
+		typ := reflect.StructOf([]reflect.StructField{{
+			Name: "Payload", Type: reflect.TypeOf(issue985Payload{}),
+			Anonymous: true, Tag: reflect.StructTag(fmt.Sprintf(`issue985:"%d"`, round)),
+		}})
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for worker := 0; worker < 8; worker++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				dst := reflect.New(typ)
+				<-start
+				if err := sonic.Unmarshal(b.Bytes(), dst.Interface()); err != nil {
+					t.Error(err)
+					return
+				}
+				got := dst.Elem().Field(0).Interface().(issue985Payload)
+				if got.Status != "success" || len(got.Data.Result) != rows {
+					t.Errorf("unexpected payload: status=%q rows=%d", got.Status, len(got.Data.Result))
+					return
+				}
+				for _, row := range got.Data.Result {
+					if row.Metric["__name__"] != "up" || row.Value != [2]interface{}{float64(1788943336), "1"} {
+						t.Errorf("unexpected row: %+v", row)
+						return
+					}
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`.
- [x] The description is user-oriented and clear.
- [x] No user documentation update is needed; public APIs and configuration are unchanged.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

When a fixed-size array is completely filled, the amd64 JIT decoder advances its destination pointer past the last element and calls `runtime.memclrHasPointers(ptr, 0)` to clear the remaining elements. Even with a zero byte count, the runtime write barrier can inspect the object metadata at that address. If it lands outside a valid allocation, decoding can crash with SIGSEGV.

Skip the clearing call when the computed remaining byte count is zero. Partial arrays still have their remaining elements cleared as before. Add a concurrent first-decode regression based on #985 and compare empty, partial, full, oversized, and null array inputs against `encoding/json`, with independent prefilled destinations.

The issue is not specific to Go 1.27. On Linux amd64, the unmodified v1.15.3 reproducer failed on all tested versions from Go 1.22 through Go 1.27. Each row below represents 20 fresh processes per mode, with eight concurrent workers, ten distinct destination types, and a 3400-row payload. Normal mode uses `GOGC=100`; pressure mode uses `GOGC=10` and an explicit GC loop.

| Go version | Normal crashes | GC pressure crashes |
| --- | ---: | ---: |
| 1.18.10, 1.19.13, 1.20.10, 1.21.7, 1.21.13 | 0/20 each | 0/20 each |
| 1.22.0 | 20/20 | 20/20 |
| 1.22.12 | 19/20 | 20/20 |
| 1.23.12 | 20/20 | 20/20 |
| 1.24.13 | 20/20 | 20/20 |
| 1.25.0 | 19/20 | 20/20 |
| 1.26.3 | 20/20 | 20/20 |
| 1.27.0 | 20/20 | 20/20 |
| 1.27.1 | 20/20 | 20/20 |

Additional GDB runs on each affected version confirmed `memclrHasPointers(n=0) -> bulkBarrierPreWrite(size=0) -> typePointersOfUnchecked -> SIGSEGV`. Zero failures in the bounded older-version runs do not establish immunity, and the counts are not production failure probabilities.

Validation of the fix on Linux amd64:

- Go 1.27.1: `go test ./... ./loader/... ./issue_test` passed; the main-module, loader, and issue suites also passed with `SONIC_USE_OPTDEC=1 SONIC_USE_FASTMAP=1 SONIC_ENCODER_USE_VM=1`.
- Go 1.27.1: the regression passed in 20 independent cold-start processes and under GC pressure; the final issue regressions also passed with the optimized configuration (`-count=10`).
- Go 1.22.12: `go test ./issue_test -run '^TestIssue985' -count=10` passed.
- Go 1.26.3: focused issue regressions passed.
- macOS and arm64 were not exercised locally.

#### (Optional) Which issue(s) this PR fixes:

Fixes #985
